### PR TITLE
feat(general): default model initialization

### DIFF
--- a/packages/calculator/README.md
+++ b/packages/calculator/README.md
@@ -1,0 +1,1 @@
+# @pie-element/calculator

--- a/packages/calculator/configure/src/defaults.js
+++ b/packages/calculator/configure/src/defaults.js
@@ -1,0 +1,3 @@
+export default {
+  mode: 'basic',
+};

--- a/packages/calculator/configure/src/index.js
+++ b/packages/calculator/configure/src/index.js
@@ -3,7 +3,14 @@ import ReactDOM from 'react-dom';
 import Main from './main';
 import { ModelUpdatedEvent } from '@pie-framework/pie-configure-events';
 
-export default class extends HTMLElement {
+import defaults from './defaults';
+
+export default class Calculator extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   constructor() {
     super();
     this.onModelChanged = this.onModelChanged.bind(this);

--- a/packages/categorize/configure/src/defaults.js
+++ b/packages/categorize/configure/src/defaults.js
@@ -1,0 +1,44 @@
+export default {
+  choices: [
+    {
+      id: '0',
+      content: '<span mathjax="" data-latex="">420\\text{ cm}=4.2\\text{ meters}</span>'
+    },
+    {
+      id: '1',
+      content: '<span mathjax="" data-latex="" data-raw="3.4\\text{ kg}=350\\text{ g}">3.4\\text{ kg}=340\\text{ g}</span>'
+    },
+  ],
+  categories: [
+    {
+      id: '0',
+      label: 'Equivalent',
+      choices: [
+        {
+          id: '0',
+          content: '<span mathjax="" data-latex="">420\\text{ cm}=4.2\\text{ meters}</span>'
+        },
+      ]
+    },
+    {
+      id: '1',
+      label: '<b>NOT </b>equivalent',
+      choices: [
+        {
+          id: '1',
+          content: '<span mathjax="" data-latex="">3.4\\text{ kg}=340\\text{ g}</span>'
+        },
+      ]
+    }
+  ],
+  correctResponse: [
+    {
+      category: '0',
+      choices: ['0']
+    },
+    {
+      category: '1',
+      choices: ['1']
+    }
+  ],
+};

--- a/packages/categorize/configure/src/index.js
+++ b/packages/categorize/configure/src/index.js
@@ -7,7 +7,14 @@ import {
   InsertImageEvent
 } from '@pie-framework/pie-configure-events';
 
+import defaults from './defaults';
+
 export default class CategorizeConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   set model(m) {
     this._model = m;
     this.render();

--- a/packages/categorize/controller/src/defaults.js
+++ b/packages/categorize/controller/src/defaults.js
@@ -1,0 +1,31 @@
+export default {
+  choices: [
+    {
+      id: '0',
+      content: '420 cm = 4.2 meters'
+    },
+    {
+      id: '1',
+      content: '3.4 kg = 340 g'
+    },
+  ],
+  categories: [
+    {
+      id: '0',
+      label: 'Equivalent',
+    },
+    {
+      id: '1',
+      label: '<b>NOT </b>equivalent',
+    }
+  ],
+  config: {
+    choices: {
+      columns: 2,
+      position: 'below',
+    },
+    categories: {
+      columns: 2
+    }
+  }
+};

--- a/packages/categorize/controller/src/index.js
+++ b/packages/categorize/controller/src/index.js
@@ -1,5 +1,6 @@
 import { buildState, score } from '@pie-lib/categorize';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
+import defaults from './defaults';
 import debug from 'debug';
 const log = debug('@pie-element:categorize:controller');
 
@@ -32,6 +33,14 @@ export const getCorrectness = (question, session, env) => {
     }
   });
 };
+
+export const createDefaultModel = (model = {}) =>
+  new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model,
+    })
+  });
 
 export const model = (question, session, env) =>
   new Promise(resolve => {

--- a/packages/extended-text-entry/configure/src/defaults.js
+++ b/packages/extended-text-entry/configure/src/defaults.js
@@ -1,0 +1,3 @@
+export default {
+  prompt: 'This is the question prompt',
+};

--- a/packages/extended-text-entry/configure/src/index.js
+++ b/packages/extended-text-entry/configure/src/index.js
@@ -3,6 +3,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Root from './root';
 
+import defaults from './defaults';
+
 const csToUi = cs => {};
 /**
  *
@@ -10,7 +12,12 @@ const csToUi = cs => {};
  * {"{"width":"200px","height":"100px","disabled":true,"mode":"evaluate","feedback":{"type":"default","default":"Your answer has been submitted","customFeedback":"<div>Thank you very much</div>"},"id":"1","element":"extended-text-entry","value":"<div>asrt</div>","mathEnabled":false}"} ui
  */
 const uiToCs = ui => {};
-export default class extends HTMLElement {
+export default class ExtendedTextEntry extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   set model(m) {
     this._model = m;
     this.render();

--- a/packages/extended-text-entry/controller/src/defaults.js
+++ b/packages/extended-text-entry/controller/src/defaults.js
@@ -1,0 +1,4 @@
+export default {
+  prompt: '<div>This is the question prompt</div>',
+  width: '500px',
+};

--- a/packages/extended-text-entry/controller/src/index.js
+++ b/packages/extended-text-entry/controller/src/index.js
@@ -2,6 +2,17 @@ import debug from 'debug';
 const log = debug('@pie-element:extended-text-entry:controller');
 import { getFeedback } from '@pie-lib/feedback';
 
+import defaults from './defaults';
+
+export async function createDefaultModel(model = {}) {
+  log('[createDefaultModel]', model);
+
+  return {
+    ...defaults,
+    ...model,
+  };
+}
+
 export async function model(model, session, env) {
   log('[model]', model);
 

--- a/packages/function-entry/configure/src/defaults.js
+++ b/packages/function-entry/configure/src/defaults.js
@@ -1,0 +1,4 @@
+export default {
+  equation: '3x+2',
+  showFormattingHelp: true,
+};

--- a/packages/function-entry/configure/src/index.js
+++ b/packages/function-entry/configure/src/index.js
@@ -4,9 +4,15 @@ import Configure from './configure';
 import { ModelUpdatedEvent } from '@pie-framework/pie-configure-events';
 import debug from 'debug';
 
+import defaults from './defaults';
+
 const log = debug('pie-elements:function-entry:configure');
 
 export default class FunctionEntryConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
 
   constructor() {
     super();

--- a/packages/function-entry/controller/src/defaults.js
+++ b/packages/function-entry/controller/src/defaults.js
@@ -1,0 +1,4 @@
+export default {
+  equation: '3x+2',
+  showFormattingHelp: true,
+};

--- a/packages/function-entry/controller/src/index.js
+++ b/packages/function-entry/controller/src/index.js
@@ -2,6 +2,8 @@ import debug from 'debug';
 import mathjs from 'mathjs';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
 
+import defaults from './defaults';
+
 const log = debug('@pie-element:function-entry:controller');
 
 const process = v => mathjs.simplify(v ? v.trim() : '');
@@ -13,6 +15,15 @@ const isResponseCorrect = (correctResponse, value) => {
   log('correctResponse:', cr);
   return processedValue.equals(cr);
 };
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model,
+    });
+  });
+}
 
 export function model(question, session, env) {
   return new Promise(resolve => {

--- a/packages/inline-choice/configure/src/defaults.js
+++ b/packages/inline-choice/configure/src/defaults.js
@@ -1,0 +1,24 @@
+export default {
+  choices: [
+    {
+      correct: true,
+      value: 'sweden',
+      label: 'Sweden'
+    },
+    {
+      value: 'iceland',
+      label: 'Iceland',
+      feedback: {
+        type: 'default'
+      }
+    },
+    {
+      value: 'finland',
+      label: 'Finland',
+      feedback: {
+        type: 'custom',
+        value: 'Nokia was founded in Finland.'
+      }
+    }
+  ]
+};

--- a/packages/inline-choice/configure/src/index.js
+++ b/packages/inline-choice/configure/src/index.js
@@ -5,7 +5,14 @@ import ReactDOM from 'react-dom';
 import Root from './root';
 import { choiceUtils as utils } from '@pie-lib/config-ui';
 
-export default class extends HTMLElement {
+import defaults from './defaults';
+
+export default class InlineChoice extends HTMLElement {
+  static createDefaultModel = (model = {}) => utils.normalizeChoices({
+    ...defaults,
+    ...model,
+  });
+
   constructor() {
     super();
     this.onModelChanged = this.onModelChanged.bind(this);

--- a/packages/inline-choice/controller/src/defaults.js
+++ b/packages/inline-choice/controller/src/defaults.js
@@ -1,0 +1,16 @@
+export default {
+  choices: [
+    {
+      value: 'sweden',
+      label: 'Sweden'
+    },
+    {
+      value: 'iceland',
+      label: 'Iceland',
+    },
+    {
+      value: 'finland',
+      label: 'Finland',
+    }
+  ]
+};

--- a/packages/inline-choice/controller/src/index.js
+++ b/packages/inline-choice/controller/src/index.js
@@ -1,8 +1,19 @@
 import debug from 'debug';
 
+import defaults from './defaults';
+
 const log = debug('pie-element:inline-choice:controller');
 
 /** build a ui model to work with @pie-ui/inline-choice */
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model
+    });
+  });
+}
 
 export function model(question, session, env) {
   return new Promise(resolve => {

--- a/packages/match/configure/src/defaults.js
+++ b/packages/match/configure/src/defaults.js
@@ -1,0 +1,17 @@
+export default {
+  rows: [
+    {
+      id: 1,
+      title: 'Question Text 1',
+      values: [false, false]
+    },
+    {
+      id: 2,
+      title: 'Question Text 2',
+      values: [false, false]
+    },
+  ],
+  layout: 3,
+  headers: ['Column 1', 'Column 2', 'Column 3'],
+  responseType: 'radio',
+};

--- a/packages/match/configure/src/index.js
+++ b/packages/match/configure/src/index.js
@@ -8,9 +8,16 @@ import {
 } from '@pie-framework/pie-configure-events';
 import debug from 'debug';
 
+import defaults from './defaults';
+
 const log = debug('pie-elements:match:configure');
 
 export default class MatchConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   constructor() {
     super();
   }

--- a/packages/match/controller/src/defaults.js
+++ b/packages/match/controller/src/defaults.js
@@ -1,0 +1,18 @@
+export default {
+  config: {
+    rows: [
+      {
+        id: 1,
+        title: 'Question Text 1',
+        values: [false, false]
+      },
+      {
+        id: 2,
+        title: 'Question Text 2',
+        values: [false, false]
+      },
+    ],
+    layout: 3,
+    headers: ['Column 1', 'Column 2', 'Column 3'],
+  }
+};

--- a/packages/match/controller/src/index.js
+++ b/packages/match/controller/src/index.js
@@ -1,6 +1,8 @@
 import debug from 'debug';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
 
+import defaults from './defaults';
+
 const log = debug('@pie-element:graph-lines:controller');
 
 const getResponseCorrectness = (
@@ -97,6 +99,15 @@ export const outcome = (question, session, env) => {
     }
   });
 };
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model
+    });
+  });
+}
 
 export function model(question, session, env) {
   return new Promise(resolve => {

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -1,0 +1,20 @@
+export default {
+  mode: 'advanced',
+  expression: 'y = ',
+  question: '',
+  equationEditor: 'everything',
+  defaultResponse: {
+    id: 0,
+    validation: 'symbolic',
+    answer: 'mx + b',
+    alternates: {},
+    allowDecimals: true
+  },
+  responses: [{
+    id: 'answerBlock1',
+    validation: 'symbolic',
+    answer: 'mx + b',
+    alternates: {},
+    allowDecimals: true
+  }],
+};

--- a/packages/math-inline/configure/src/index.js
+++ b/packages/math-inline/configure/src/index.js
@@ -4,9 +4,16 @@ import Configure from './configure';
 import { ModelUpdatedEvent } from '@pie-framework/pie-configure-events';
 import debug from 'debug';
 
+import defaults from './defaults';
+
 const log = debug('pie-elements:math-inline:configure');
 
 export default class MathInlineConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   constructor() {
     super();
   }

--- a/packages/math-inline/controller/src/defaults.js
+++ b/packages/math-inline/controller/src/defaults.js
@@ -1,0 +1,22 @@
+export default {
+  mode: 'advanced',
+  expression: 'y = ',
+  question: 'What is the equation for a slope?',
+  equationEditor: 'everything',
+  defaultResponse: {
+    id: 0,
+    validation: 'symbolic',
+    answer: 'mx + b',
+    alternates: {},
+    allowSpaces: true,
+    allowDecimals: true
+  },
+  responses: [{
+    id: 'answerBlock1',
+    validation: 'symbolic',
+    answer: 'mx + b',
+    alternates: {},
+    allowSpaces: true,
+    allowDecimals: true
+  }],
+};

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -2,6 +2,8 @@ import debug from 'debug';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
 import areValuesEqual from '@pie-lib/math-evaluator';
 
+import defaults from './defaults';
+
 const log = debug('@pie-element:math-inline:controller');
 
 const getResponseCorrectness = (
@@ -70,6 +72,17 @@ const getCorrectness = (question, env, answers) => {
     );
   }
 };
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      config: {
+        ...defaults,
+        ...model
+      }
+    });
+  });
+}
 
 export function model(question, session, env) {
   return new Promise(resolve => {

--- a/packages/multiple-choice/configure/src/defaults.js
+++ b/packages/multiple-choice/configure/src/defaults.js
@@ -1,0 +1,16 @@
+export default {
+  prompt: 'Which of these northern European countries are EU members?',
+  choiceMode: 'checkbox',
+  keyMode: 'numbers',
+  choices: [
+    {
+      correct: true,
+      value: 'sweden',
+      label: 'Sweden',
+    },
+    {
+      value: 'iceland',
+      label: 'Iceland',
+    },
+  ],
+};

--- a/packages/multiple-choice/configure/src/index.js
+++ b/packages/multiple-choice/configure/src/index.js
@@ -11,6 +11,8 @@ import debug from 'debug';
 import { choiceUtils as utils } from '@pie-lib/config-ui';
 import defaults from 'lodash/defaults';
 
+import sensibleDefaults from './defaults';
+
 const log = debug('multiple-choice:configure');
 
 const defaultValues = {
@@ -59,7 +61,12 @@ const prepareCustomizationObject = (configure, model) => {
   };
 };
 
-export default class extends HTMLElement {
+export default class MultipleChoice extends HTMLElement {
+  static createDefaultModel = (model = {}) => utils.normalizeChoices({
+    ...sensibleDefaults,
+    ...model,
+  });
+
   constructor() {
     super();
     this.onModelChanged = this.onModelChanged.bind(this);

--- a/packages/multiple-choice/controller/src/defaults.js
+++ b/packages/multiple-choice/controller/src/defaults.js
@@ -1,0 +1,15 @@
+export default {
+  prompt: 'Which of these northern European countries are EU members?',
+  choiceMode: 'checkbox',
+  keyMode: 'numbers',
+  choices: [
+    {
+      value: 'sweden',
+      label: 'Sweden',
+    },
+    {
+      value: 'iceland',
+      label: 'Iceland',
+    },
+  ],
+};

--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -2,6 +2,8 @@ import debug from 'debug';
 import shuffle from 'lodash/shuffle';
 import { isResponseCorrect } from './utils';
 
+import defaults from './defaults';
+
 const log = debug('pie-elements:multiple-choice:controller');
 
 const prepareChoice = (mode, defaultFeedback) => choice => {
@@ -24,6 +26,15 @@ const prepareChoice = (mode, defaultFeedback) => choice => {
 
   return out;
 };
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model
+    });
+  });
+}
 
 export function model(question, session, env) {
   return new Promise((resolve, reject) => {

--- a/packages/number-line/configure/src/defaults.js
+++ b/packages/number-line/configure/src/defaults.js
@@ -1,0 +1,29 @@
+export default {
+  correctResponse: [],
+  allowPartialScoring: false,
+  config: {
+    domain: [-5, 5],
+    initialElements: [
+      {
+        type: 'point',
+        pointType: 'empty',
+        domainPosition: -1
+      }
+    ],
+    showMinorTicks: true,
+    initialType: 'PF',
+    exhibitOnly: false,
+    availableTypes: {
+      PF: true,
+      PE: true,
+      LFF: true,
+      LEF: true,
+      LFE: true,
+      LEE: true,
+      RFN: true,
+      RFP: true,
+      REN: true,
+      REP: true
+    }
+  }
+};

--- a/packages/number-line/configure/src/index.js
+++ b/packages/number-line/configure/src/index.js
@@ -2,7 +2,14 @@ import Main from './main';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import defaults from './defaults';
+
 export default class NumberLineConfigReactElement extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   constructor() {
     super();
   }

--- a/packages/number-line/controller/src/defaults.js
+++ b/packages/number-line/controller/src/defaults.js
@@ -1,0 +1,28 @@
+export default {
+  domain: [-5, 5],
+  initialElements: [
+    {
+      type: 'point',
+      pointType: 'empty',
+      domainPosition: -1
+    }
+  ],
+  maxNumberOfPoints: 20,
+  tickFrequency: 6,
+  showMinorTicks: true,
+  snapPerTick: 1,
+  tickLabelOverrides: [],
+  initialType: 'PF',
+  availableTypes: {
+    PF: true,
+    PE: true,
+    LFF: true,
+    LEF: true,
+    LFE: true,
+    LEE: true,
+    RFN: true,
+    RFP: true,
+    REN: true,
+    REP: true
+  }
+};

--- a/packages/number-line/controller/src/index.js
+++ b/packages/number-line/controller/src/index.js
@@ -6,6 +6,8 @@ import merge from 'lodash/merge';
 import omitBy from 'lodash/omitBy';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
 
+import defaults from './defaults';
+
 const score = number => {
   return {
     score: {
@@ -138,6 +140,20 @@ export function normalize(question) {
       question.feedback = feedback;
       resolve(question);
     }
+  });
+}
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    const out = {
+      config: {
+        ...defaults,
+        ...model
+      },
+      colorContrast: 'black_on_white',
+    };
+
+    resolve(omitBy(out, v => !v));
   });
 }
 

--- a/packages/placement-ordering/configure/src/defaultConfiguration.js
+++ b/packages/placement-ordering/configure/src/defaultConfiguration.js
@@ -1,19 +1,66 @@
 export default {
-  orientationLabel: 'Orientation',
-  shuffleLabel: 'Highlight choices',
-  includePlacementAreaLabel: 'Include placement area',
-  numberedGuidesLabel: 'Numbered guides',
-  promptLabel: 'Prompt',
-  choiceLabel: 'Choice label',
-  choicesLabel: 'Choices',
-  removeTilesLabel: 'Remove all tiles after placing',
-  enableOrientationChange: true,
-  enableShuffleChange: true,
-  enablePlacementAreaChange: true,
-  enableNumberedGuideChange: true,
-  enablePromptChange: true,
-  enableChoiceLabelChange: true,
-  enableChoicesLabelChange: true,
-  enableRemoveTiles: true,
-  enableFeedback: true
+  configure: {
+    orientationLabel: 'Orientation',
+    shuffleLabel: 'Highlight choices',
+    includePlacementAreaLabel: 'Include placement area',
+    numberedGuidesLabel: 'Numbered guides',
+    promptLabel: 'Prompt',
+    choiceLabel: 'Choice label',
+    choicesLabel: 'Choices',
+    removeTilesLabel: 'Remove all tiles after placing',
+    enableOrientationChange: true,
+    enableShuffleChange: true,
+    enablePlacementAreaChange: true,
+    enableNumberedGuideChange: true,
+    enablePromptChange: true,
+    enableChoiceLabelChange: true,
+    enableChoicesLabelChange: true,
+    enableRemoveTiles: true,
+    enableFeedback: true,
+  },
+  correctResponse: [
+    {
+      id: 'c1',
+      weight: 0.2
+    },
+    {
+      id: 'c4',
+      weight: 0.2
+    },
+    {
+      id: 'c3',
+      weight: 0.3
+    },
+    {
+      id: 'c2',
+      weight: 0.3
+    }
+  ],
+  prompt: 'Arrange the fruits alphabetically',
+  choices: [
+    {
+      id: 'c2',
+      label: 'Lemon',
+      shuffle: false,
+      moveOnDrag: true
+    },
+    {
+      id: 'c3',
+      label: 'Melon',
+      moveOnDrag: true
+    },
+    {
+      id: 'c1',
+      label: 'Blueberry',
+      moveOnDrag: false
+    },
+    {
+      id: 'c4',
+      label: 'Pear',
+      moveOnDrag: false
+    }
+  ],
+  choiceAreaLayout: 'vertical',
+  choiceAreaLabel: 'choices: ',
+  showOrdering: true,
 };

--- a/packages/placement-ordering/configure/src/index.js
+++ b/packages/placement-ordering/configure/src/index.js
@@ -13,11 +13,19 @@ import defaults from 'lodash/defaults';
 const prepareCustomizationObject = (model) => {
   return {
     ...model,
-    configure: defaults(model.configure, defaultValues)
+    configure: defaults(model.configure, defaultValues.configure)
   };
 };
 
 export default class PlacementOrdering extends HTMLElement {
+  static createDefaultModel = (model = {}) => {
+    return {
+      ...defaultValues,
+      configure: defaults(model.configure, defaultValues.configure),
+      ...model
+    };
+  };
+
   constructor() {
     super();
     this.onModelChange = (model, resetSession) => {

--- a/packages/placement-ordering/controller/src/defaults.js
+++ b/packages/placement-ordering/controller/src/defaults.js
@@ -1,0 +1,33 @@
+export default {
+  choices: [
+    {
+      id: 'c2',
+      label: 'Lemon',
+      shuffle: false,
+      moveOnDrag: true
+    },
+    {
+      id: 'c3',
+      label: 'Melon',
+      moveOnDrag: true
+    },
+    {
+      id: 'c1',
+      label: 'Blueberry',
+      moveOnDrag: false
+    },
+    {
+      id: 'c4',
+      label: 'Pear',
+      moveOnDrag: false
+    }
+  ],
+  completeLength: 4,
+  config: {
+    orientation: 'vertical',
+    targetLabel: 'Answer Area Label',
+    choiceLabel: 'choices: ',
+    showOrdering: true
+  },
+  prompt: 'Arrange the fruits alphabetically',
+};

--- a/packages/placement-ordering/controller/src/index.js
+++ b/packages/placement-ordering/controller/src/index.js
@@ -3,6 +3,9 @@ import { flattenCorrect, score } from './scoring';
 import _ from 'lodash';
 import debug from 'debug';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
+
+import defaults from './defaults';
+
 const log = debug('@pie-element:placement-ordering-controller');
 
 export function outcome(question, session, env) {
@@ -68,6 +71,15 @@ function shuffle(session, choices) {
     session.stash.shuffledOrder = shuffled.map(({ id }) => id);
     return shuffled;
   }
+}
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model
+    });
+  });
 }
 
 export function model(question, session, env) {

--- a/packages/ruler/configure/src/defaults.js
+++ b/packages/ruler/configure/src/defaults.js
@@ -1,0 +1,4 @@
+export default {
+  measure: 'metric',
+  label: 'm',
+};

--- a/packages/ruler/configure/src/index.js
+++ b/packages/ruler/configure/src/index.js
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom';
 import Main from './main';
 import { ModelUpdatedEvent } from '@pie-framework/pie-configure-events';
 
+import defaults from './defaults';
+
 const defaultModel = () => ({
   model: {
     config: {
@@ -16,6 +18,11 @@ const defaultModel = () => ({
 });
 
 export default class RulerConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   connectedCallback() {
     setTimeout(() => {
       if (!this._model) {

--- a/packages/select-text/configure/src/index.js
+++ b/packages/select-text/configure/src/index.js
@@ -12,11 +12,19 @@ import defaultValues from './defaultConfiguration';
 const prepareCustomizationObject = model => {
   return {
     ...model,
-    configure: defaults(model.configure, defaultValues)
+    configure: defaults(model.configure, defaultValues.configure)
   };
 };
 
 export default class SelectTextConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => {
+    return {
+      ...defaultValues,
+      configure: defaults(model.configure, defaultValues.configure),
+      ...model,
+    };
+  };
+
   constructor() {
     super();
   }

--- a/packages/select-text/controller/src/defaults.js
+++ b/packages/select-text/controller/src/defaults.js
@@ -3,13 +3,11 @@ const tokens = () => [
     text: 'Rachel cut out 8 stars in 6 minutes.',
     start: 0,
     end: 36,
-    correct: true
   },
   {
     text: 'Lovelle cut out 6 stars in 4 minutes.',
     start: 37,
     end: 74,
-    correct: true
   },
   {
     text: 'Lovelle and Rachel cut the same number of stars in 6 minutes.',
@@ -20,29 +18,9 @@ const tokens = () => [
 
 export default {
   highlightChoices: true,
-  partialScoring: false,
   maxSelections: 2,
-  mode: 'sentence',
   prompt: 'What sentences contain the character 6 in them?',
   text:
     'Rachel cut out 8 stars in 6 minutes. Lovelle cut out 6 stars in 4 minutes. Rachel cut out 4 more stars than Lovelle. Lovelle and Rachel cut the same number of stars in 6 minutes.',
   tokens: tokens(),
-  configure: {
-    contentLabel: 'Content',
-    highlightChoicesLabel: 'Highlight choices',
-    tokensLabel: 'Tokens',
-    setCorrectAnswersLabel: 'Set correct answers',
-    modeLabel: 'Mode',
-    availableSelectionsLabel: 'Selections Available',
-    correctAnswersLabel: 'Correct Answers',
-    selectionCountLabel: 'Selection count',
-    enableContentChange: true,
-    enableHighlightChoices: true,
-    enableTokensChange: true,
-    showMode: true,
-    showSelections: true,
-    showCorrectAnswersNumber: true,
-    showSelectionCount: true,
-    enableFeedback: true
-  }
 };

--- a/packages/select-text/controller/src/index.js
+++ b/packages/select-text/controller/src/index.js
@@ -1,6 +1,8 @@
 import debug from 'debug';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
 
+import defaults from './defaults';
+
 const log = debug('@pie-element:select-text:controller');
 
 const buildTokens = (tokens, evaluateMode) => {
@@ -80,6 +82,15 @@ export const outcome = (question, session, env) => {
     }
   });
 };
+
+export function createDefaultModel(model = {}) {
+  return new Promise(resolve => {
+    resolve({
+      ...defaults,
+      ...model
+    });
+  });
+}
 
 export const model = (question, session, env) => {
   return new Promise(resolve => {

--- a/packages/text-entry/configure/src/defaults.js
+++ b/packages/text-entry/configure/src/defaults.js
@@ -1,0 +1,18 @@
+export default {
+  correctResponses: {
+    values: ['mutt', 'hound'],
+    ignoreWhitespace: true,
+    ignoreCase: false
+  },
+  partialResponses: {
+    values: ['mutty'],
+    ignoreWhitespace: true,
+    ignoreCase: true,
+    awardPercentage: '50'
+  },
+  answerBlankSize: '10',
+  answerAlignment: 'left',
+  prompt: 'Question Prompt goes here',
+  allowDecimal: true,
+  allowThousandsSeparator: true
+};

--- a/packages/text-entry/configure/src/index.js
+++ b/packages/text-entry/configure/src/index.js
@@ -4,9 +4,16 @@ import Configure from './configure';
 import { ModelUpdatedEvent } from '@pie-framework/pie-configure-events';
 import debug from 'debug';
 
+import defaults from './defaults';
+
 const log = debug('pie-elements:text-entry:configure');
 
 export default class TextEntryConfigure extends HTMLElement {
+  static createDefaultModel = (model = {}) => ({
+    ...defaults,
+    ...model,
+  });
+
   constructor() {
     super();
   }


### PR DESCRIPTION
This PR aims to resolve #124 ticket.

Default config initialization lives in a static method and the default properties are the minimum required for the UI to display and function properly.

Both config and controller methods are called `createDefaultConfig()` and default properties can be overwritten by sending the model as a parameter.

**Note**: I replaced the previous branch called: `chore/elements-model-initialization` with this one.
