### PR TITLE
Add rationale support for several Item Types

### DIFF
--- a/packages/drag-in-the-blank/configure/src/defaults.js
+++ b/packages/drag-in-the-blank/configure/src/defaults.js
@@ -64,6 +64,11 @@ export default {
       settings: true,
       label: 'Partial Scoring'
     },
+    rationale: {
+      settings: true,
+      label: 'Rationale',
+      enabled: false,
+    },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',

--- a/packages/drag-in-the-blank/configure/src/main.jsx
+++ b/packages/drag-in-the-blank/configure/src/main.jsx
@@ -121,6 +121,13 @@ export class Main extends React.Component {
     });
   };
 
+  onRationaleChanged = rationale => {
+    this.props.onModelChanged({
+      ...this.props.model,
+      rationale
+    });
+  };
+
   onTeacherInstructionsChanged = teacherInstructions => {
     this.props.onModelChanged({
       ...this.props.model,
@@ -173,6 +180,7 @@ export class Main extends React.Component {
       prompt,
       partialScoring,
       lockChoiceOrder,
+      rationale = {},
       teacherInstructions = {}
     } = configuration;
     const positionOption = positionOptions.find(option => option.value === model.choicesPosition);
@@ -192,10 +200,14 @@ export class Main extends React.Component {
                   toggle(partialScoring.label),
                   duplicates: duplicates.settings && toggle(duplicates.label),
                   lockChoiceOrder: lockChoiceOrder.settings &&
-                  toggle(lockChoiceOrder.label),
-                  'teacherInstructions.enabled': teacherInstructions.settings && toggle(teacherInstructions.label, true)
+                  toggle(lockChoiceOrder.label)
                 },
-                'Properties': {}
+                'Properties': {
+                  'teacherInstructions.enabled': teacherInstructions.settings &&
+                    toggle(teacherInstructions.label, true),
+                  'rationale.enabled': rationale.settings &&
+                    toggle(rationale.label, true)
+                }
               }}
             />
           }
@@ -224,6 +236,19 @@ export class Main extends React.Component {
                   imageSupport={imageSupport}
                   nonEmpty={!prompt.settings}
                   disableUnderline
+                />
+              </InputContainer>
+            )}
+            {rationale.enabled && (
+              <InputContainer
+                label={rationale.label}
+                className={classes.promptHolder}
+              >
+                <EditableHtml
+                  className={classes.prompt}
+                  markup={model.rationale || ''}
+                  onChange={this.onRationaleChanged}
+                  imageSupport={imageSupport}
                 />
               </InputContainer>
             )}

--- a/packages/drag-in-the-blank/controller/src/index.js
+++ b/packages/drag-in-the-blank/controller/src/index.js
@@ -45,8 +45,10 @@ export function model(question, session, env) {
           : undefined,
     };
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
+      out.rationale = question.rationale;
       out.teacherInstructions = question.teacherInstructions;
     } else {
+      out.rationale = null;
       out.teacherInstructions = null;
     }
 

--- a/packages/explicit-constructed-response/configure/src/defaults.js
+++ b/packages/explicit-constructed-response/configure/src/defaults.js
@@ -60,6 +60,11 @@ export default {
       settings: true,
       label: 'Partial Scoring'
     },
+    rationale: {
+      settings: true,
+      label: 'Rationale',
+      enabled: false,
+    },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',

--- a/packages/explicit-constructed-response/configure/src/main.jsx
+++ b/packages/explicit-constructed-response/configure/src/main.jsx
@@ -91,6 +91,13 @@ export class Main extends React.Component {
     });
   };
 
+  onRationaleChanged = rationale => {
+    this.props.onModelChanged({
+      ...this.props.model,
+      rationale
+    });
+  };
+
   onMarkupChanged = slateMarkup => {
     this.props.onModelChanged({
       ...this.props.model,
@@ -175,6 +182,7 @@ export class Main extends React.Component {
     const {
       prompt,
       partialScoring,
+      rationale = {},
       teacherInstructions = {}
     } = configuration;
 
@@ -194,7 +202,9 @@ export class Main extends React.Component {
                 },
                 'Properties': {
                   'teacherInstructions.enabled': teacherInstructions.settings &&
-                    toggle(teacherInstructions.label, true),
+                  toggle(teacherInstructions.label, true),
+                  'rationale.enabled': rationale.settings &&
+                  toggle(rationale.label, true)
                 }
               }}
             />
@@ -224,6 +234,19 @@ export class Main extends React.Component {
                   imageSupport={imageSupport}
                   nonEmpty={!prompt.settings}
                   disableUnderline
+                />
+              </InputContainer>
+            )}
+            {rationale.enabled && (
+              <InputContainer
+                label={rationale.label}
+                className={classes.promptHolder}
+              >
+                <EditableHtml
+                  className={classes.prompt}
+                  markup={model.rationale || ''}
+                  onChange={this.onRationaleChanged}
+                  imageSupport={imageSupport}
                 />
               </InputContainer>
             )}

--- a/packages/explicit-constructed-response/controller/src/index.js
+++ b/packages/explicit-constructed-response/controller/src/index.js
@@ -83,8 +83,10 @@ export function model(question, session, env) {
       env.role === 'instructor' &&
       (env.mode === 'view' || env.mode === 'evaluate')
     ) {
+      out.rationale = question.rationale;
       out.teacherInstructions = question.teacherInstructions;
     } else {
+      out.rationale = null;
       out.teacherInstructions = null;
     }
 

--- a/packages/inline-dropdown/configure/src/defaults.js
+++ b/packages/inline-dropdown/configure/src/defaults.js
@@ -75,6 +75,11 @@ export default {
       settings: true,
       label: 'Partial Scoring'
     },
+    rationale: {
+      settings: true,
+      label: 'Rationale',
+      enabled: false,
+    },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',

--- a/packages/inline-dropdown/configure/src/main.jsx
+++ b/packages/inline-dropdown/configure/src/main.jsx
@@ -149,6 +149,10 @@ export class Main extends React.Component {
     this.onModelChange({ prompt });
   };
 
+  onRationaleChanged = rationale => {
+    this.onModelChange({ rationale });
+  };
+
   onTeacherInstructionsChanged = teacherInstructions => {
     this.onModelChange({ teacherInstructions });
   };
@@ -266,6 +270,7 @@ export class Main extends React.Component {
       prompt,
       partialScoring,
       lockChoiceOrder,
+      rationale = {},
       teacherInstructions = {}
     } = configuration;
 
@@ -287,7 +292,9 @@ export class Main extends React.Component {
                 },
                 'Properties': {
                   'teacherInstructions.enabled': teacherInstructions.settings &&
-                    toggle(teacherInstructions.label, true)
+                    toggle(teacherInstructions.label, true),
+                  'rationale.enabled': rationale.settings &&
+                    toggle(rationale.label, true),
                 },
               }}
             />
@@ -318,6 +325,20 @@ export class Main extends React.Component {
                   imageSupport={imageSupport}
                   nonEmpty={!prompt.settings}
                   disableUnderline
+                />
+              </InputContainer>
+            )}
+
+            {rationale.enabled && (
+              <InputContainer
+                label={rationale.label}
+                className={classes.promptHolder}
+              >
+                <EditableHtml
+                  className={classes.prompt}
+                  markup={model.rationale || ''}
+                  onChange={this.onRationaleChanged}
+                  imageSupport={imageSupport}
                 />
               </InputContainer>
             )}

--- a/packages/inline-dropdown/controller/src/index.js
+++ b/packages/inline-dropdown/controller/src/index.js
@@ -91,11 +91,13 @@ export function model(question, session, env) {
     }
 
     let teacherInstructions = null;
+    let rationale = null;
 
     if (
-      env.role === 'instructor' &&
+      // env.role === 'instructor' &&
       (env.mode === 'view' || env.mode === 'evaluate')
     ) {
+      rationale = question.rationale;
       teacherInstructions = question.teacherInstructions;
     }
 
@@ -110,6 +112,7 @@ export function model(question, session, env) {
 
       responseCorrect:
         env.mode === 'evaluate' ? getScore(question, session) === 1 : undefined,
+      rationale,
       teacherInstructions
     };
 


### PR DESCRIPTION
Add rationale support for ECR, Drag in the Blank, Inline Dropdown.

Noticed that all above interactions already had `rationale` inside docs.

Issue reported [here](https://app.clubhouse.io/keydatasystems/story/2626/several-item-types-rationale-missing-from-settings-panel-and-when-toggled-on-item-authoring).