### PR TITLE
feat: add Part Labels for EBSR and MC

### DIFF
--- a/packages/ebsr/configure/src/__tests__/index.test.js
+++ b/packages/ebsr/configure/src/__tests__/index.test.js
@@ -84,6 +84,7 @@ describe('index', () => {
   beforeEach(() => {
     el = new Def();
     el.connectedCallback();
+    el.populatePart = jest.fn();
     ebsr = {
       partA: new HTMLElement(),
       partB: new HTMLElement()

--- a/packages/ebsr/configure/src/defaults.js
+++ b/packages/ebsr/configure/src/defaults.js
@@ -53,7 +53,7 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
+      enabled: true,
     },
     scoringType: {
       settings: false,
@@ -74,10 +74,11 @@ export default {
       label: 'Sequential Choice Labels',
       enabled: false
     },
+    partLabelType: 'Letters',
     partLabels: {
-      settings: false,
+      settings: true,
       label: 'Part Labels',
-      enabled: false
+      enabled: true
     }
   }
 };

--- a/packages/ebsr/configure/src/index.js
+++ b/packages/ebsr/configure/src/index.js
@@ -51,15 +51,15 @@ export default class EbsrConfigure extends HTMLElement {
     this.onConfigurationChanged = this.onConfigurationChanged.bind(this);
   }
 
-  populatePart(newConfig, id) {
+  populatePart(config, id) {
     const isFirst= id === 'a';
     const labelEl = document.getElementById(`${isFirst ? 'first' : 'second'}_label_config`);
     let labelVal;
 
-    if (newConfig.partLabels && !newConfig.partLabels.enabled) {
+    if (config.partLabels && !config.partLabels.enabled) {
       labelVal = ''
     } else {
-      const type = newConfig.partLabelType || 'Numbers';
+      const type = config.partLabelType || 'Numbers';
       const typeIsNumber = type === 'Numbers';
 
       if (isFirst) {

--- a/packages/multiple-choice/configure/src/defaults.js
+++ b/packages/multiple-choice/configure/src/defaults.js
@@ -42,6 +42,12 @@ export default {
       settings: true,
       label: 'Lock Choice Order'
     },
+    partLabelType: 'Numbers',
+    partLabels: {
+      settings: false,
+      label: 'Part Labels',
+      enabled: false
+    },
     partialScoring: {
       settings: true,
       label: 'Allow Partial Scoring',

--- a/packages/multiple-choice/configure/src/main.jsx
+++ b/packages/multiple-choice/configure/src/main.jsx
@@ -11,7 +11,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import merge from 'lodash/merge';
 
-const { Panel, toggle, radio } = settings;
+const { Panel, toggle, radio, dropdown } = settings;
 
 const styles = theme => ({
   promptHolder: {
@@ -95,6 +95,8 @@ const Design = withStyles(styles)(props => {
               'Settings': {
                 'partLabels.enabled': partLabels.settings &&
                   toggle(partLabels.label, true),
+                partLabelType: partLabels.enabled &&
+                  dropdown('', ['Numbers', 'Letters'], true),
                 choiceMode:
                   choiceMode.settings &&
                   radio(choiceMode.label, ['checkbox', 'radio']),


### PR DESCRIPTION
Should fix the first 2/3 elements from [3555](https://app.clubhouse.io/keydatasystems/story/3555/part-labels-for-ebsr). 

Ideally would be to 
* have one setting panel for EBSR
* update `pie-lib/config-ui/settings` to have a comp like `toggleWithDropdown`; currently we use two diff comps for Part Labels feature (which means two objects in configuration, not sure how good is that, cc. @edeustace ): `toggle` for rendering or not the dropdown and `dropdown` for Letters/Numbers options
* update tests accordingly

Agreed with @andreeapescar to pass her this task. 