### PR TITLE
Add “correct answer indication” controller method 

### DIFF
--- a/packages/categorize/controller/src/index.js
+++ b/packages/categorize/controller/src/index.js
@@ -156,3 +156,16 @@ export const outcome = (question, session, env) => {
     });
   }
 };
+
+export const createCorrectResponseSession = (question, env) => {
+  if (env.mode !== 'evaluate' && env.role === 'instructor') {
+    const { correctResponse } = question;
+
+    return new Promise(resolve => {
+      resolve({
+        answers: correctResponse,
+        id: 1
+      })
+    });
+  }
+};

--- a/packages/drag-in-the-blank/controller/src/index.js
+++ b/packages/drag-in-the-blank/controller/src/index.js
@@ -106,3 +106,14 @@ export function outcome(model, session) {
     resolve({ score: partialScoringEnabled ? score : score === 1 ? 1 : 0 });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      resolve({
+        value: question.correctResponse,
+        id: '1'
+      });
+    }
+  });
+};

--- a/packages/ebsr/controller/src/index.js
+++ b/packages/ebsr/controller/src/index.js
@@ -125,3 +125,40 @@ export function outcome(config, session, env) {
     }
   });
 }
+
+const returnPartCorrect = (choices) => {
+  let answers = [];
+
+  choices.forEach(i => {
+    const { correct, value } = i;
+    if (correct) {
+      answers.push(value);
+    }
+  });
+  return answers;
+};
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { partA, partB } = question;
+
+      const partACorrect = returnPartCorrect(partA.choices);
+      const partBCorrect = returnPartCorrect(partB.choices);
+
+      resolve({
+        value: {
+          partA: {
+            id: 'partA',
+            value: partACorrect,
+          },
+          partB: {
+            id: 'partB',
+            value: partBCorrect
+          }
+        },
+        id: '1'
+      });
+    }
+  });
+};

--- a/packages/explicit-constructed-response/controller/src/index.js
+++ b/packages/explicit-constructed-response/controller/src/index.js
@@ -141,3 +141,21 @@ export function outcome(model, session) {
     resolve({ score: partialScoringEnabled ? score : score === 1 ? 1 : 0 });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { choices } = question;
+      const value = {};
+
+      Object.keys(choices).forEach((key, i) => {
+        value[i] = choices[key][0].label;
+      });
+
+      resolve({
+        id: '1',
+        value
+      });
+    }
+  });
+};

--- a/packages/function-entry/controller/src/index.js
+++ b/packages/function-entry/controller/src/index.js
@@ -62,3 +62,16 @@ export function model(question, session, env) {
     });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { equation } = question;
+
+      resolve({
+        id: '1',
+        value: equation
+      });
+    }
+  });
+};

--- a/packages/graphing/controller/src/index.js
+++ b/packages/graphing/controller/src/index.js
@@ -337,3 +337,16 @@ export function outcome(model, session) {
     resolve({ score: getScore(model, session).score });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { answers: { correctAnswer: { marks } } } = question;
+
+      resolve({
+        answer: marks,
+        id: '1'
+      });
+    }
+  });
+};

--- a/packages/hotspot/controller/src/index.js
+++ b/packages/hotspot/controller/src/index.js
@@ -115,3 +115,34 @@ export function outcome(config, session, env) {
     }
   });
 }
+
+const returnShapesCorrect = (shapes) => {
+  let answers = [];
+
+  shapes.forEach(i => {
+    const { correct, id } = i;
+    if (correct) {
+      answers.push({ id });
+    }
+  });
+  return answers;
+};
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { shapes: { rectangles, polygons } } = question;
+
+      const rectangleCorrect = returnShapesCorrect(rectangles);
+      const polygonsCorrect = returnShapesCorrect(polygons);
+
+      resolve({
+        answers: [
+          ...rectangleCorrect,
+          ...polygonsCorrect
+        ],
+        id: '1'
+      });
+    }
+  });
+};

--- a/packages/image-cloze-association/controller/src/index.js
+++ b/packages/image-cloze-association/controller/src/index.js
@@ -132,3 +132,26 @@ export function outcome(config, session, env) {
     }
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+    const { validation: { valid_response: { value } } } = question;
+    const answers = [];
+
+    value.forEach((container, i) => {
+      container.forEach(v => {
+        answers.push({
+          value: v,
+          containerIndex: i
+        });
+      });
+    });
+
+    resolve({
+      answers,
+      id: '1'
+    });
+    }
+  });
+};

--- a/packages/inline-choice/controller/src/index.js
+++ b/packages/inline-choice/controller/src/index.js
@@ -56,3 +56,17 @@ export function model(question, session, env) {
     });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { choices } = question;
+      const value = choices.filter(c => c.correct)[0].value;
+
+      resolve({
+        id: '1',
+        value
+      });
+    }
+  });
+};

--- a/packages/inline-dropdown/controller/src/index.js
+++ b/packages/inline-dropdown/controller/src/index.js
@@ -175,3 +175,21 @@ export function outcome(model, session) {
     resolve({ score: partialScoringEnabled ? score : score === 1 ? 1 : 0 });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { choices } = question;
+      const value = {};
+
+      Object.keys(choices).forEach((key, i) => {
+        value[i] = choices[key].filter(c => c.correct)[0].value;
+      });
+
+      resolve({
+        id: '1',
+        value
+      });
+    }
+  });
+};

--- a/packages/match-list/controller/src/index.js
+++ b/packages/match-list/controller/src/index.js
@@ -147,3 +147,24 @@ export function model(question, session, env) {
     });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { prompts, answers } = question;
+      const value = {};
+
+      prompts.forEach(p => {
+        if (answers.filter(a => a.id === p.relatedAnswer).length) {
+          value[p.id] = p.relatedAnswer;
+        }
+      });
+
+      resolve({
+        value,
+        id: '1'
+      });
+    }
+  });
+};
+

--- a/packages/match/controller/src/index.js
+++ b/packages/match/controller/src/index.js
@@ -178,3 +178,22 @@ export function model(question, session, env) {
     });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { rows } = question;
+      const answers = {};
+
+      rows.forEach(r => {
+        answers[r.id] = r.values;
+      });
+
+      resolve({
+        answers,
+        id: '1'
+      });
+    }
+  });
+};
+

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -217,3 +217,22 @@ export function model(question, session, env) {
     });
   });
 }
+
+// This method supports simple equations only, eg: 3x + 1 = 4
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { response: { answer } } = question;
+      const equalIndex = answer.indexOf('=');
+
+      resolve({
+        answers: {
+          r1: { value: answer.substring(0, equalIndex) },
+          r2: { value: answer.substring(equalIndex, answer.length) }
+        },
+        completeAnswer: answer,
+        id: '1'
+      });
+    }
+  });
+};

--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -122,3 +122,24 @@ export function outcome(model, session, env) {
     resolve({ score: partialScoringEnabled ? score : score === 1 ? 1 : 0 });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { choices } = question;
+      const value = [];
+
+      choices.forEach(c => {
+        if (c.correct) {
+          value.push(c.value);
+        }
+      });
+
+      resolve({
+        id: '1',
+        value
+      });
+    }
+  });
+};
+

--- a/packages/number-line/controller/src/index.js
+++ b/packages/number-line/controller/src/index.js
@@ -223,3 +223,16 @@ export function model(question, session, env) {
     }
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { correctResponse: answer } = question;
+
+      resolve({
+        answer,
+        id: '1'
+      });
+    }
+  });
+};

--- a/packages/placement-ordering/controller/src/index.js
+++ b/packages/placement-ordering/controller/src/index.js
@@ -188,3 +188,17 @@ export function model(question, session, env) {
     }
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { choices } = question;
+      const value = choices.map(c => c.id);
+
+      resolve({
+        id: '1',
+        value
+      });
+    }
+  });
+};

--- a/packages/point-intercept/controller/src/index.js
+++ b/packages/point-intercept/controller/src/index.js
@@ -106,3 +106,26 @@ export function model(question, session, env) {
     });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { correctResponse, graph: { pointLabels } } = question;
+      const points = [];
+
+      pointLabels.forEach((p, i) => {
+        const c = correctResponse[i].split(',');
+        points.push({
+          x: c[0],
+          y: c[1],
+          label: p
+        })
+      });
+
+      resolve({
+        id: '1',
+        points
+      });
+    }
+  });
+};

--- a/packages/select-text/controller/src/index.js
+++ b/packages/select-text/controller/src/index.js
@@ -126,3 +126,17 @@ export const model = (question, session, env) => {
     });
   });
 };
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { tokens } = question;
+      const selectedTokens = tokens.filter(t => t.correct);
+
+      resolve({
+        id: '1',
+        selectedTokens
+      });
+    }
+  });
+};

--- a/packages/text-entry/controller/src/index.js
+++ b/packages/text-entry/controller/src/index.js
@@ -69,3 +69,17 @@ export function model(question, session, env) {
     });
   });
 }
+
+export const createCorrectResponseSession = (question, env) => {
+  return new Promise(resolve => {
+    if (env.mode !== 'evaluate' && env.role === 'instructor') {
+      const { correctResponses: { values } } = question;
+      const value = values[0];
+
+      resolve({
+        id: '1',
+        value
+      });
+    }
+  });
+};


### PR DESCRIPTION
If the result from `createCorrectResponseSession` is passed to the player via `session` setter,  question should be filled with the correct answers of the question. 

Example:

```
const player = document.querySelector('hotspot-element');

createCorrectResponseSession(question, env).then(session => {
  player.session = session;  
});
```

Requirements presented [here](https://app.clubhouse.io/keydatasystems/story/2885/add-createcorrectresponsesession-to-controller-for-all-pie-elements).

Let me know if this approach looks good to you, so I can add tests (I assume this method should require tests, right?) and clean the commit history.