### PR TITLE
feat: update scoring [ch1199]

### DIFF
--- a/packages/ebsr/configure/src/index.js
+++ b/packages/ebsr/configure/src/index.js
@@ -47,6 +47,10 @@ export default class EbsrConfigure extends HTMLElement {
       .then(() => {
         this.partA.model = this._model.partA;
         this.partB.model = this._model.partB;
+        this.partA.configure = {
+          settingsPartialScoring: false,
+          settingsSelectChoiceMode: false
+        };
       });
   }
 

--- a/packages/ebsr/controller/src/__tests__/index.test.js
+++ b/packages/ebsr/controller/src/__tests__/index.test.js
@@ -75,7 +75,8 @@ describe('controller', () => {
     };
 
     returnsScoreOf('green', 'purple', 0); // both wrong
-    returnsScoreOf('yellow', 'purple', 1); // one correct
+    returnsScoreOf('green', 'orange', 0); // first wrong, second correct
+    returnsScoreOf('yellow', 'purple', 1); // first correct, second wrong
     returnsScoreOf('yellow', 'orange', 2); // both correct
 
     describe('partial scoring', () => {
@@ -89,7 +90,6 @@ describe('controller', () => {
           };
         };
 
-        turnPartialCorrectOn(PART_A);
         turnPartialCorrectOn(PART_B);
       });
 
@@ -100,10 +100,10 @@ describe('controller', () => {
         });
       };
 
-      returnsScoreOf({}, {}, 0.66);
-      returnsScoreOf({ value: ['yellow'] }, {}, 1);
-      returnsScoreOf({}, { value: ['orange'] }, 1);
-      returnsScoreOf({ value: ['yellow'] }, { value: ['orange'] }, 1.34);
+      returnsScoreOf({}, {}, 0);
+      returnsScoreOf({ value: ['yellow'] }, {}, 1.33);
+      returnsScoreOf({ value: ['yellow'] }, { value: ['orange'] }, 1.67);
+      returnsScoreOf({ value: ['yellow'] }, { value: ['orange', 'c'] }, 2);
     });
   });
 

--- a/packages/ebsr/controller/src/index.js
+++ b/packages/ebsr/controller/src/index.js
@@ -116,7 +116,7 @@ export function outcome(config, session, env) {
       const { partA, partB } = value;
 
       const scoreA = getScore(config, partA, 'partA');
-      const scoreB = getScore(config, partB, 'partB');
+      const scoreB = scoreA ? getScore(config, partB, 'partB') : 0;
 
       const score = scoreA + scoreB;
 


### PR DESCRIPTION
* first part can be only a single-correct MC
* second part defaults to MC, but can be changed to MS
* if the first part is incorrect, the score for the second one defaults to zero
* if the first part is correct, the second is scored like a stand-alone MS item (including partial scoring)