### PR TITLE
Andreea/ch3566/from ibx item authoring not able to add choices

### DIFF
--- a/packages/drag-in-the-blank/configure/src/choice.jsx
+++ b/packages/drag-in-the-blank/configure/src/choice.jsx
@@ -3,6 +3,7 @@ import MoreVert from '@material-ui/icons/MoreVert';
 import Delete from '@material-ui/icons/Delete';
 import { DragSource } from '@pie-lib/drag';
 import { withStyles } from '@material-ui/core/styles';
+import { choiceIsEmpty } from './markupUtils';
 
 const GripIcon = ({ style }) => {
   return (
@@ -76,6 +77,11 @@ export const BlankContent = withStyles(theme => ({
 
 const tileSource = {
   canDrag(props) {
+    if (choiceIsEmpty(props.choice)) {
+      alert('You need to define a value for an answer choice before it can be associated with a response area.');
+      return false;
+    }
+
     return !props.disabled;
   },
   beginDrag(props) {

--- a/packages/drag-in-the-blank/configure/src/choice.jsx
+++ b/packages/drag-in-the-blank/configure/src/choice.jsx
@@ -84,11 +84,6 @@ const tileSource = {
       value: props.choice,
       instanceId: props.instanceId
     };
-  },
-  endDrag(props, monitor) {
-    if (monitor.didDrop()) {
-      props.onChoiceDropped();
-    }
   }
 };
 

--- a/packages/drag-in-the-blank/configure/src/choices.jsx
+++ b/packages/drag-in-the-blank/configure/src/choices.jsx
@@ -60,6 +60,7 @@ export class Choices extends React.Component {
     });
 
     if (choiceIsEmpty({ value: val })) {
+      // if the edited content is empty, its usage has to be searched in the correct response definitions
       let usedForResponse = false;
 
       Object.keys(correctResponse).forEach(responseKey => {
@@ -77,9 +78,14 @@ export class Choices extends React.Component {
       if (usedForResponse) {
         alert('Answer choices cannot be blank.');
       } else {
-        const newChoicesWithoutTheEmptyOne = newChoices.filter(choice => !choiceIsEmpty(choice));
+        if (!choiceIsEmpty({ value: prevValue })) {
+          // if the previous value was not empty, it means that the choice can be deleted
+          const newChoicesWithoutTheEmptyOne = newChoices.filter(choice => choice.id !== key);
 
-        onChange(newChoicesWithoutTheEmptyOne);
+          onChange(newChoicesWithoutTheEmptyOne);
+        } else {
+          onChange(newChoices);
+        }
       }
     } else {
       onChange(newChoices);

--- a/packages/drag-in-the-blank/configure/src/defaults.js
+++ b/packages/drag-in-the-blank/configure/src/defaults.js
@@ -4,47 +4,10 @@ export default {
     mode: 'gather',
     prompt: 'Use the inputs to complete the sentence',
     shuffle: true,
-    markup: '<div><p>The {{0}} jumped {{1}} the {{2}}</p></div>',
-    choices: [
-      {
-        value: 'cow',
-        id: '0'
-      },
-      {
-        value: 'over',
-        id: '1'
-      },
-      {
-        value: 'moon',
-        id: '2'
-      },
-      {
-        value: 'cattle',
-        id: '3'
-      },
-      {
-        value: 'calf',
-        id: '4'
-      },
-      {
-        value: 'past',
-        id: '5'
-      },
-      {
-        value: 'beyond',
-        id: '6'
-      },
-      {
-        value: 'satellite',
-        id: '7'
-      }
-    ],
+    markup: '',
+    choices: [],
     choicesPosition: 'below',
-    correctResponse: {
-      0: '0',
-      1: '1',
-      2: '2'
-    },
+    correctResponse: {},
     duplicates: true
   },
   configuration: {

--- a/packages/drag-in-the-blank/configure/src/index.js
+++ b/packages/drag-in-the-blank/configure/src/index.js
@@ -44,7 +44,7 @@ export default class DragInTheBlank extends HTMLElement {
   set model(s) {
     const formModel = {
       ...s,
-      markup: `<span>${s.markup}</span>`
+      markup: `<span>${s.markup || sensibleDefaults.model.markup}</span>`
     };
 
     this._model = DragInTheBlank.prepareModel(formModel);

--- a/packages/drag-in-the-blank/configure/src/markupUtils.js
+++ b/packages/drag-in-the-blank/configure/src/markupUtils.js
@@ -62,4 +62,12 @@ export const createSlateMarkup = (markup, choices, correctResponse) => {
   });
 };
 
-export const choiceIsEmpty = choice => choice && choice.value && (choice.value.trim() === '' || choice.value.replace(/<[^>]*>?/gm, '') === '');
+export const choiceIsEmpty = choice => {
+  if (choice) {
+    const { value = '' } = choice;
+
+    return value.trim() === '' || value.replace(/<[^>]*>?/gm, '') === '';
+  }
+
+  return false;
+};

--- a/packages/drag-in-the-blank/configure/src/markupUtils.js
+++ b/packages/drag-in-the-blank/configure/src/markupUtils.js
@@ -61,3 +61,5 @@ export const createSlateMarkup = (markup, choices, correctResponse) => {
     return `<span data-type="drag_in_the_blank" data-index="${index++}" data-id="${correctChoice.id}" data-value="${escape(correctChoice.value)}"></span>`;
   });
 };
+
+export const choiceIsEmpty = choice => choice && choice.value && (choice.value.trim() === '' || choice.value.replace(/<[^>]*>?/gm, '') === '');

--- a/packages/drag-in-the-blank/controller/src/index.js
+++ b/packages/drag-in-the-blank/controller/src/index.js
@@ -1,6 +1,6 @@
 import reduce from 'lodash/reduce';
 import isEmpty from 'lodash/isEmpty';
-import { getAllCorrectResponses } from './utils';
+import { getAllCorrectResponses, choiceIsEmpty } from './utils';
 import { getShuffledChoices } from '@pie-lib/controller-utils';
 
 /**
@@ -45,7 +45,8 @@ export function model(question, session, env, updateSession) {
       }
     }
 
-    let choices = question.choices;
+    let choices = question.choices && question.choices.filter(choice => !choiceIsEmpty(choice));
+
     if (!question.lockChoiceOrder) {
       choices = await getShuffledChoices(choices, session, updateSession, 'id');
     }

--- a/packages/drag-in-the-blank/controller/src/utils.js
+++ b/packages/drag-in-the-blank/controller/src/utils.js
@@ -25,3 +25,5 @@ export const getAllCorrectResponses = ({ correctResponse, alternateResponses }) 
     numberOfPossibleResponses: undefined
   });
 };
+
+export const choiceIsEmpty = choice => choice && choice.value && (choice.value.trim() === '' || choice.value.replace(/<[^>]*>?/gm, '') === '');

--- a/packages/drag-in-the-blank/controller/src/utils.js
+++ b/packages/drag-in-the-blank/controller/src/utils.js
@@ -26,4 +26,12 @@ export const getAllCorrectResponses = ({ correctResponse, alternateResponses }) 
   });
 };
 
-export const choiceIsEmpty = choice => choice && choice.value && (choice.value.trim() === '' || choice.value.replace(/<[^>]*>?/gm, '') === '');
+export const choiceIsEmpty = choice => {
+  if (choice) {
+    const { value = '' } = choice;
+
+    return value.trim() === '' || value.replace(/<[^>]*>?/gm, '') === '';
+  }
+
+  return false;
+};


### PR DESCRIPTION
I was still blocked on testing the changes on pie-components-integration. However, I am 99.9% sure that my changes will fix the issue.
Updated with:
Adding a choice:
- by default its value is an empty string;
- Student will not see that new choice because it is empty;
- If author tries to drag that empty choice, in order to associate it with a response area, the drag won’t be possible and an alert box will display an info message (“You need to define a value for an answer choice before it can be associated with a response area”).
- Clicking the Add Choice button to result in focus switching to the choice you have just created, so that it is in effect prompting you to populate it with a value.
- Support workflow where you first create placeholders for a bunch of answer choices all at once, and then populate them sequentially. 

Editing a choice (Author starts editing an existing choice and removes all the characters.):
- Editing an answer choice that is not associated with any response areas, then arguably saving it as blank should be equivalent to deleting it.
- assuming that the choice was previously associated with a response area (or multiple response area if duplicates are allowed), saving it as blank shouldn’t be allowed (Display an error message, “Answer choices cannot be blank” and revert the field to the last saved value.)