### PR TITLE
fix: feedback not set correctly if there's no correct response or no …

### DIFF
--- a/packages/drag-in-the-blank/controller/src/index.js
+++ b/packages/drag-in-the-blank/controller/src/index.js
@@ -6,13 +6,14 @@ export function model(question, session, env) {
     let feedback = {};
 
     if (env.mode === 'evaluate') {
-      const allCorrectResponses = getAllCorrectResponses(question);
-      const respAreaLength = Object.keys(allCorrectResponses).length;
-      let correctResponses = 0;
+      const responses = getAllCorrectResponses(question);
+      const allCorrectResponses = responses.possibleResponses;
+      const numberOfPossibleResponses = responses.numberOfPossibleResponses || 0;
+      let correctResponses = undefined;
 
-      for (let i = 0; i < respAreaLength; i++) {
+      for (let i = 0; i < numberOfPossibleResponses; i++) {
         const result = reduce(allCorrectResponses, (obj, choices, key) => {
-          const answer = session.value[key] || '';
+          const answer = (session.value && session.value[key]) || '';
 
           obj.feedback[key] = choices[i] === answer;
 
@@ -23,12 +24,12 @@ export function model(question, session, env) {
           return obj;
         }, { correctResponses: 0, feedback: {} });
 
-        if (result.correctResponses > correctResponses) {
+        if (correctResponses === undefined || result.correctResponses > correctResponses) {
           correctResponses = result.correctResponses;
           feedback = result.feedback;
         }
 
-        if (result.correctResponses === respAreaLength) {
+        if (result.correctResponses === numberOfPossibleResponses) {
           break;
         }
       }
@@ -57,13 +58,15 @@ export function model(question, session, env) {
 }
 
 const getScore = (config, session) => {
+  const responses = getAllCorrectResponses(config);
+  const allCorrectResponses = responses.possibleResponses;
   const maxScore = Object.keys(config.correctResponse).length;
-  const allCorrectResponses = getAllCorrectResponses(config);
+  const numberOfPossibleResponses = responses.numberOfPossibleResponses || 0;
   let correctCount = 0;
 
-  for (let i = 0; i < maxScore; i++) {
+  for (let i = 0; i < numberOfPossibleResponses; i++) {
     const result = reduce(allCorrectResponses, (total, choices, key) => {
-      const answer = session.value[key] || '';
+      const answer = (session.value && session.value[key]) || '';
 
       if (choices[i] === answer) {
         return total;

--- a/packages/drag-in-the-blank/controller/src/utils.js
+++ b/packages/drag-in-the-blank/controller/src/utils.js
@@ -12,7 +12,10 @@ export const getAllCorrectResponses = ({ correctResponse, alternateResponses }) 
       ];
     }
 
-    if (obj.numberOfPossibleResponses === undefined || obj.numberOfPossibleResponses > obj.possibleResponses[key].length) {
+    if (
+      (obj.numberOfPossibleResponses === undefined) ||
+      (obj.numberOfPossibleResponses > obj.possibleResponses[key].length)
+    ) {
       obj.numberOfPossibleResponses = obj.possibleResponses[key].length;
     }
 

--- a/packages/drag-in-the-blank/controller/src/utils.js
+++ b/packages/drag-in-the-blank/controller/src/utils.js
@@ -3,15 +3,22 @@ import reduce from 'lodash/reduce';
 
 export const getAllCorrectResponses = ({ correctResponse, alternateResponses }) => {
   return reduce(correctResponse || {}, (obj, val, key) => {
-    obj[key] = [val];
+    obj.possibleResponses[key] = [val];
 
     if (alternateResponses && alternateResponses[key]) {
-      obj[key] = [
-        ...obj[key],
+      obj.possibleResponses[key] = [
+        ...obj.possibleResponses[key],
         ...cloneDeep(alternateResponses[key])
       ];
     }
 
+    if (obj.numberOfPossibleResponses === undefined || obj.numberOfPossibleResponses > obj.possibleResponses[key].length) {
+      obj.numberOfPossibleResponses = obj.possibleResponses[key].length;
+    }
+
     return obj;
-  }, {});
+  }, {
+    possibleResponses: {},
+    numberOfPossibleResponses: undefined
+  });
 };


### PR DESCRIPTION
- feedback not set correctly if there's no correct response or no response at all.
- not taking in consideration alternate responses if there are more alternate responses than answers (if there are 2 possible responses, both having 3 alternates, the 2nd and the 3rd alternates will be ignored)