### PR TITLE
feat(categorize): added image support for categorize choices

### DIFF
--- a/packages/categorize/configure/src/design/choices/choice.jsx
+++ b/packages/categorize/configure/src/design/choices/choice.jsx
@@ -32,7 +32,11 @@ export class Choice extends React.Component {
     onDelete: PropTypes.func.isRequired,
     connectDragSource: PropTypes.func.isRequired,
     connectDragPreview: PropTypes.func.isRequired,
-    correctResponseCount: PropTypes.number.isRequired
+    correctResponseCount: PropTypes.number.isRequired,
+    imageSupport: PropTypes.shape({
+      add: PropTypes.func.isRequired,
+      delete: PropTypes.func.isRequired
+    })
   };
 
   static defaultProps = {};
@@ -60,7 +64,8 @@ export class Choice extends React.Component {
       choice,
       onDelete,
       connectDragSource,
-      connectDragPreview
+      connectDragPreview,
+      imageSupport
     } = this.props;
 
     const draggable = canDrag(this.props);
@@ -82,6 +87,7 @@ export class Choice extends React.Component {
         {connectDragPreview(
           <span>
             <InputHeader
+              imageSupport={imageSupport}
               label={choice.content}
               onChange={this.changeContent}
               onDelete={onDelete}

--- a/packages/categorize/configure/src/design/choices/index.jsx
+++ b/packages/categorize/configure/src/design/choices/index.jsx
@@ -17,7 +17,11 @@ export class Choices extends React.Component {
     choices: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     onAdd: PropTypes.func.isRequired,
-    onDelete: PropTypes.func.isRequired
+    onDelete: PropTypes.func.isRequired,
+    imageSupport: PropTypes.shape({
+      add: PropTypes.func.isRequired,
+      delete: PropTypes.func.isRequired
+    })
   };
 
   static defaultProps = {};
@@ -55,7 +59,8 @@ export class Choices extends React.Component {
       onAdd,
       onDelete,
       config,
-      onConfigChange
+      onConfigChange,
+      imageSupport
     } = this.props;
 
     const categoryCountIsOne = this.allChoicesHaveCount(1);
@@ -78,6 +83,7 @@ export class Choices extends React.Component {
               choice={h}
               correctResponseCount={h.correctResponseCount}
               key={index}
+              imageSupport={imageSupport}
               onChange={this.changeChoice}
               onDelete={() => onDelete(h)}
             />

--- a/packages/categorize/configure/src/design/index.jsx
+++ b/packages/categorize/configure/src/design/index.jsx
@@ -31,7 +31,11 @@ export class Design extends React.Component {
     className: PropTypes.string,
     model: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    uid: PropTypes.string
+    uid: PropTypes.string,
+    imageSupport: PropTypes.shape({
+      add: PropTypes.func.isRequired,
+      delete: PropTypes.func.isRequired
+    })
   };
 
   static defaultProps = {};
@@ -182,7 +186,7 @@ export class Design extends React.Component {
   };
 
   render() {
-    const { classes, className, model } = this.props;
+    const { classes, className, model, imageSupport } = this.props;
 
     const config = model.config || {};
     config.categories = config.categories || { columns: 2 };
@@ -218,6 +222,7 @@ export class Design extends React.Component {
           />
           <Divider />
           <Choices
+            imageSupport={imageSupport}
             choices={choices}
             config={config.choices}
             onConfigChange={this.changeChoicesConfig}

--- a/packages/categorize/configure/src/design/input-header.jsx
+++ b/packages/categorize/configure/src/design/input-header.jsx
@@ -10,15 +10,21 @@ export class InputHeader extends React.Component {
     className: PropTypes.string,
     label: PropTypes.string,
     onChange: PropTypes.func,
-    onDelete: PropTypes.func
+    onDelete: PropTypes.func,
+    imageSupport: PropTypes.shape({
+      add: PropTypes.func.isRequired,
+      delete: PropTypes.func.isRequired
+    })
   };
 
   static defaultProps = {};
   render() {
-    const { onChange, label, classes, className } = this.props;
+    const { onChange, label, classes, className, imageSupport } = this.props;
+
     return (
       <div className={classNames(classes.inputHeader, className)}>
         <EditableHtml
+          imageSupport={imageSupport}
           autoWidthToolbar
           label={'label'}
           markup={label}

--- a/packages/categorize/configure/src/index.js
+++ b/packages/categorize/configure/src/index.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Main from './main';
-import { ModelUpdatedEvent } from '@pie-framework/pie-configure-events';
+import {
+  ModelUpdatedEvent,
+  DeleteImageEvent,
+  InsertImageEvent
+} from '@pie-framework/pie-configure-events';
 
 export default class CategorizeConfigure extends HTMLElement {
   set model(m) {
@@ -17,10 +21,26 @@ export default class CategorizeConfigure extends HTMLElement {
 
   connectedCallback() {}
 
+  /**
+   *
+   * @param {done, progress, file} handler
+   */
+  insertImage(handler) {
+    this.dispatchEvent(new InsertImageEvent(handler));
+  }
+
+  onDeleteImage(src, done) {
+    this.dispatchEvent(new DeleteImageEvent(src, done));
+  }
+
   render() {
     const el = React.createElement(Main, {
       model: this._model,
-      onChange: this.onChange.bind(this)
+      onChange: this.onChange.bind(this),
+      imageSupport: {
+        add: this.insertImage.bind(this),
+        delete: this.onDeleteImage.bind(this)
+      }
     });
     ReactDOM.render(el, this);
   }

--- a/packages/categorize/configure/src/main.jsx
+++ b/packages/categorize/configure/src/main.jsx
@@ -11,7 +11,8 @@ export class Main extends React.Component {
     classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     model: PropTypes.object.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    imageSupport: PropTypes.object
   };
 
   static defaultProps = {};
@@ -37,10 +38,16 @@ export class Main extends React.Component {
         }
       };
     }
+
     return (
       <div className={classNames(classes.main, className)}>
         <Tabs>
-          <Design title="Design" model={model} onChange={onChange} />
+          <Design
+            imageSupport={this.props.imageSupport}
+            title="Design"
+            model={model}
+            onChange={onChange}
+          />
           <Scoring
             title="Scoring"
             scoring={model.scoring}
@@ -62,7 +69,8 @@ const StyledMain = withStyles(styles)(Main);
 class Stateful extends React.Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    model: PropTypes.object.isRequired
+    model: PropTypes.object.isRequired,
+    imageSupport: PropTypes.object
   };
 
   constructor(props) {
@@ -83,7 +91,13 @@ class Stateful extends React.Component {
   };
 
   render() {
-    return <StyledMain model={this.state.model} onChange={this.onChange} />;
+    return (
+      <StyledMain
+        imageSupport={this.props.imageSupport}
+        model={this.state.model}
+        onChange={this.onChange}
+      />
+    );
   }
 }
 


### PR DESCRIPTION
This is for the [Issue 85](https://github.com/pie-framework/pie-elements/issues/85).
placement-ordering already has image support in choices