### PR TITLE
ICA: fixes for partial scoring 

### DIFF
--- a/packages/image-cloze-association/controller/src/__tests__/index.test.js
+++ b/packages/image-cloze-association/controller/src/__tests__/index.test.js
@@ -287,6 +287,92 @@ describe('controller', () => {
         );
         expect(result.score).toEqual(1);
       });
+
+      describe('duplicates', () => {
+        it('for 2 correct of 5 minus one deduction returns a score of 0.2', async () => {
+          const result = await outcome(
+            question,
+            {
+              answers: [
+                { value: rhomb, containerIndex: 0, id: 1 },
+                { value: rhomb, containerIndex: 0, id: 2 },
+                { value: rhomb, containerIndex: 1, id: 3 },
+                { value: rhomb, containerIndex: 1, id: 4 },
+                { value: rhomb, containerIndex: 1, id: 5 },
+                { value: rhomb, containerIndex: 1, id: 6 }  // extra object
+              ]
+            }
+          );
+          expect(result.score).toEqual(0.2);
+        });
+
+        it('for 2 correct of 5 returns a score of 0.6', async () => {
+          const result = await outcome(
+            question,
+            {
+              answers: [
+                { value: rhomb, containerIndex: 0, id: 1 },
+                { value: rhomb, containerIndex: 0, id: 2 },
+                { value: rhomb, containerIndex: 1, id: 3 },
+                { value: rhomb, containerIndex: 1, id: 4 },
+                { value: rhomb, containerIndex: 1, id: 5 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(0.4);
+        });
+
+
+        it('for 4 correct of 5 minus one deduction returns a score of 0.6', async () => {
+          const result = await outcome(
+            question,
+            {
+              answers: [
+                { value: rhomb, containerIndex: 0, id: 1 },
+                { value: rhomb, containerIndex: 0, id: 2 },
+                { value: rhomb, containerIndex: 0, id: 3 }, // extra object
+                { value: rhomb, containerIndex: 1, id: 4 },
+                { value: square, containerIndex: 1, id: 5 },
+                { value: trapeze, containerIndex: 1, id: 6 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(0.6);
+        });
+
+        it('for 5 correct of 5 minus one deduction returns a score of 0.8', async () => {
+          const result = await outcome(
+            question,
+            {
+              answers: [
+                { value: rhomb, containerIndex: 0, id: 1 },
+                { value: square, containerIndex: 0, id: 2 },
+                { value: rhomb, containerIndex: 0, id: 3 }, // extra object
+                { value: rhomb, containerIndex: 1, id: 4 },
+                { value: square, containerIndex: 1, id: 5 },
+                { value: trapeze, containerIndex: 1, id: 6 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(0.8);
+        });
+
+        it('for 4 correct of 5 returns a score of 0.8', async () => {
+          const result = await outcome(
+            question,
+            {
+              answers: [
+                { value: rhomb, containerIndex: 0, id: 1 },
+                { value: rhomb, containerIndex: 0, id: 2 },
+                { value: rhomb, containerIndex: 1, id: 3 },
+                { value: square, containerIndex: 1, id: 4 },
+                { value: trapeze, containerIndex: 1, id: 5 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(0.8);
+        });
+      });
     });
 
     describe('model', () => {

--- a/packages/image-cloze-association/controller/src/__tests__/index.test.js
+++ b/packages/image-cloze-association/controller/src/__tests__/index.test.js
@@ -76,13 +76,148 @@ describe('controller', () => {
       expect(result.score).toEqual(1);
     });
 
+    describe('alternate correct answers', () => {
+      describe('handles one option', async () => {
+        it('returns score of 1', async () => {
+          const result = await outcome(
+            {
+              ...question,
+              validation: {
+                ...question.validation,
+                alt_responses: [{
+                  score: 1,
+                  value: [
+                    [rhomb],
+                    [square],
+                    [trapeze],
+                    [hexagon]
+                  ]
+                }]
+              }
+            },
+            { answers: [
+                { value: rhomb, containerIndex: 0 },
+                { value: square, containerIndex: 1 },
+                { value: trapeze, containerIndex: 2 },
+                { value: hexagon, containerIndex: 3 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(1);
+        });
+
+        it('returns score of 0', async () => {
+          const result = await outcome(
+            {
+              ...question,
+              validation: {
+                ...question.validation,
+                alt_responses: [{
+                  score: 1,
+                  value: [
+                    [rhomb],
+                    [square],
+                    [trapeze],
+                    [hexagon]
+                  ]
+                }]
+              }
+            },
+            { answers: [
+                { value: rhomb, containerIndex: 3 },
+                { value: square, containerIndex: 1 },
+                { value: trapeze, containerIndex: 2 },
+                { value: hexagon, containerIndex: 0 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(0);
+        });
+      });
+
+      describe('handles multiple options', async () => {
+        it('returns score of 1', async () => {
+          const result = await outcome(
+            {
+              ...question,
+              validation: {
+                ...question.validation,
+                alt_responses: [{
+                  score: 1,
+                  value: [
+                    [square],
+                    [rhomb],
+                    [hexagon],
+                    [trapeze]
+                  ]
+                }, {
+                  score: 1,
+                  value: [
+                    [rhomb],
+                    [square],
+                    [trapeze],
+                    [hexagon]
+                  ]
+                }]
+              }
+            },
+            { answers: [
+                { value: rhomb, containerIndex: 0 },
+                { value: square, containerIndex: 1 },
+                { value: trapeze, containerIndex: 2 },
+                { value: hexagon, containerIndex: 3 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(1);
+        });
+
+        it('returns score of 0', async () => {
+          const result = await outcome(
+            {
+              ...question,
+              validation: {
+                ...question.validation,
+                alt_responses: [{
+                  score: 1,
+                  value: [
+                    [square],
+                    [rhomb],
+                    [hexagon],
+                    [trapeze]
+                  ]
+                }, {
+                  score: 1,
+                  value: [
+                    [rhomb],
+                    [square],
+                    [trapeze],
+                    [hexagon]
+                  ]
+                }]
+              }
+            },
+            { answers: [
+                { value: rhomb, containerIndex: 3 },
+                { value: square, containerIndex: 1 },
+                { value: trapeze, containerIndex: 2 },
+                { value: hexagon, containerIndex: 0 }
+              ]
+            }
+          );
+          expect(result.score).toEqual(0);
+        });
+      });
+    });
+
     describe('partial scoring', () => {
       beforeEach(() => {
         question = {
           ...question,
-          partialScoring: true,
+          partialScoring: true
         };
       });
+
       it('returns a score of 0.2', async () => {
         const result = await outcome(
           question,

--- a/packages/image-cloze-association/controller/src/index.js
+++ b/packages/image-cloze-association/controller/src/index.js
@@ -1,9 +1,8 @@
 import debug from 'debug';
 import { camelizeKeys } from 'humps';
+import { getAllUniqueCorrectness } from './utils';
 
 const log = debug('pie-elements:image-cloze-association:controller');
-
-import { getNumberOfDuplicates } from './utils';
 
 export function model(question, session, env) {
   const questionCamelized = camelizeKeys(question);
@@ -15,7 +14,7 @@ export function model(question, session, env) {
       ...questionCamelized,
       responseCorrect:
         env.mode === 'evaluate'
-          ? isDefaultOrAltResponseCorrect(questionCamelized, session)
+          ? getScore(questionCamelized, session) === 1
           : undefined,
     };
 
@@ -48,6 +47,7 @@ const isResponseCorrect = (responses, session) => {
   return isCorrect;
 };
 
+// This applies for items that don't support partial scoring.
 const isDefaultOrAltResponseCorrect = (question, session) => {
   const { validation: { validResponse: { value }, altResponses } } = question;
 
@@ -64,19 +64,42 @@ const isDefaultOrAltResponseCorrect = (question, session) => {
   return isCorrect;
 };
 
+// Deduct only the items that exceeded the maximum valid response per container.
+const getDeductionPerContainer = (containerIndex, answers, valid) => {
+  const totalStack = answers.filter(item => item.containerIndex === containerIndex);
+  const incorrectStack = totalStack.filter(item => !item.isCorrect);
+  const maxValid = valid.value[containerIndex].length;
+
+  if (totalStack.length > maxValid) {
+    const ignored = totalStack.length - maxValid;
+    return incorrectStack.slice(-ignored);
+  }
+  return [];
+};
+
 const getPartialScore = (question, session) => {
   const { validation: { validResponse }, maxResponsePerZone, responseContainers } = question;
   let correctAnswers = 0;
-  let totalValidResponses = 0;
+  let possibleResponses = 0;
 
-  validResponse.value.forEach(value => totalValidResponses += value.length);
+  validResponse.value.forEach(value => possibleResponses += value.length);
 
   if (session.answers && session.answers.length) {
+    const all = getAllUniqueCorrectness(session.answers, validResponse.value);
+    correctAnswers = all.filter(item => item.isCorrect).length;
+
+    // deduction rules: https://docs.google.com/document/d/1Oprm8Qs5fg_Dwoj2pNpsfu4D63QgCZgvcqTgeaVel7I/edit
     session.answers.forEach(answer => {
-      if (validResponse.value[answer.containerIndex].includes(answer.value)) {
-        correctAnswers += 1;
-      } else if (maxResponsePerZone > 1) {
-        correctAnswers -= 1;
+      if (maxResponsePerZone > 1) {
+        const deductionList = getDeductionPerContainer(answer.containerIndex, all, validResponse);
+
+        if (deductionList.length) {
+          deductionList.forEach(item => {
+            if (item.id === answer.id) {
+              correctAnswers -= 1;
+            }
+          });
+        }
       }
     });
   } else {
@@ -84,12 +107,8 @@ const getPartialScore = (question, session) => {
   }
   // negative values will implicitly make the score equal to zero
   correctAnswers = correctAnswers < 0 ? 0 : correctAnswers;
-  const duplicates = getNumberOfDuplicates(session.answers, validResponse.value);
 
-  const uniqueCorrectAnswers = correctAnswers - (duplicates) * 2; // times two because 'correctAnswers' might have duplicates
-  correctAnswers = uniqueCorrectAnswers < 0 ? 0 : uniqueCorrectAnswers;
-
-  const denominator = maxResponsePerZone > 1 ? totalValidResponses : responseContainers.length;
+  const denominator = maxResponsePerZone > 1 ? possibleResponses : responseContainers.length;
   const str = (correctAnswers / denominator).toFixed(2);
 
   return parseFloat(str);

--- a/packages/image-cloze-association/controller/src/utils.js
+++ b/packages/image-cloze-association/controller/src/utils.js
@@ -1,15 +1,17 @@
-const getAllCorrectAnswers = (answers, validResponses) =>
+const getAllCorrectness = (answers, responses) =>
   answers.map(answer => ({
     ...answer,
-    isCorrect: validResponses[answer.containerIndex].includes(answer.value)
+    isCorrect: responses[answer.containerIndex].includes(answer.value)
   }));
 
-export const getNumberOfDuplicates = (answers, validResponses) => {
-  const allCorrect = getAllCorrectAnswers(answers, validResponses);
-  let finalAnswers = allCorrect;
+const getValidAnswer = (answer, response) =>
+  response[answer.containerIndex].filter(res => res === answer.value);
 
-  allCorrect.forEach((answer1) => {
-    const valuesToParse = allCorrect.filter(answer2 =>
+export const getAllUniqueCorrectness = (answers, validResponses) => {
+  let allCorrectness = getAllCorrectness(answers, validResponses);
+
+  answers.forEach((answer1) => {
+    const valuesToParse = answers.filter(answer2 =>
       (answer2.value === answer1.value) && (answer2.containerIndex === answer1.containerIndex));
 
     if (valuesToParse.length > 1) {
@@ -17,13 +19,13 @@ export const getNumberOfDuplicates = (answers, validResponses) => {
       valuesToParse.shift();
       // mark duplicates as incorrect
       valuesToParse.forEach((value, index) => {
-        finalAnswers = finalAnswers.map(finalAnswer => {
+        allCorrectness = allCorrectness.map(finalAnswer => {
           if (finalAnswer.id === value.id) {
-            const finalAnswerValues =
-              validResponses[finalAnswer.containerIndex].filter(validResponse => validResponse === finalAnswer.value);
+            let valid = getValidAnswer(finalAnswer, validResponses);
+
             return {
               ...finalAnswer,
-              duplicate: finalAnswer.isCorrect && finalAnswerValues.length <= index + 1
+              isCorrect: valid.length > index + 1
             }
           }
           return finalAnswer;
@@ -31,5 +33,5 @@ export const getNumberOfDuplicates = (answers, validResponses) => {
       });
     }
   });
-  return finalAnswers.filter(a => a.duplicate === true).length;
+  return allCorrectness;
 };


### PR DESCRIPTION
Outcome fix: there should only be deductions to the extent that the student placed more objects than were in the correct response.

This branch was created from `sergiulucaci/ch1955/ica-alternate-correct-answers`, so make sure you review and merge after #284. 