### PR TITLE
feat(select-text): move partial scoring to settings panel

### DIFF
--- a/packages/select-text/configure/src/__tests__/__snapshots__/design.test.jsx.snap
+++ b/packages/select-text/configure/src/__tests__/__snapshots__/design.test.jsx.snap
@@ -78,6 +78,7 @@ exports[`design snapshot renders all items except feedback 1`] = `
           "Settings": Object {
             "feedback.enabled": false,
             "highlightChoices": undefined,
+            "partialScoring": undefined,
           },
         }
       }
@@ -128,11 +129,6 @@ exports[`design snapshot renders all items except feedback 1`] = `
       max={0}
       min={0}
       onChange={[Function]}
-    />
-    <Component
-      label="Allow Partial Scoring"
-      onChange={[Function]}
-      title="Scoring"
     />
     <Component
       onChange={[Function]}
@@ -219,6 +215,7 @@ exports[`design snapshot renders all items except the content input 1`] = `
           "Settings": Object {
             "feedback.enabled": false,
             "highlightChoices": undefined,
+            "partialScoring": undefined,
           },
         }
       }
@@ -261,11 +258,6 @@ exports[`design snapshot renders all items except the content input 1`] = `
       max={0}
       min={0}
       onChange={[Function]}
-    />
-    <Component
-      label="Allow Partial Scoring"
-      onChange={[Function]}
-      title="Scoring"
     />
     <Component
       onChange={[Function]}
@@ -352,6 +344,7 @@ exports[`design snapshot renders all items with defaultProps 1`] = `
           "Settings": Object {
             "feedback.enabled": undefined,
             "highlightChoices": undefined,
+            "partialScoring": undefined,
           },
         }
       }
@@ -402,11 +395,6 @@ exports[`design snapshot renders all items with defaultProps 1`] = `
       max={0}
       min={0}
       onChange={[Function]}
-    />
-    <Component
-      label="Allow Partial Scoring"
-      onChange={[Function]}
-      title="Scoring"
     />
     <Component
       onChange={[Function]}

--- a/packages/select-text/configure/src/design.jsx
+++ b/packages/select-text/configure/src/design.jsx
@@ -164,6 +164,8 @@ export class Design extends React.Component {
             onChangeConfiguration={onConfigurationChanged}
             groups={{
               'Settings': {
+                partialScoring: partialScoring.settings &&
+                toggle(partialScoring.label),
                 highlightChoices: highlightChoices.settings &&
                 toggle(highlightChoices.label),
                 'feedback.enabled': feedback.settings &&
@@ -277,15 +279,6 @@ export class Design extends React.Component {
             />
           }
 
-          {
-            partialScoring.settings &&
-            <PartialScoring
-              title={'Scoring'}
-              label={partialScoring.label}
-              partialScoring={model.partialScoring}
-              onChange={this.changePartialScoring}
-            />
-          }
           {
             feedback.enabled && (
               <FeedbackConfig


### PR DESCRIPTION
Should fix [3558](https://app.clubhouse.io/keydatasystems/story/3558/select-text-partial-scoring-should-be-in-settings).