### PR TITLE
fix: apply scoring deductions

### DIFF
--- a/packages/select-text/controller/src/__tests__/index.test.js
+++ b/packages/select-text/controller/src/__tests__/index.test.js
@@ -154,6 +154,28 @@ describe('outcome', () => {
       score: 0.5
     }
   );
+  assert(
+    'score 0 for partially-correct and partialScoring config with deduction',
+    q({
+      partialScoring: true
+    }),
+    s({ selectedTokens: [...q().tokens, { start: 3, end: 4, text: '0' }] }),
+    e({ mode: 'evaluate' }),
+    {
+      score: 0
+    }
+  );
+  assert(
+    'score 0.50 for partially-correct and partialScoring config with deduction',
+    q({
+      partialScoring: true
+    }),
+    s({ selectedTokens: q().tokens }),
+    e({ mode: 'evaluate' }),
+    {
+      score: 0.5
+    }
+  );
 });
 
 describe('model', () => {

--- a/packages/select-text/controller/src/index.js
+++ b/packages/select-text/controller/src/index.js
@@ -52,8 +52,12 @@ const getCorrectCount = (tokens, selected) =>
   getCorrectSelected(tokens, selected).length;
 
 const getPartialScore = (question, session, totalCorrect) => {
-  const count = getCorrectCount(question.tokens, session.selectedTokens);
-  return parseFloat((count / totalCorrect.length).toFixed(2));
+  const correctCount = getCorrectCount(question.tokens, session.selectedTokens);
+  const incorrectCount = session.selectedTokens.length - correctCount;
+  const count = correctCount - incorrectCount;
+  const positiveCount = count < 0 ? 0 : count;
+
+  return parseFloat((positiveCount / totalCorrect.length).toFixed(2));
 };
 
 export const outcome = (question, session, env) =>


### PR DESCRIPTION
Issue reported [here](https://app.clubhouse.io/keydatasystems/story/2289/select-text-partial-credit-scoring-does-not-apply-necessary-deductions-when-needed).