### PR TITLE
fix(hotspot): hotspotList prop type is array, not string

### DIFF
--- a/packages/hotspot/configure/src/hotspot-palette.jsx
+++ b/packages/hotspot/configure/src/hotspot-palette.jsx
@@ -85,7 +85,7 @@ const styles = theme => ({
 Palette.propTypes = {
   classes: PropTypes.object.isRequired,
   hotspotColor: PropTypes.string.isRequired,
-  hotspotList: PropTypes.string.isRequired,
+  hotspotList: PropTypes.shape([]).isRequired,
   onHotspotColorChange: PropTypes.func.isRequired,
   onOutlineColorChange: PropTypes.func.isRequired,
   outlineColor: PropTypes.shape([]).isRequired,


### PR DESCRIPTION
Small fix here. React freaked out when the "incorrect" prop type was provided.