### PR TITLE
Feature/440 ordering scoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@pie-framework/build-helper": "^4.4.2",
     "@pie-lib/test-utils": "^0.0.3",
     "@tbranyen/jsdom": "^13.0.0",
+    "@types/jest": "^24.0.11",
     "@yarnpkg/lockfile": "^1.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^9.0.0",

--- a/packages/placement-ordering/controller/package.json
+++ b/packages/placement-ordering/controller/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@pie-lib/feedback": "^0.4.1",
     "debug": "^3.1.0",
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.5",
+    "js-combinatorics": "^0.5.4",
+    "@pie-lib/controller-utils": "^0.1.1"
   }
 }

--- a/packages/placement-ordering/controller/src/__tests__/index.test.js
+++ b/packages/placement-ordering/controller/src/__tests__/index.test.js
@@ -40,10 +40,12 @@ describe('index', () => {
       'returns empty config for mode=gather',
       assertModel(base(), {}, { mode: 'gather' }, {})
     );
+
     it(
       'returns empty config for mode=view',
       assertModel(base(), {}, { mode: 'view' }, { disabled: true })
     );
+
     it(
       'returns config.disabled=true for mode=evaluate',
       assertModel(base(), {}, { mode: 'evaluate' }, { disabled: true })
@@ -69,6 +71,7 @@ describe('index', () => {
         correctResponse: ['a', 'b'],
         choices: [{ label: 'a', id: 'a' }, { label: 'b', id: 'b' }]
       });
+
       session = { value: ['a', 'b'] };
       env = { mode: 'evaluate' };
 
@@ -165,82 +168,41 @@ describe('index', () => {
   });
 
   describe('outcome', () => {
-    let outcome = (q, s, e, handler) => {
-      return done => {
-        controller
-          .outcome(q, s, e)
-          .then(o => {
-            handler(o);
-            done();
-          })
-          .catch(e => {
-            handler(e);
-            done();
-          });
-      };
+    const assertOutcome = (question, value, expectedScore, env) => {
+      it(`${expectedScore} when answer: ${value} and question: ${JSON.stringify(
+        question
+      )}, env: ${JSON.stringify(env)}`, async () => {
+        const result = await controller.outcome(question, { value }, env);
+        expect(result.score).toEqual(expectedScore);
+      });
     };
-
-    it(
-      'returns an error if the question is null',
-      outcome(null, {}, {}, result => {
-        expect(result.message).toEqual(
-          'Question is missing required array: correctResponse'
-        );
-      })
+    const assertOutcomeError = (question, session, env) => {
+      it(`throws error for ${JSON.stringify(question)}`, () =>
+        expect(controller.outcome(question, session, env)).rejects.toThrow(
+          controller.questionError()
+        ));
+    };
+    assertOutcomeError(null, {}, {});
+    assertOutcomeError({}, {}, {});
+    assertOutcomeError({ correctResponse: [] }, {}, {});
+    assertOutcome({ partialScoring: true, correctResponse: ['a'] }, ['a'], 1);
+    assertOutcome({ partialScoring: true, correctResponse: ['a'] }, ['b'], 0);
+    assertOutcome({ correctResponse: ['a', 'b', 'c'] }, ['a', 'b'], 0.33);
+    assertOutcome(
+      { partialScoring: true, correctResponse: ['a', 'b', 'c'] },
+      ['a', 'b'],
+      0.33
     );
-
-    it(
-      'returns an error if the question.correctResponse',
-      outcome({}, {}, {}, result => {
-        expect(result.message).toEqual(
-          'Question is missing required array: correctResponse'
-        );
-      })
+    assertOutcome(
+      { partialScoring: false, correctResponse: ['a', 'b', 'c'] },
+      ['a', 'b'],
+      0
     );
-
-    it(
-      'returns an error if the question.correctResponse is empty',
-      outcome({ correctResponse: [] }, {}, {}, result => {
-        expect(result.message).toEqual(
-          'Question is missing required array: correctResponse'
-        );
-      })
-    );
-
-    it(
-      'returns score.scaled: 1 for a correct response',
-      outcome(
-        {
-          correctResponse: ['a']
-        },
-        { value: ['a'] },
-        null,
-        result => {
-          expect(result).toEqual({
-            score: {
-              scaled: 1
-            }
-          });
-        }
-      )
-    );
-
-    it(
-      'returns score.scaled: 0 for an incorrect response',
-      outcome(
-        {
-          correctResponse: ['a']
-        },
-        { value: ['b'] },
-        null,
-        result => {
-          expect(result).toEqual({
-            score: {
-              scaled: 0
-            }
-          });
-        }
-      )
+    assertOutcome(
+      { partialScoring: false, correctResponse: ['a', 'b', 'c'] },
+      ['a', 'b'],
+      0.33,
+      { partialScoring: true }
     );
   });
 });

--- a/packages/placement-ordering/controller/src/__tests__/scoring.test.js
+++ b/packages/placement-ordering/controller/src/__tests__/scoring.test.js
@@ -1,183 +1,114 @@
-import { maxScore, flattenCorrect, score } from '../scoring';
+import { flattenCorrect, score, pairwiseCombinationScore } from '../scoring';
 import _ from 'lodash';
 
-describe('flattenCorrect', () => {
-  let correctResponseIds = ['c1', 'c2', 'c3', 'c4'];
-
-  describe('correctResponse is an array of identifiers', () => {
-    let question = {
-      correctResponse: correctResponseIds
-    };
-
-    it('returns correctResponse field value', () => {
-      expect(flattenCorrect(question)).toEqual(question.correctResponse);
+describe('pairwiseCombinationScore', () => {
+  const assertScore = correctResponse => (answer, expectedScore) => {
+    it(`${expectedScore} for ${
+      typeof answer === 'string' ? answer : JSON.stringify(answer)
+    }`, () => {
+      const c = correctResponse.split('');
+      const a = typeof answer === 'string' ? answer.split('') : answer;
+      const result = pairwiseCombinationScore(c, a);
+      expect(result).toEqual(expectedScore);
     });
+  };
 
+  describe('correct response: A', () => {
+    const assertA = assertScore('A');
+    assertA('A', 1);
+    assertA('B', 0);
+    assertA('C', 0);
+    assertA({ foo: true }, 0);
+    assertA([{ foo: true }, { bar: true }], 0);
+    assertA('', 0);
   });
 
-  describe('correctResponse contains weight definitions', () => {
-    let question = {
-      correctResponse: correctResponseIds.map((id) => {
-        return {
-          id: id,
-          weight: Math.random()
-        };
-      })
-    }
-
-    it('return correctResponse identifiers', () => {
-      expect(flattenCorrect(question)).toEqual(correctResponseIds);
-    });
+  describe('correct response: AB', () => {
+    const assertAB = assertScore('AB');
+    assertAB('A', 0);
+    assertAB('B', 0);
+    assertAB('C', 0);
+    assertAB('', 0);
+    assertAB('AB', 1);
+    assertAB('BA', 0);
+    assertAB('AC', 0);
   });
 
+  describe('correct response: AAB', () => {
+    const assertAAB = assertScore('AAB');
+    assertAAB('', 0);
+    assertAAB('A', 0);
+    assertAAB('AA', 0.33);
+    assertAAB('AAC', 0.33);
+    assertAAB('AAB', 1);
+    assertAAB('BAA', 0.33);
+    assertAAB('ABA', 0.67);
+    assertAAB('ABAB', 0);
+  });
+
+  describe('correct response: ABC', () => {
+    const assertABC = assertScore('ABC');
+    assertABC('ABC', 1);
+    assertABC('BCA', 0.33);
+    assertABC('CAB', 0.33);
+    assertABC('CBA', 0);
+    assertABC('ACB', 0.67);
+    assertABC('A', 0);
+    assertABC('B', 0);
+    assertABC('C', 0);
+    assertABC('AB', 0.33);
+    assertABC('BC', 0.33);
+    assertABC('AC', 0.33);
+    assertABC('CA', 0);
+    assertABC('CB', 0);
+    assertABC('BA', 0);
+    assertABC('', 0);
+    assertABC('ABCD', 0);
+  });
+  describe('correct response: ABCD', () => {
+    const assertABCD = assertScore('ABCD');
+    assertABCD('ABCD', 1);
+    assertABCD('ABDC', 0.83);
+    assertABCD('ABC', 0.5);
+    assertABCD('CDAB', 0.33);
+    assertABCD('CDBA', 0.17);
+    assertABCD('DCBA', 0);
+    assertABCD('DCAB', 0.17);
+    assertABCD('AB', 0.17);
+  });
 });
 
+const correctResponse = ['c1', 'c2', 'c3', 'c4'];
 describe('score', () => {
-  let correctResponse = ['c1', 'c2', 'c3', 'c4'];
-
   let baseQuestion = {
     correctResponse: correctResponse
   };
-
-  describe('default scoring', () => {
-    let question = _.cloneDeep(baseQuestion);
-
-    describe('all correct', () => {
-      let session = {
-        value: _.cloneDeep(correctResponse)
-      };
-
-      it('should return 1', () => {
-        expect(score(question, session)).toEqual(1);
-      });
-
-    });
-
-    describe('some correct', () => {
-      let session = {
-        value: (() => {
-          let response = _.cloneDeep(correctResponse);
-          response[1] = undefined;
-          return response;
-        })()
-      };
-
-      it('should return 0', () => {
-        expect(score(question, session)).toEqual(0);
-      });
-
-    });
-
-    describe('none correct', () => {
-      let session = {
-        value: [null, null, null, null]
-      };
-
-      it('should return 0', () => {
-        expect(score(question, session)).toEqual(0);
-      });
-
-    });
-
-  });
-
   describe('partial scoring', () => {
     let question = _.merge(_.cloneDeep(baseQuestion), {
-      partialScoring: [
-        {
-          correctCount: 1,
-          weight: 0.2
-        }
-      ]
+      partialScoring: true
     });
 
-    let weightFor = (count) => {
-      return question.partialScoring.find(({ correctCount }) => count === correctCount).weight;
-    }
-
-    describe('all correct', () => {
-      let session = {
-        value: _.cloneDeep(correctResponse)
-      };
-
-      it('should return 1', () => {
-        expect(score(question, session)).toEqual(1);
+    const assertScore = (value, expectedScore) => {
+      it(`${expectedScore} for: ${value}`, () => {
+        const result = score(question, { value });
+        expect(result).toEqual(expectedScore);
       });
-
-    });
-
-    describe('some correct', () => {
-      let numberCorrect = 1;
-
-      let session = {
-        value: (() => {
-          let response = _.cloneDeep(correctResponse);
-          for (var i = 0; i < response.length - numberCorrect; i++) {
-            response[i] = undefined;
-          }
-          return response;
-        })()
-      };
-
-      it('should return corresponding weight * maxScore', () => {
-        expect(score(question, session)).toEqual(maxScore * weightFor(numberCorrect));
-      });
-
-    });
-
-    describe('none correct', () => {
-      let session = {
-        value: [null, null, null, null]
-      };
-
-      it('should return 0', () => {
-        expect(score(question, session)).toEqual(0);
-      });
-
-    });
-
+    };
+    assertScore([], 0);
+    assertScore(['c1'], 0);
+    assertScore(['c1', 'c2'], 0.17);
+    assertScore(['c1', 'c2', 'c3'], 0.5);
+    assertScore(['c1', 'c2', 'c3', 'c4'], 1);
   });
+});
+describe('flattenCorrect', () => {
+  describe('correctResponse is an array of identifiers', () => {
+    let question = {
+      correctResponse: correctResponse.map(v => ({ id: v }))
+    };
 
-  describe('weighted scoring', () => {
-    let question = _.merge(_.cloneDeep(baseQuestion), {
-      correctResponse: correctResponse.map((value, id) => {
-        return {
-          id: value,
-          weight: Math.random()
-        };
-      })
+    it('returns correctResponse field value', () => {
+      expect(flattenCorrect(question)).toEqual(correctResponse);
     });
-
-    describe('some correct', () => {
-      let session = {};
-
-      function sessionForCorrect(correct) {
-        return {
-          value: correctResponse.map(id => {
-            return correct.includes(id) ? id : null
-          })
-        };
-      }
-
-      it('should return 0', () => {
-        const correctChoices = ['c1', 'c3'];
-        let session = sessionForCorrect(correctChoices);
-        expect(score(question, session)).toEqual(0);
-      });
-
-    });
-
-    describe('none correct', () => {
-      let session = {
-        value: [null, null, null, null]
-      };
-
-      it('should return 0', () => {
-        expect(score(question, session)).toEqual(0);
-      });
-
-    });
-
   });
-
 });

--- a/packages/placement-ordering/controller/src/scoring.js
+++ b/packages/placement-ordering/controller/src/scoring.js
@@ -1,44 +1,47 @@
 import _ from 'lodash';
+import { combination } from 'js-combinatorics';
 
-export const maxScore = 1;
+export const pairwiseCombinationScore = (correct, answer) => {
+  if (!Array.isArray(correct) || correct.length === 0) {
+    throw new Error('correct must be non empty an array');
+  }
 
-function defaultScore(question, session) {
+  if (correct.length === 1) {
+    return _.isEqual(correct, answer) ? 1 : 0;
+  }
 
-  let allCorrect = _.isEqual(_.cloneDeep(session.value).sort(), _.cloneDeep(flattenCorrect(question)).sort());
-  return allCorrect ? 1 : 0;
-}
+  if (!Array.isArray(answer) || answer.length < 2) {
+    return 0;
+  }
 
-function partialScore(question, session) {
-  let allCorrect = _.isEqual(_.cloneDeep(session.value).sort(), _.cloneDeep(flattenCorrect(question)).sort());
-  let numCorrect = flattenCorrect(question).reduce((score, response, index) => {
-    return (session.value[index] === response) ? score + 1 : score;
-  }, 0);
-  let weighting = question.partialScoring.find(({ correctCount }) => correctCount === numCorrect);
-  return allCorrect ? maxScore : (weighting !== undefined && weighting.weight !== undefined) ? weighting.weight * maxScore : 0;
-}
+  if (answer.length > correct.length) {
+    return 0;
+  }
+  const correctCombo = combination(correct, 2).toArray();
+  const answerCombo = combination(answer, 2).toArray();
+  const diff = _.differenceWith(answerCombo, correctCombo, _.isEqual);
+  const comboLengthDiff = correctCombo.length - answerCombo.length;
+  const total = correctCombo.length;
+  const actual = total - diff.length - comboLengthDiff;
+  const n = (actual / total).toFixed(2);
+  return parseFloat(n, 10);
+};
 
 /**
  * Flattens the correctResponse into an array of ordered identifiers representing the
- * correct response. 
+ * correct response.
  */
-export function flattenCorrect(question) {
-  return question.correctResponse.find((response) => response instanceof Object) === undefined ? question.correctResponse :
-    question.correctResponse.map(({ id }) => id);
-}
+export const flattenCorrect = question =>
+  question.correctResponse.map(r => (r && r.id ? r.id : r));
 
 /**
  * Returns the score for a session. If weighted scoring is present in the correctResponse
  * field for the question, this will be used. If partial scoring is present in the question
  * model, this will be used. Otherwise the default scoring mechanism (0 for any incorrect, 1
- * for all correct) will be used. 
+ * for all correct) will be used.
  */
-export function score(question, session) {
-  /**
-   * Note: weighted scoring has been removed for now - the existing component doesn't have it,* Can add it back when needed.
-   */
-  if (question.partialScoring !== undefined) {
-    return partialScore(question, session);
-  } else {
-    return defaultScore(question, session);
-  }
-}
+
+export const score = (question, session) => {
+  const cr = flattenCorrect(question);
+  return pairwiseCombinationScore(cr, session.value);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,7 +1665,7 @@
     prop-types "^15.6.2"
     react-measure "^2.2.2"
 
-"@pie-lib/controller-utils@^0.1.0":
+"@pie-lib/controller-utils@^0.1.0", "@pie-lib/controller-utils@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@pie-lib/controller-utils/-/controller-utils-0.1.1.tgz#e69118d2bdaa86ac20dc76f49d2b3539b41a5eee"
   integrity sha512-tSrTsZuAju/43lq+aRt6bWPa6lPxJLedFxTp1hK+qhHLiPd2VHIa16FC5Q4KOwel+wwWQTv5ozAQJZicjmKFfg==
@@ -2156,6 +2156,18 @@
   version "2.2.29"
   resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.29.tgz#aa845204cd0a289f65d47e0de63a6a815e30cc66"
   integrity sha512-lRVw09gOvgviOfeUrKc/pmTiRZ7g7oDOU6OAutyuSHpm1/o2RaBQvRhgK8QEdu+FFuw/wnWb29A/iuxv9i8OpQ==
+
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.11":
+  version "24.0.11"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
+  integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
+  dependencies:
+    "@types/jest-diff" "*"
 
 "@types/jss@^9.5.3", "@types/jss@^9.5.6":
   version "9.5.8"
@@ -7247,6 +7259,11 @@ jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
   integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+
+js-combinatorics@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/js-combinatorics/-/js-combinatorics-0.5.4.tgz#c92916b8f8171b64ecd7c4435b72cfabc803c756"
+  integrity sha512-PCqUIKGqv/Kjao1G4GE/Yni6QkCP2nWW3KnxL+8IGWPlP18vQpT8ufGMf4XUAAY8JHEryUCJbf51zG8329ntMg==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
feat: partial scoring logic updated to use pairwise combinations 
* `partialScoring`: [{correctCount: number, weight: number}] is gone
* `partialScoring` is now a boolean (partialScoring defaults to true).
* uses pairwise combinations to calculate the partial score

BREAKING CHANGE: `question.partialScoring` is no longer a set of rules
with weights. It's now a boolean.