### PR TITLE
Andreea/ch3596/from ibx item authoring revision teacher instructions and rationale

### DIFF
--- a/packages/categorize/configure/src/defaults.js
+++ b/packages/categorize/configure/src/defaults.js
@@ -1,27 +1,20 @@
 export default {
   model: {
-    choices: [
-      {
-        id: '0',
-        content: 'Choice 0'
-      },
-    ],
+    choices: [],
     choicesPerRow: 2,
     choicesPosition: 'below',
     choicesLabel: '',
     lockChoiceOrder: true,
     removeTilesAfterPlacing: false,
     categoriesPerRow: 2,
-    categories: [
-      {
-        id: '0',
-        label: 'Category 0',
-        choices: []
-      },
-    ],
-    rowLabels: [''],
+    categories: [],
+    alternates: [],
     correctResponse: [],
+    rowLabels: [''],
     partialScoring: true,
+    rationaleEnabled: true,
+    teacherInstructionsEnabled: true,
+    studentInstructionsEnabled: true
   },
   configuration: {
     feedback: {
@@ -43,8 +36,7 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false,
+      label: 'Rationale'
     },
     scoringType: {
       settings: false,
@@ -52,13 +44,11 @@ export default {
     },
     studentInstructions: {
       settings: false,
-      label: 'Student Instructions',
-      enabled: true,
+      label: 'Student Instructions'
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: false,
+      label: 'Teacher Instructions'
     },
   }
 };

--- a/packages/categorize/configure/src/design/__tests__/__snapshots__/index.test.jsx.snap
+++ b/packages/categorize/configure/src/design/__tests__/__snapshots__/index.test.jsx.snap
@@ -10,10 +10,10 @@ exports[`Design snapshot renders 1`] = `
         groups={
           Object {
             "Properties": Object {
-              "rationale.enabled": undefined,
+              "rationaleEnabled": undefined,
               "scoringType": undefined,
-              "studentInstructions.enabled": undefined,
-              "teacherInstructions.enabled": undefined,
+              "studentInstructionsEnabled": undefined,
+              "teacherInstructionsEnabled": undefined,
             },
             "Settings": Object {
               "feedback.enabled": undefined,

--- a/packages/categorize/configure/src/design/categories/__tests__/alternateResponses.test.jsx
+++ b/packages/categorize/configure/src/design/categories/__tests__/alternateResponses.test.jsx
@@ -2,12 +2,34 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { AlternateResponses } from '../alternateResponses';
-import defaultValues from '../../../defaults';
 
 describe('AlternateResponses', () => {
   let w;
   let onModelChanged = jest.fn();
-  let model = defaultValues.model;
+  let model = {
+    choices: [
+      {
+        id: '0',
+        content: 'Choice 0'
+      },
+    ],
+    choicesPerRow: 2,
+    choicesPosition: 'below',
+    choicesLabel: '',
+    lockChoiceOrder: true,
+    removeTilesAfterPlacing: false,
+    categoriesPerRow: 2,
+    categories: [
+      {
+        id: '0',
+        label: 'Category 0',
+        choices: []
+      },
+    ],
+    rowLabels: [''],
+    correctResponse: [],
+    partialScoring: true,
+  };
 
   const wrapper = extras => {
     const defaults = {

--- a/packages/categorize/configure/src/design/categories/__tests__/index.test.jsx
+++ b/packages/categorize/configure/src/design/categories/__tests__/index.test.jsx
@@ -2,12 +2,34 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { Categories } from '../index';
-import defaultValues from '../../../defaults';
 
 describe('Categories', () => {
   let w;
   let onModelChanged = jest.fn();
-  let model = defaultValues.model;
+  let model = {
+    choices: [
+      {
+        id: '0',
+        content: 'Choice 0'
+      },
+    ],
+    choicesPerRow: 2,
+    choicesPosition: 'below',
+    choicesLabel: '',
+    lockChoiceOrder: true,
+    removeTilesAfterPlacing: false,
+    categoriesPerRow: 2,
+    categories: [
+      {
+        id: '0',
+        label: 'Category 0',
+        choices: []
+      },
+    ],
+    rowLabels: [''],
+    correctResponse: [],
+    partialScoring: true,
+  };
 
   const wrapper = extras => {
     const defaults = {

--- a/packages/categorize/configure/src/design/choices/__tests__/config.test.jsx
+++ b/packages/categorize/configure/src/design/choices/__tests__/config.test.jsx
@@ -2,7 +2,6 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { Config } from '../config';
-import defaults from '../../../defaults';
 
 
 describe('config', () => {
@@ -13,7 +12,30 @@ describe('config', () => {
   beforeEach(() => {
     onModelChanged = jest.fn();
     allChoicesHaveCount = jest.fn();
-    config = defaults.model;
+    config = {
+      choices: [
+        {
+          id: '0',
+          content: 'Choice 0'
+        },
+      ],
+      choicesPerRow: 2,
+      choicesPosition: 'below',
+      choicesLabel: '',
+      lockChoiceOrder: true,
+      removeTilesAfterPlacing: false,
+      categoriesPerRow: 2,
+      categories: [
+        {
+          id: '0',
+          label: 'Category 0',
+          choices: []
+        },
+      ],
+      rowLabels: [''],
+      correctResponse: [],
+      partialScoring: true,
+    };
   });
   const wrapper = extras => {
     const props = { classes: {}, onModelChanged, allChoicesHaveCount, config, ...extras };

--- a/packages/categorize/configure/src/design/choices/__tests__/index.test.jsx
+++ b/packages/categorize/configure/src/design/choices/__tests__/index.test.jsx
@@ -2,11 +2,33 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { Choices } from '../index';
-import defaults from '../../../defaults';
 
 describe('choices', () => {
   let onModelChanged = jest.fn();
-  let model = defaults.model;
+  let model = {
+    choices: [
+      {
+        id: '0',
+        content: 'Choice 0'
+      },
+    ],
+    choicesPerRow: 2,
+    choicesPosition: 'below',
+    choicesLabel: '',
+    lockChoiceOrder: true,
+    removeTilesAfterPlacing: false,
+    categoriesPerRow: 2,
+    categories: [
+      {
+        id: '0',
+        label: 'Category 0',
+        choices: []
+      },
+    ],
+    rowLabels: [''],
+    correctResponse: [],
+    partialScoring: true,
+  };
   let onConfigChange;
   let onAdd;
   let onDelete;

--- a/packages/categorize/configure/src/design/index.jsx
+++ b/packages/categorize/configure/src/design/index.jsx
@@ -144,6 +144,7 @@ export class Design extends React.Component {
       feedback = {},
       prompt = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     const config = model.config || {};
     config.choices = config.choices || { label: '', columns: 2 };
@@ -183,12 +184,12 @@ export class Design extends React.Component {
                   'feedback.enabled': feedback.settings && toggle(feedback.label, true),
                 },
                 'Properties': {
-                  'teacherInstructions.enabled': teacherInstructions.settings &&
-                    toggle(teacherInstructions.label, true),
-                  'studentInstructions.enabled': studentInstructions.settings &&
-                    toggle(studentInstructions.label, true),
-                  'rationale.enabled': rationale.settings &&
-                    toggle(rationale.label, true),
+                  teacherInstructionsEnabled: teacherInstructions.settings &&
+                    toggle(teacherInstructions.label),
+                  studentInstructionsEnabled: studentInstructions.settings &&
+                    toggle(studentInstructions.label),
+                  rationaleEnabled: rationale.settings &&
+                    toggle(rationale.label),
                   scoringType: scoringType.settings &&
                     radio(scoringType.label, ['auto', 'rubric']),
                 },
@@ -214,7 +215,7 @@ export class Design extends React.Component {
               </InputContainer>
             )}
 
-            {teacherInstructions.enabled && (
+            {teacherInstructionsEnabled && (
               <InputContainer label={teacherInstructions.label} className={classes.inputHolder}>
                 <EditableHtml
                   className={classes.input}
@@ -226,7 +227,7 @@ export class Design extends React.Component {
               </InputContainer>
             )}
 
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer label={rationale.label} className={classes.inputHolder}>
                 <EditableHtml
                   className={classes.input}
@@ -241,7 +242,7 @@ export class Design extends React.Component {
             <Categories
               imageSupport={imageSupport}
               model={model}
-              categories={categories}
+              categories={categories || []}
               onModelChanged={this.updateModel}
             />
 

--- a/packages/categorize/controller/src/defaults.js
+++ b/packages/categorize/controller/src/defaults.js
@@ -1,31 +1,4 @@
 export default {
-  choices: [
-    {
-      id: '0',
-      content: '420 cm = 4.2 meters'
-    },
-    {
-      id: '1',
-      content: '3.4 kg = 340 g'
-    },
-  ],
-  categories: [
-    {
-      id: '0',
-      label: 'Equivalent',
-    },
-    {
-      id: '1',
-      label: '<b>NOT </b>equivalent',
-    }
-  ],
-  config: {
-    choices: {
-      columns: 2,
-      position: 'below',
-    },
-    categories: {
-      columns: 2
-    }
-  }
+  choices: [],
+  categories: [],
 };

--- a/packages/categorize/controller/src/index.js
+++ b/packages/categorize/controller/src/index.js
@@ -74,8 +74,8 @@ export const model = (question, session, env, updateSession) =>
           correctness,
           feedback,
           prompt: question.prompt,
-          choices,
-          categories: question.categories,
+          choices: choices || [],
+          categories: question.categories || [],
           disabled: env.mode !== 'gather',
           choicesPerRow: question.choicesPerRow || 2,
           choicesLabel: question.choicesLabel || '',
@@ -93,8 +93,8 @@ export const model = (question, session, env, updateSession) =>
           env.role === 'instructor' &&
           (env.mode === 'view' || env.mode === 'evaluate')
         ) {
-          out.rationale = question.rationale;
-          out.teacherInstructions = question.teacherInstructions;
+          out.rationale = question.rationaleEnabled ? question.rationale : null;
+          out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
         } else {
           out.rationale = null;
           out.teacherInstructions = null;

--- a/packages/categorize/docs/pie-schema.json
+++ b/packages/categorize/docs/pie-schema.json
@@ -364,6 +364,21 @@
       "type": "boolean",
       "title": "partialScoring"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -380,7 +395,10 @@
     "choices",
     "element",
     "id",
-    "prompt"
+    "prompt",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/categorize/docs/pie-schema.json.md
+++ b/packages/categorize/docs/pie-schema.json.md
@@ -144,6 +144,18 @@ Indicates the value for rationale
 
 Indicates if partial scoring is enabled
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/charting/configure/src/__tests__/__snapshots__/configure.test.js.snap
+++ b/packages/charting/configure/src/__tests__/__snapshots__/configure.test.js.snap
@@ -82,17 +82,14 @@ exports[`Configure renders snapshot 1`] = `
             "settings": true,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
           "title": Object {
-            "enabled": true,
             "label": "Graph Title",
             "settings": false,
           },
@@ -105,10 +102,10 @@ exports[`Configure renders snapshot 1`] = `
             "title.enabled": false,
           },
           "Properties": Object {
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": undefined,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
         }
       }
@@ -135,7 +132,10 @@ exports[`Configure renders snapshot 1`] = `
             "min": 0,
           },
           "rationale": "Rationale goes here!",
+          "rationaleEnabled": false,
           "scoringType": "partial scoring",
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
           "title": "This is a chart!",
         }
       }
@@ -223,7 +223,10 @@ exports[`Configure renders snapshot 1`] = `
             "min": 0,
           },
           "rationale": "Rationale goes here!",
+          "rationaleEnabled": false,
           "scoringType": "partial scoring",
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
           "title": "This is a chart!",
         }
       }
@@ -286,7 +289,10 @@ exports[`Configure renders snapshot 1`] = `
             "min": 0,
           },
           "rationale": "Rationale goes here!",
+          "rationaleEnabled": false,
           "scoringType": "partial scoring",
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
           "title": "This is a chart!",
         }
       }

--- a/packages/charting/configure/src/configure.jsx
+++ b/packages/charting/configure/src/configure.jsx
@@ -84,6 +84,7 @@ export class Configure extends React.Component {
       teacherInstructions = {},
       prompt = {},
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     return (
       <layout.ConfigLayout
@@ -112,14 +113,14 @@ export class Configure extends React.Component {
                 })
               },
               Properties: {
-                'teacherInstructions.enabled':
+                teacherInstructionsEnabled:
                   teacherInstructions.settings &&
-                  toggle(teacherInstructions.label, true),
-                'studentInstructions.enabled':
+                  toggle(teacherInstructions.label),
+                studentInstructionsEnabled:
                   studentInstructions.settings &&
-                  toggle(studentInstructions.label, true),
-                'rationale.enabled':
-                  rationale.settings && toggle(rationale.label, true),
+                  toggle(studentInstructions.label),
+                rationaleEnabled:
+                  rationale.settings && toggle(rationale.label),
                 scoringType:
                   scoringType.settings &&
                   radio(scoringType.label, ['all or nothing', 'partial scoring'])
@@ -137,7 +138,7 @@ export class Configure extends React.Component {
             </span>
           </Typography>
 
-          {teacherInstructions.enabled && (
+          {teacherInstructionsEnabled && (
             <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
               <EditableHtml
                 className={classes.prompt}
@@ -165,7 +166,7 @@ export class Configure extends React.Component {
             </InputContainer>
           )}
 
-          {rationale.enabled && (
+          {rationaleEnabled && (
             <InputContainer
               label={rationale.label || 'Rationale'}
               className={classes.promptHolder}

--- a/packages/charting/configure/src/defaults.js
+++ b/packages/charting/configure/src/defaults.js
@@ -39,6 +39,9 @@ export default {
     },
     scoringType: 'partial scoring',
     title: 'This is a chart!',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     prompt: {
@@ -56,18 +59,15 @@ export default {
     },
     studentInstructions: {
       settings: false,
-      label: 'Student Instructions',
-      enabled: true
+      label: 'Student Instructions'
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: false
+      label: 'Teacher Instructions'
     },
     title: {
       settings: false,
-      label: 'Graph Title',
-      enabled: true
+      label: 'Graph Title'
     }
   }
 };

--- a/packages/charting/controller/src/index.js
+++ b/packages/charting/controller/src/index.js
@@ -170,8 +170,8 @@ export function model(question, session, env) {
     }
 
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-      base.rationale = question.rationale;
-      base.teacherInstructions = question.teacherInstructions;
+      base.rationale = question.rationaleEnabled ? question.rationale : null;
+      base.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       base.rationale = null;
       base.teacherInstructions = null;

--- a/packages/charting/docs/pie-schema.json
+++ b/packages/charting/docs/pie-schema.json
@@ -491,6 +491,21 @@
       "type": "string",
       "title": "title"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -513,7 +528,10 @@
     "element",
     "graph",
     "id",
-    "range"
+    "range",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/charting/docs/pie-schema.json
+++ b/packages/charting/docs/pie-schema.json
@@ -4,18 +4,13 @@
   "type": "object",
   "properties": {
     "addCategoryEnabled": {
-      "title": "Boolean",
-      "type": "object"
+      "description": "Indicates if user can add more categories",
+      "type": "boolean",
+      "title": "addCategoryEnabled"
     },
     "categoryDefaultLabel": {
-      "description": "Allows manipulation and formatting of text strings and determination and location of substrings within strings.",
-      "type": "object",
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[0-9]+$": {
-          "type": "string"
-        }
-      },
+      "description": "Indicates default value for a new category's label",
+      "type": "string",
       "title": "categoryDefaultLabel"
     },
     "chartType": {
@@ -396,8 +391,9 @@
       ]
     },
     "editCategoryEnabled": {
-      "title": "Boolean",
-      "type": "object"
+      "description": "Indicates if user can edit default categories",
+      "type": "boolean",
+      "title": "editCategoryEnabled"
     },
     "graph": {
       "title": "Chart",
@@ -554,10 +550,6 @@
           "title": "enabled"
         }
       }
-    },
-    "Boolean": {
-      "title": "Boolean",
-      "type": "object"
     },
     "Answer": {
       "title": "Answer",

--- a/packages/charting/docs/pie-schema.json.md
+++ b/packages/charting/docs/pie-schema.json.md
@@ -136,6 +136,18 @@ Indicates teacher instructions
 
 Indicates chart title
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/charting/docs/pie-schema.json.md
+++ b/packages/charting/docs/pie-schema.json.md
@@ -4,11 +4,13 @@ Model Object for @pie-elements/charting
 
 The schema defines the following properties:
 
-# `addCategoryEnabled` (object, required)
+# `addCategoryEnabled` (boolean, required)
 
-# `categoryDefaultLabel` (object, required)
+Indicates if user can add more categories
 
-Allows manipulation and formatting of text strings and determination and location of substrings within strings.
+# `categoryDefaultLabel` (string, required)
+
+Indicates default value for a new category's label
 
 # `chartType` (string, enum, required)
 
@@ -69,7 +71,9 @@ Label step value
 
 Axis Label
 
-# `editCategoryEnabled` (object, required)
+# `editCategoryEnabled` (boolean, required)
+
+Indicates if user can edit default categories
 
 # `graph` (object, required)
 
@@ -177,8 +181,6 @@ Indicates the label for the item
 ### `enabled` (boolean)
 
 Indicates the value of the item if it affects config-ui (eg.: if item is a switch)
-
-## `Boolean` (object)
 
 ## `Answer` (object)
 

--- a/packages/drag-in-the-blank/configure/src/defaults.js
+++ b/packages/drag-in-the-blank/configure/src/defaults.js
@@ -8,7 +8,10 @@ export default {
     choices: [],
     choicesPosition: 'below',
     correctResponse: {},
-    duplicates: true
+    duplicates: true,
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     choicesPosition: {
@@ -33,13 +36,11 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false,
+      label: 'Rationale'
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: true
+      label: 'Teacher Instructions'
     }
   }
 };

--- a/packages/drag-in-the-blank/configure/src/main.jsx
+++ b/packages/drag-in-the-blank/configure/src/main.jsx
@@ -147,6 +147,10 @@ export class Main extends React.Component {
       teacherInstructions = {},
       choicesPosition = {}
     } = configuration || {};
+    const {
+      rationaleEnabled,
+      teacherInstructionsEnabled
+    } = model || {};
 
     return (
       <div className={classes.design}>
@@ -172,17 +176,17 @@ export class Main extends React.Component {
                   ])
                 },
                 'Properties': {
-                  'teacherInstructions.enabled': teacherInstructions.settings &&
-                    toggle(teacherInstructions.label, true),
-                  'rationale.enabled': rationale.settings &&
-                    toggle(rationale.label, true)
+                  teacherInstructionsEnabled: teacherInstructions.settings &&
+                    toggle(teacherInstructions.label),
+                  rationaleEnabled: rationale.settings &&
+                    toggle(rationale.label)
                 }
               }}
             />
           }
         >
           <div>
-            {teacherInstructions.enabled && (
+            {teacherInstructionsEnabled && (
               <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
                 <EditableHtml
                   className={classes.prompt}
@@ -235,7 +239,7 @@ export class Main extends React.Component {
               duplicates={model.duplicates}
               onChange={this.onResponsesChanged}
             />
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer
                 label={rationale.label}
                 className={classes.promptHolder}

--- a/packages/drag-in-the-blank/controller/src/defaults.js
+++ b/packages/drag-in-the-blank/controller/src/defaults.js
@@ -2,14 +2,5 @@ export default {
   prompt: 'Which of these northern European countries are EU members?',
   choiceMode: 'checkbox',
   choicePrefix: 'numbers',
-  choices: [
-    {
-      value: 'sweden',
-      label: 'Sweden',
-    },
-    {
-      value: 'iceland',
-      label: 'Iceland',
-    },
-  ],
+  choices: [],
 };

--- a/packages/drag-in-the-blank/controller/src/index.js
+++ b/packages/drag-in-the-blank/controller/src/index.js
@@ -62,12 +62,13 @@ export function model(question, session, env, updateSession) {
           ? getScore(question, session) === 1
           : undefined,
     };
+
     if (
       env.role === 'instructor' &&
       (env.mode === 'view' || env.mode === 'evaluate')
     ) {
-      out.rationale = question.rationale;
-      out.teacherInstructions = question.teacherInstructions;
+      out.rationale = question.rationaleEnabled ? question.rationale : null;
+      out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       out.rationale = null;
       out.teacherInstructions = null;

--- a/packages/drag-in-the-blank/docs/pie-schema.json
+++ b/packages/drag-in-the-blank/docs/pie-schema.json
@@ -100,6 +100,21 @@
       "type": "string",
       "title": "rubric"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -118,7 +133,10 @@
     "id",
     "markup",
     "rationale",
-    "rubric"
+    "rationaleEnabled",
+    "rubric",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/drag-in-the-blank/docs/pie-schema.json.md
+++ b/packages/drag-in-the-blank/docs/pie-schema.json.md
@@ -72,6 +72,18 @@ Indicates teacher instructions
 
 Indicates value for rubric
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/drawing-response/configure/src/defaults.js
+++ b/packages/drawing-response/configure/src/defaults.js
@@ -5,6 +5,9 @@ export default {
     height: 0,
     width: 0
   },
+  rationaleEnabled: false,
+  teacherInstructionsEnabled: false,
+  studentInstructionsEnabled: false,
   configuration: {
     backgroundImage: {
       settings: true,
@@ -13,13 +16,11 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false
+      label: 'Rationale'
     },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: true,
     }
   }
 };

--- a/packages/drawing-response/configure/src/root.jsx
+++ b/packages/drawing-response/configure/src/root.jsx
@@ -25,7 +25,8 @@ class Root extends React.Component {
       onTeacherInstructionsChanged
     } = this.props;
     const { backgroundImage = {}, rationale = {}, teacherInstructions = {} } = configuration || {};
-    
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
+
     return (
       <div className={classes.base}>
         <layout.ConfigLayout
@@ -39,10 +40,9 @@ class Root extends React.Component {
                 'Settings': {
                   'backgroundImage.enabled':
                   backgroundImage.settings && toggle(backgroundImage.label, true),
-                  'rationale.enabled':
-                  rationale.settings && toggle(rationale.label, true),
-                  'teacherInstructions.enabled':
-                    teacherInstructions.settings && toggle(teacherInstructions.label, true)
+                  rationaleEnabled: rationale.settings && toggle(rationale.label),
+                  teacherInstructionsEnabled:
+                    teacherInstructions.settings && toggle(teacherInstructions.label)
                 },
                 Properties: {}
               }}
@@ -50,7 +50,7 @@ class Root extends React.Component {
           }
         >
           <div className={classes.regular}>
-            {teacherInstructions.enabled && (
+            {teacherInstructionsEnabled && (
               <InputContainer label={teacherInstructions.label} className={classes.prompt}>
                 <EditableHtml
                   markup={model.teacherInstructions || ''}
@@ -65,7 +65,7 @@ class Root extends React.Component {
               <EditableHtml markup={model.prompt} onChange={onPromptChanged} />
             </InputContainer>
 
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer
                 label={rationale.label}
                 className={classes.prompt}

--- a/packages/drawing-response/controller/src/index.js
+++ b/packages/drawing-response/controller/src/index.js
@@ -20,9 +20,11 @@ export function model(question, session, env) {
     };
 
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-      out.teacherInstructions = question.teacherInstructions;
+      out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
+      out.rationale = question.rationaleEnabled ? question.rationale : null;
     } else {
       out.teacherInstructions = null;
+      out.rationale = null;
     }
 
     resolve(out);

--- a/packages/drawing-response/docs/pie-schema.json
+++ b/packages/drawing-response/docs/pie-schema.json
@@ -48,6 +48,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -62,7 +77,10 @@
   "required": [
     "element",
     "id",
-    "imageDimensions"
+    "imageDimensions",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/drawing-response/docs/pie-schema.json.md
+++ b/packages/drawing-response/docs/pie-schema.json.md
@@ -37,6 +37,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/explicit-constructed-response/configure/src/defaults.js
+++ b/packages/explicit-constructed-response/configure/src/defaults.js
@@ -49,7 +49,10 @@ export default {
           value: '3'
         }
       ]
-    }
+    },
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     prompt: {
@@ -62,13 +65,11 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false,
+      label: 'Rationale'
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: true,
+      label: 'Teacher Instructions'
     },
   }
 };

--- a/packages/explicit-constructed-response/configure/src/main.jsx
+++ b/packages/explicit-constructed-response/configure/src/main.jsx
@@ -187,6 +187,7 @@ export class Main extends React.Component {
       rationale = {},
       teacherInstructions = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     return (
       <div className={classes.design}>
@@ -203,17 +204,16 @@ export class Main extends React.Component {
                   toggle(partialScoring.label)
                 },
                 'Properties': {
-                  'teacherInstructions.enabled': teacherInstructions.settings &&
-                  toggle(teacherInstructions.label, true),
-                  'rationale.enabled': rationale.settings &&
-                  toggle(rationale.label, true)
+                  teacherInstructionsEnabled: teacherInstructions.settings &&
+                  toggle(teacherInstructions.label),
+                  rationaleEnabled: rationale.settings && toggle(rationale.label)
                 }
               }}
             />
           }
         >
           <div>
-            {teacherInstructions.enabled && (
+            {teacherInstructionsEnabled && (
               <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
                 <EditableHtml
                   className={classes.prompt}
@@ -287,7 +287,7 @@ export class Main extends React.Component {
               model={model}
               onChange={this.onResponsesChanged}
             />
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer
                 label={rationale.label}
                 className={classes.promptHolder}

--- a/packages/explicit-constructed-response/controller/src/index.js
+++ b/packages/explicit-constructed-response/controller/src/index.js
@@ -95,8 +95,8 @@ export function model(question, session, env, updateSession) {
       env.role === 'instructor' &&
       (env.mode === 'view' || env.mode === 'evaluate')
     ) {
-      out.rationale = question.rationale;
-      out.teacherInstructions = question.teacherInstructions;
+      out.rationale = question.rationaleEnabled ? question.rationale : null;
+      out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       out.rationale = null;
       out.teacherInstructions = null;

--- a/packages/explicit-constructed-response/docs/pie-schema.json
+++ b/packages/explicit-constructed-response/docs/pie-schema.json
@@ -73,6 +73,21 @@
       "type": "string",
       "title": "rubric"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -91,7 +106,10 @@
     "id",
     "markup",
     "rationale",
-    "rubric"
+    "rationaleEnabled",
+    "rubric",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/explicit-constructed-response/docs/pie-schema.json.md
+++ b/packages/explicit-constructed-response/docs/pie-schema.json.md
@@ -43,6 +43,18 @@ Indicates teacher instructions
 
 Indicates value for rubric
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/extended-text-entry/configure/src/__tests__/__snapshots__/main.test.js.snap
+++ b/packages/extended-text-entry/configure/src/__tests__/__snapshots__/main.test.js.snap
@@ -36,12 +36,10 @@ exports[`Render Main Component Match Snapshot 1`] = `
             "settings": true,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
           "teacherInstructions": Object {
-            "enabled": true,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -50,8 +48,8 @@ exports[`Render Main Component Match Snapshot 1`] = `
       groups={
         Object {
           "Properties": Object {
-            "configure.studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
           "Settings": Object {
             "dimensions": undefined,
@@ -72,6 +70,9 @@ exports[`Render Main Component Match Snapshot 1`] = `
           "equationEditor": "everything",
           "mathInput": false,
           "prompt": "This is the question prompt",
+          "rationaleEnabled": false,
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
         }
       }
       onChangeConfiguration={[Function]}
@@ -80,15 +81,6 @@ exports[`Render Main Component Match Snapshot 1`] = `
   }
 >
   <div>
-    <Component
-      label="Teacher Instructions"
-    >
-      <EditableHtml
-        markup=""
-        nonEmpty={false}
-        onChange={[Function]}
-      />
-    </Component>
     <br />
     <Component
       label="Prompt"

--- a/packages/extended-text-entry/configure/src/defaults.js
+++ b/packages/extended-text-entry/configure/src/defaults.js
@@ -6,7 +6,10 @@ export default {
     },
     prompt: 'This is the question prompt',
     mathInput: false,
-    equationEditor: 'everything'
+    equationEditor: 'everything',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     dimensions: {
@@ -35,8 +38,7 @@ export default {
     },
     studentInstructions: {
       settings: false,
-      label: 'Student Instructions',
-      enabled: true,
+      label: 'Student Instructions'
     },
     prompt: {
       settings: true,
@@ -45,8 +47,7 @@ export default {
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: true,
+      label: 'Teacher Instructions'
     },
   }
 };

--- a/packages/extended-text-entry/configure/src/main.jsx
+++ b/packages/extended-text-entry/configure/src/main.jsx
@@ -76,6 +76,7 @@ export class Main extends React.Component {
       dimensions = {},
       equationEditor = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled } = model || {};
 
     return (
       <layout.ConfigLayout
@@ -119,9 +120,9 @@ export class Main extends React.Component {
                 'feedback.enabled': feedback.settings && toggle(feedback.label, true),
               },
               'Properties': {
-                'teacherInstructions.enabled': teacherInstructions.settings &&
-                toggle(teacherInstructions.label, true),
-                'configure.studentInstructions.enabled': studentInstructions.settings &&
+                teacherInstructionsEnabled: teacherInstructions.settings &&
+                toggle(teacherInstructions.label),
+                studentInstructionsEnabled: studentInstructions.settings &&
                 toggle(studentInstructions.label),
               },
             }}
@@ -130,7 +131,7 @@ export class Main extends React.Component {
       >
         <div>
           
-          {teacherInstructions.enabled && (
+          {teacherInstructionsEnabled && (
             <InputContainer label={teacherInstructions.label} className={classes.promptContainer}>
               <EditableHtml
                 className={classes.prompt}

--- a/packages/extended-text-entry/controller/src/index.js
+++ b/packages/extended-text-entry/controller/src/index.js
@@ -24,7 +24,9 @@ export async function model(model, session, env) {
   let teacherInstructions = null;
 
   if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-    teacherInstructions = model.teacherInstructions;
+    teacherInstructions = model.teacherInstructionsEnabled ? model.teacherInstructions : null;
+  } else {
+    teacherInstructions = null;
   }
 
   let equationEditor = model.equationEditor || 'everything';

--- a/packages/extended-text-entry/docs/pie-schema.json
+++ b/packages/extended-text-entry/docs/pie-schema.json
@@ -83,6 +83,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -97,7 +112,10 @@
   "required": [
     "dimensions",
     "element",
-    "id"
+    "id",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/extended-text-entry/docs/pie-schema.json.md
+++ b/packages/extended-text-entry/docs/pie-schema.json.md
@@ -71,6 +71,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/graph-lines/configure/src/configure.jsx
+++ b/packages/graph-lines/configure/src/configure.jsx
@@ -156,12 +156,11 @@ export class Configure extends React.Component {
                 labels: labels.settings && toggle(labels.label),
               },
               'Properties': {
-                'teacherInstructions.enabled': teacherInstructions.settings &&
-                toggle(teacherInstructions.label, true),
-                'studentInstructions.enabled': studentInstructions.settings &&
-                toggle(studentInstructions.label, true),
-                'rationale.enabled': rationale.settings &&
-                toggle(rationale.label, true),
+                teacherInstructionsEnabled: teacherInstructions.settings &&
+                toggle(teacherInstructions.label),
+                studentInstructionsEnabled: studentInstructions.settings &&
+                toggle(studentInstructions.label),
+                rationaleEnabled: rationale.settings && toggle(rationale.label),
                 scoringType: scoringType.settings &&
                 radio(scoringType.label, ['auto', 'rubric']),
               },
@@ -186,6 +185,7 @@ export class Configure extends React.Component {
             config={config}
             configuration={configuration}
             rationale={model.rationale}
+            rationaleEnabled={model && model.rationaleEnabled}
             onChange={this.onChange}
             imageSupport={imageSupport}
           />

--- a/packages/graph-lines/configure/src/defaults.js
+++ b/packages/graph-lines/configure/src/defaults.js
@@ -9,6 +9,9 @@ export default {
     scoringType: 'auto',
     arrows: true,
     padding: true,
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     arrows: {
@@ -31,8 +34,7 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false,
+      label: 'Rationale'
     },
     scoringType: {
       settings: false,
@@ -40,13 +42,11 @@ export default {
     },
     studentInstructions: {
       settings: false,
-      label: 'Student Instructions',
-      enabled: true,
+      label: 'Student Instructions'
     },
     teacherInstructions: {
       settings: false,
-      label: 'Teacher Instructions',
-      enabled: false,
+      label: 'Teacher Instructions'
     },
   }
 };

--- a/packages/graph-lines/configure/src/general-config-block.jsx
+++ b/packages/graph-lines/configure/src/general-config-block.jsx
@@ -62,7 +62,8 @@ export class GeneralConfigBlock extends React.Component {
     configuration: PropTypes.object,
     rationale: PropTypes.string,
     imageSupport: PropTypes.object,
-    onRationaleChange: PropTypes.func
+    onRationaleChange: PropTypes.func,
+    rationaleEnabled: PropTypes.bool
   };
 
   static defaultProps = {
@@ -97,7 +98,8 @@ export class GeneralConfigBlock extends React.Component {
       configuration,
       rationale,
       imageSupport,
-      onRationaleChange
+      onRationaleChange,
+      rationaleEnabled
     } = this.props;
     const { rationale: cRationale = {} } = configuration || {};
 
@@ -162,7 +164,7 @@ export class GeneralConfigBlock extends React.Component {
               onChange={this.onChange('exhibitOnly', true)}/>
           </div>
         </div>
-        {cRationale.enabled && (
+        {rationaleEnabled && (
           <InputContainer
             label={cRationale.label || 'Rationale'}
           >

--- a/packages/graph-lines/controller/src/index.js
+++ b/packages/graph-lines/controller/src/index.js
@@ -109,7 +109,7 @@ export function model(question, session, env) {
       });
 
       if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-        out.rationale = question.rationale;
+        out.rationale = question.rationaleEnabled ? question.rationale : null;
       } else {
         out.rationale = null;
       }

--- a/packages/graph-lines/docs/pie-schema.json
+++ b/packages/graph-lines/docs/pie-schema.json
@@ -395,6 +395,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -410,7 +425,10 @@
     "element",
     "graph",
     "id",
-    "multiple"
+    "multiple",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/graph-lines/docs/pie-schema.json.md
+++ b/packages/graph-lines/docs/pie-schema.json.md
@@ -176,6 +176,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/graphing/configure/src/__tests__/__snapshots__/configure.test.js.snap
+++ b/packages/graphing/configure/src/__tests__/__snapshots__/configure.test.js.snap
@@ -29,7 +29,6 @@ exports[`Configure renders snapshot 1`] = `
             "settings": true,
           },
           "rationale": Object {
-            "enabled": false,
             "label": "Rationale",
             "settings": true,
           },
@@ -38,12 +37,10 @@ exports[`Configure renders snapshot 1`] = `
             "settings": true,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -65,10 +62,10 @@ exports[`Configure renders snapshot 1`] = `
           },
           "Properties": Object {
             "authoring.enabled": false,
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": undefined,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
         }
       }
@@ -106,7 +103,10 @@ exports[`Configure renders snapshot 1`] = `
             "step": 0.5,
           },
           "rationale": "Rationale goes here!",
+          "rationaleEnabled": false,
           "scoringType": "partial scoring",
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
           "title": "",
           "toolbarTools": Array [
             "point",
@@ -186,7 +186,10 @@ exports[`Configure renders snapshot 1`] = `
             "step": 0.5,
           },
           "rationale": "Rationale goes here!",
+          "rationaleEnabled": false,
           "scoringType": "partial scoring",
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
           "title": "",
           "toolbarTools": Array [
             "point",
@@ -284,7 +287,10 @@ exports[`Configure renders snapshot 1`] = `
             "step": 0.5,
           },
           "rationale": "Rationale goes here!",
+          "rationaleEnabled": false,
           "scoringType": "partial scoring",
+          "studentInstructionsEnabled": false,
+          "teacherInstructionsEnabled": false,
           "title": "",
           "toolbarTools": Array [
             "point",

--- a/packages/graphing/configure/src/configure.jsx
+++ b/packages/graphing/configure/src/configure.jsx
@@ -101,6 +101,7 @@ export class Configure extends React.Component {
       authoring = {}
     } = configuration || {};
     log('[render] model', model);
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     return (
       <layout.ConfigLayout
@@ -134,14 +135,11 @@ export class Configure extends React.Component {
               Properties: {
                 'authoring.enabled':
                   authoring.settings && toggle(authoring.label, true),
-                'teacherInstructions.enabled':
-                  teacherInstructions.settings &&
-                  toggle(teacherInstructions.label, true),
-                'studentInstructions.enabled':
-                  studentInstructions.settings &&
-                  toggle(studentInstructions.label, true),
-                'rationale.enabled':
-                  rationale.settings && toggle(rationale.label, true),
+                teacherInstructionsEnabled:
+                  teacherInstructions.settings && toggle(teacherInstructions.label),
+                studentInstructionsEnabled:
+                  studentInstructions.settings && toggle(studentInstructions.label),
+                rationaleEnabled: rationale.settings && toggle(rationale.label),
                 scoringType:
                   scoringType.settings &&
                   radio(scoringType.label, ['dichotomous', 'partial scoring'])
@@ -159,7 +157,7 @@ export class Configure extends React.Component {
             </span>
           </Typography>
 
-          {teacherInstructions.enabled && (
+          {teacherInstructionsEnabled && (
             <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
               <EditableHtml
                 className={classes.prompt}
@@ -187,7 +185,7 @@ export class Configure extends React.Component {
             </InputContainer>
           )}
 
-          {rationale.enabled && (
+          {rationaleEnabled && (
             <InputContainer
               label={rationale.label || 'Rationale'}
               className={classes.promptHolder}

--- a/packages/graphing/configure/src/defaults.js
+++ b/packages/graphing/configure/src/defaults.js
@@ -51,7 +51,10 @@ export default {
     },
     rationale: 'Rationale goes here!',
     scoringType: 'partial scoring',
-    title: ''
+    title: '',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     authoring: {
@@ -78,8 +81,7 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false
+      label: 'Rationale'
     },
     scoringType: {
       settings: true,
@@ -87,13 +89,11 @@ export default {
     },
     studentInstructions: {
       settings: false,
-      label: 'Student Instructions',
-      enabled: true
+      label: 'Student Instructions'
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: false
+      label: 'Teacher Instructions'
     },
     title: {
       settings: false,

--- a/packages/graphing/controller/src/index.js
+++ b/packages/graphing/controller/src/index.js
@@ -321,8 +321,8 @@ export function model(question, session, env) {
     }
 
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-      base.rationale = question.rationale;
-      base.teacherInstructions = question.teacherInstructions;
+      base.rationale = question.rationaleEnabled ? question.rationale : null;
+      base.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       base.rationale = null;
       base.teacherInstructions = null;

--- a/packages/graphing/docs/pie-schema.json
+++ b/packages/graphing/docs/pie-schema.json
@@ -1674,6 +1674,21 @@
       },
       "title": "toolbarTools"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -1692,7 +1707,10 @@
     "element",
     "graph",
     "id",
-    "range"
+    "range",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/graphing/docs/pie-schema.json.md
+++ b/packages/graphing/docs/pie-schema.json.md
@@ -183,6 +183,18 @@ Additional restrictions:
 
 * Minimum items: `1`
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/hotspot/configure/src/defaults.js
+++ b/packages/hotspot/configure/src/defaults.js
@@ -19,7 +19,10 @@ export default {
     outlineColor: 'blue',
     outlineList: [
       'blue'
-    ]
+    ],
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     multipleCorrect: {
@@ -32,8 +35,7 @@ export default {
     },
     rationale: {
       settings: true,
-      label: 'Rationale',
-      enabled: false
+      label: 'Rationale'
     },
     prompt: {
       settings: true,
@@ -42,8 +44,7 @@ export default {
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: true
+      label: 'Teacher Instructions'
     }
   }
 };

--- a/packages/hotspot/configure/src/root.jsx
+++ b/packages/hotspot/configure/src/root.jsx
@@ -53,6 +53,7 @@ class Root extends React.Component {
       teacherInstructions = {},
       rationale = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     return (
       <div className={classes.base}>
@@ -71,19 +72,18 @@ class Root extends React.Component {
                     partialScoring.settings && toggle(partialScoring.label),
                   'prompt.enabled':
                     prompt.settings && toggle(prompt.label, true),
-                  'rationale.enabled':
-                    rationale.settings && toggle(rationale.label, true)
+                  rationaleEnabled: rationale.settings && toggle(rationale.label)
                 },
                 Properties: {
-                  'teacherInstructions.enabled':
-                    teacherInstructions.settings && toggle(teacherInstructions.label, true)
+                  teacherInstructionsEnabled:
+                    teacherInstructions.settings && toggle(teacherInstructions.label)
                 }
               }}
             />
           }
         >
           <div className={classes.regular}>
-            {teacherInstructions.enabled && (
+            {teacherInstructionsEnabled && (
               <InputContainer label={teacherInstructions.label} className={classes.prompt}>
                 <EditableHtml
                   markup={model.teacherInstructions || ''}
@@ -104,7 +104,7 @@ class Root extends React.Component {
               </InputContainer>
             )}
 
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer
                 label={rationale.label}
                 className={classes.prompt}

--- a/packages/hotspot/controller/src/index.js
+++ b/packages/hotspot/controller/src/index.js
@@ -39,8 +39,8 @@ export function model(question, session, env) {
     };
 
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-      out.rationale = question.rationale;
-      out.teacherInstructions = question.teacherInstructions;
+      out.rationale = question.rationaleEnabled ? question.rationale : null;
+      out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       out.rationale = null;
       out.teacherInstructions = null;

--- a/packages/hotspot/docs/pie-schema.json
+++ b/packages/hotspot/docs/pie-schema.json
@@ -185,6 +185,21 @@
       "type": "string",
       "title": "rationale"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -202,7 +217,10 @@
     "id",
     "multipleCorrect",
     "partialScoring",
-    "shapes"
+    "rationaleEnabled",
+    "shapes",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "Shape": {

--- a/packages/hotspot/docs/pie-schema.json.md
+++ b/packages/hotspot/docs/pie-schema.json.md
@@ -126,6 +126,18 @@ The object is an array with all elements of the type `string`.
 
 Indicates the value for rationale
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/image-cloze-association/configure/src/defaults.js
+++ b/packages/image-cloze-association/configure/src/defaults.js
@@ -1,10 +1,13 @@
 export default {
-  model: { },
+  model: {
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
+  },
   configuration: {
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions',
-      enabled: true
+      label: 'Teacher Instructions'
     }
   }
 };

--- a/packages/image-cloze-association/configure/src/root.jsx
+++ b/packages/image-cloze-association/configure/src/root.jsx
@@ -32,15 +32,14 @@ export class Root extends React.Component {
             onChangeConfiguration={config => onConfigurationChanged(config)}
             groups={{
               'Properties': {
-                'teacherInstructions.enabled': teacherInstructions.settings &&
-                  toggle(teacherInstructions.label, true),
+                teacherInstructionsEnabled: teacherInstructions.settings && toggle(teacherInstructions.label),
               },
             }}
           />
         }
       >
         <div className={classes.content}>
-          {teacherInstructions.enabled && (
+          {model && model.teacherInstructionsEnabled && (
             <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
               <EditableHtml
                 className={classes.prompt}

--- a/packages/image-cloze-association/controller/src/index.js
+++ b/packages/image-cloze-association/controller/src/index.js
@@ -19,9 +19,8 @@ export function model(question, session, env) {
           : undefined,
     };
 
-
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-      out.teacherInstructions = question.teacherInstructions;
+      out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       out.teacherInstructions = null;
     }

--- a/packages/inline-dropdown/configure/src/defaults.js
+++ b/packages/inline-dropdown/configure/src/defaults.js
@@ -61,6 +61,9 @@ export default {
     alternateResponse: {
       2: ['3']
     },
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     prompt: {
@@ -78,12 +81,10 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
     },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: true
     }
   }
 };

--- a/packages/inline-dropdown/configure/src/main.jsx
+++ b/packages/inline-dropdown/configure/src/main.jsx
@@ -309,6 +309,7 @@ export class Main extends React.Component {
       rationale = {},
       teacherInstructions = {}
     } = configuration || {};
+    const { rationaleEnabled, teacherInstructionsEnabled } = model || {};
 
     return (
       <div className={classes.design}>
@@ -327,17 +328,16 @@ export class Main extends React.Component {
                   toggle(lockChoiceOrder.label)
                 },
                 'Properties': {
-                  'teacherInstructions.enabled': teacherInstructions.settings &&
-                    toggle(teacherInstructions.label, true),
-                  'rationale.enabled': rationale.settings &&
-                    toggle(rationale.label, true),
+                  teacherInstructionsEnabled: teacherInstructions.settings &&
+                    toggle(teacherInstructions.label),
+                  rationaleEnabled: rationale.settings && toggle(rationale.label),
                 },
               }}
             />
           }
         >
           <div>
-            {teacherInstructions.enabled && (
+            {teacherInstructionsEnabled && (
               <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
                 <EditableHtml
                   className={classes.prompt}
@@ -365,7 +365,7 @@ export class Main extends React.Component {
               </InputContainer>
             )}
 
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer
                 label={rationale.label}
                 className={classes.promptHolder}

--- a/packages/inline-dropdown/controller/src/index.js
+++ b/packages/inline-dropdown/controller/src/index.js
@@ -97,8 +97,11 @@ export function model(question, session, env, updateSession) {
       // env.role === 'instructor' &&
       (env.mode === 'view' || env.mode === 'evaluate')
     ) {
-      rationale = question.rationale;
-      teacherInstructions = question.teacherInstructions;
+      rationale = question.rationaleEnabled ? question.rationale : null;
+      teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
+    } else {
+      rationale = null;
+      teacherInstructions = null;
     }
 
     const out = {

--- a/packages/inline-dropdown/docs/pie-schema.json
+++ b/packages/inline-dropdown/docs/pie-schema.json
@@ -97,6 +97,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -117,7 +132,10 @@
     "markup",
     "partialScoring",
     "rationale",
-    "scoringType"
+    "rationaleEnabled",
+    "scoringType",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/inline-dropdown/docs/pie-schema.json.md
+++ b/packages/inline-dropdown/docs/pie-schema.json.md
@@ -51,6 +51,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/match/configure/src/configure.jsx
+++ b/packages/match/configure/src/configure.jsx
@@ -194,6 +194,7 @@ class Configure extends React.Component {
       prompt = {},
       feedback = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     log('[render] model', model);
 
@@ -218,12 +219,11 @@ class Configure extends React.Component {
                 toggle(feedback.label, true),
               },
               'Properties': {
-                'teacherInstructions.enabled': teacherInstructions.settings &&
-                toggle(teacherInstructions.label, true),
-                'studentInstructions.enabled': studentInstructions.settings &&
-                toggle(studentInstructions.label, true),
-                'rationale.enabled': rationale.settings &&
-                toggle(rationale.label, true),
+                teacherInstructionsEnabled: teacherInstructions.settings &&
+                toggle(teacherInstructions.label),
+                studentInstructionsEnabled: studentInstructions.settings &&
+                toggle(studentInstructions.label),
+                rationaleEnabled: rationale.settings && toggle(rationale.label),
                 scoringType: scoringType.settings &&
                 radio(scoringType.label, ['auto', 'rubric']),
               },
@@ -233,7 +233,7 @@ class Configure extends React.Component {
       >
         <div className={classes.content}>
 
-          {teacherInstructions.enabled && (
+          {teacherInstructionsEnabled && (
             <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
               <EditableHtml
                 className={classes.prompt}
@@ -261,7 +261,7 @@ class Configure extends React.Component {
             </InputContainer>
           )}
 
-          {rationale.enabled && (
+          {rationaleEnabled && (
             <InputContainer label={rationale.label}
                             className={classes.promptHolder}>
               <EditableHtml

--- a/packages/match/configure/src/defaults.js
+++ b/packages/match/configure/src/defaults.js
@@ -19,6 +19,9 @@ export default {
       },
     ],
     scoringType: 'auto',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   prompt: 'Prompt goes here',
   configuration: {
@@ -57,7 +60,6 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
     },
     scoringType: {
       settings: false,
@@ -66,12 +68,10 @@ export default {
     studentInstructions: {
       settings: false,
       label: 'Student Instructions',
-      enabled: true,
     },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: true,
     },
   }
 };

--- a/packages/match/controller/src/index.js
+++ b/packages/match/controller/src/index.js
@@ -187,8 +187,8 @@ export function model(question, session, env, updateSession) {
       };
 
       if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-        base.teacherInstructions = question.teacherInstructions;
-        base.rationale = question.rationale;
+        base.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
+        base.rationale = question.rationaleEnabled ? question.rationale : null;
       } else {
         base.rationale = null;
         base.teacherInstructions = null;

--- a/packages/match/docs/pie-schema.json
+++ b/packages/match/docs/pie-schema.json
@@ -273,6 +273,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -291,7 +306,10 @@
     "layout",
     "prompt",
     "rationale",
-    "rows"
+    "rationaleEnabled",
+    "rows",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/match/docs/pie-schema.json.md
+++ b/packages/match/docs/pie-schema.json.md
@@ -99,6 +99,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/math-inline/configure/src/__tests__/__snapshots__/configure.test.js.snap
+++ b/packages/math-inline/configure/src/__tests__/__snapshots__/configure.test.js.snap
@@ -22,7 +22,6 @@ exports[`Configure renders correctly with snapshot 1`] = `
               "settings": true,
             },
             "rationale": Object {
-              "enabled": false,
               "label": "Rationale",
               "settings": true,
             },
@@ -35,12 +34,10 @@ exports[`Configure renders correctly with snapshot 1`] = `
               "settings": false,
             },
             "studentInstructions": Object {
-              "enabled": true,
               "label": "Student Instructions",
               "settings": false,
             },
             "teacherInstructions": Object {
-              "enabled": true,
               "label": "Teacher Instructions",
               "settings": true,
             },
@@ -49,10 +46,10 @@ exports[`Configure renders correctly with snapshot 1`] = `
         groups={
           Object {
             "Properties": Object {
-              "rationale.enabled": undefined,
+              "rationaleEnabled": undefined,
               "scoringType": false,
-              "studentInstructions.enabled": false,
-              "teacherInstructions.enabled": undefined,
+              "studentInstructionsEnabled": false,
+              "teacherInstructionsEnabled": undefined,
             },
             "Settings": Object {
               "feedback.enabled": undefined,
@@ -125,17 +122,6 @@ exports[`Configure renders correctly with snapshot 1`] = `
       <div
         className="Configure-content-2"
       >
-        <InputContainer
-          className="Configure-promptHolder-3"
-          label="Teacher Instructions"
-        >
-          <EditableHtml
-            className="Configure-prompt-4"
-            markup=""
-            nonEmpty={false}
-            onChange={[Function]}
-          />
-        </InputContainer>
         <WithStyles(GeneralConfigBlock)
           configuration={
             Object {
@@ -154,7 +140,6 @@ exports[`Configure renders correctly with snapshot 1`] = `
                 "settings": true,
               },
               "rationale": Object {
-                "enabled": false,
                 "label": "Rationale",
                 "settings": true,
               },
@@ -167,12 +152,10 @@ exports[`Configure renders correctly with snapshot 1`] = `
                 "settings": false,
               },
               "studentInstructions": Object {
-                "enabled": true,
                 "label": "Student Instructions",
                 "settings": false,
               },
               "teacherInstructions": Object {
-                "enabled": true,
                 "label": "Teacher Instructions",
                 "settings": true,
               },

--- a/packages/math-inline/configure/src/configure.jsx
+++ b/packages/math-inline/configure/src/configure.jsx
@@ -75,7 +75,7 @@ export class Configure extends React.Component {
       scoringType = {}
     } = configuration || {};
     log('[render] model', model);
-
+    const { rationaleEnabled, teacherInstructionsEnabled } = model || {};
 
     return (
       <div>
@@ -96,12 +96,11 @@ export class Configure extends React.Component {
                     toggle(prompt.label, true)
                 },
                 'Properties': {
-                  'teacherInstructions.enabled': teacherInstructions.settings &&
-                    toggle(teacherInstructions.label, true),
-                  'studentInstructions.enabled': studentInstructions.settings &&
-                    toggle(studentInstructions.label, true),
-                  'rationale.enabled': rationale.settings &&
-                    toggle(rationale.label, true),
+                  teacherInstructionsEnabled: teacherInstructions.settings &&
+                    toggle(teacherInstructions.label),
+                  studentInstructionsEnabled: studentInstructions.settings &&
+                    toggle(studentInstructions.label),
+                  rationaleEnabled: rationale.settings && toggle(rationale.label),
                   scoringType: scoringType.settings &&
                     radio(scoringType.label, ['auto', 'rubric']),
                 },
@@ -111,7 +110,7 @@ export class Configure extends React.Component {
         >
           <div>
             <div className={classes.content}>
-              {teacherInstructions.enabled && (
+              {teacherInstructionsEnabled && (
                 <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
                   <EditableHtml
                     className={classes.prompt}
@@ -128,6 +127,7 @@ export class Configure extends React.Component {
                 model={model}
                 configuration={configuration}
                 onChange={this.onChange}
+                rationaleEnabled={rationaleEnabled}
               />
               {
                 feedback.enabled && (

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -31,6 +31,9 @@ export default {
     responses: [],
     customKeys: [],
     scoringType: 'auto',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     prompt: {
@@ -50,7 +53,6 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
     },
     scoringType: {
       settings: false,
@@ -59,12 +61,10 @@ export default {
     studentInstructions: {
       settings: false,
       label: 'Student Instructions',
-      enabled: true,
     },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: true,
     },
     partialScoring: {
       settings: true,

--- a/packages/math-inline/configure/src/general-config-block.jsx
+++ b/packages/math-inline/configure/src/general-config-block.jsx
@@ -136,7 +136,8 @@ class GeneralConfigBlock extends React.Component {
     model: PropTypes.object.isRequired,
     imageSupport: PropTypes.object,
     configuration: PropTypes.object,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    rationaleEnabled: PropTypes.boolean
   };
 
   constructor(props) {
@@ -318,7 +319,7 @@ class GeneralConfigBlock extends React.Component {
   };
 
   render() {
-    const { classes, model, imageSupport, configuration } = this.props;
+    const { classes, model, imageSupport, configuration, rationaleEnabled } = this.props;
     const { showKeypad } = this.state;
     const {
       prompt,
@@ -354,7 +355,7 @@ class GeneralConfigBlock extends React.Component {
             />
           </InputContainer>
         )}
-        {cRationale.enabled && (
+        {rationaleEnabled && (
           <InputContainer
             label={cRationale.label}
             className={classes.promptHolder}

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -206,8 +206,8 @@ export function model(question, session, env) {
         env.role === 'instructor' &&
         (env.mode === 'view' || env.mode === 'evaluate')
       ) {
-        out.rationale = question.rationale;
-        out.teacherInstructions = question.teacherInstructions;
+        out.rationale = question.rationaleEnabled ? question.rationale : null;
+        out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
       } else {
         out.rationale = null;
         out.teacherInstructions = null;

--- a/packages/math-inline/docs/pie-schema.json
+++ b/packages/math-inline/docs/pie-schema.json
@@ -391,6 +391,21 @@
       },
       "title": "customKeys"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -406,7 +421,10 @@
     "element",
     "expression",
     "id",
-    "responses"
+    "rationaleEnabled",
+    "responses",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/math-inline/docs/pie-schema.json.md
+++ b/packages/math-inline/docs/pie-schema.json.md
@@ -167,6 +167,18 @@ Extra buttons defined by user
 
 The object is an array with all elements of the type `string`.
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/multiple-choice/configure/src/defaults.js
+++ b/packages/multiple-choice/configure/src/defaults.js
@@ -11,6 +11,9 @@ export default {
     lockChoiceOrder: true,
     partialScoring: true,
     scoringType: 'auto',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     answerChoiceCount: 0,
@@ -49,7 +52,6 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
     },
     scoringType: {
       settings: false,
@@ -58,12 +60,10 @@ export default {
     studentInstructions: {
       settings: false,
       label: 'Student Instructions',
-      enabled: true,
     },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: true,
     }
   }
 };

--- a/packages/multiple-choice/configure/src/main.jsx
+++ b/packages/multiple-choice/configure/src/main.jsx
@@ -81,10 +81,11 @@ const Design = withStyles(styles)(props => {
     sequentialChoiceLabels = {},
     settingsPanelDisabled
   } = configuration || {};
+  const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
   const Content = (
     <div>
-      {teacherInstructions.enabled && (
+      {teacherInstructionsEnabled && (
         <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
           <EditableHtml
             className={classes.prompt}
@@ -131,7 +132,7 @@ const Design = withStyles(styles)(props => {
             allowDelete={deleteChoice.settings}
             noLabels
           />
-          {rationale.enabled && (
+          {rationaleEnabled && (
             <InputContainer
               key={`rationale-${index}`}
               label={rationale.label}
@@ -194,12 +195,11 @@ const Design = withStyles(styles)(props => {
                         toggle(feedback.label, true)
                     },
                     'Properties': {
-                      'teacherInstructions.enabled': teacherInstructions.settings &&
-                        toggle(teacherInstructions.label, true),
-                      'studentInstructions.enabled': studentInstructions.settings &&
-                        toggle(studentInstructions.label, true),
-                      'rationale.enabled': rationale.settings &&
-                        toggle(rationale.label, true),
+                      teacherInstructionsEnabled: teacherInstructions.settings &&
+                        toggle(teacherInstructions.label),
+                      studentInstructionsEnabled: studentInstructions.settings &&
+                        toggle(studentInstructions.label),
+                      rationaleEnabled: rationale.settings && toggle(rationale.label),
                       scoringType: scoringType.settings &&
                         radio(scoringType.label, ['auto', 'rubric']),
                     },

--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -14,7 +14,7 @@ const prepareChoice = (model, env, defaultFeedback) => choice => {
     env.role === 'instructor' &&
     (env.mode === 'view' || env.mode === 'evaluate')
   ) {
-    out.rationale = choice.rationale;
+    out.rationale = model.rationaleEnabled ? choice.rationale : null;
   } else {
     out.rationale = null;
   }
@@ -82,7 +82,7 @@ export async function model(question, session, env, updateSession) {
   };
 
   if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-    out.teacherInstructions = question.teacherInstructions;
+    out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
   } else {
     out.teacherInstructions = null;
   }

--- a/packages/multiple-choice/docs/pie-schema.json
+++ b/packages/multiple-choice/docs/pie-schema.json
@@ -120,6 +120,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -134,7 +149,10 @@
   "required": [
     "choices",
     "element",
-    "id"
+    "id",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/multiple-choice/docs/pie-schema.json.md
+++ b/packages/multiple-choice/docs/pie-schema.json.md
@@ -102,6 +102,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/pie-models/src/pie/categorize/index.ts
+++ b/packages/pie-models/src/pie/categorize/index.ts
@@ -105,6 +105,15 @@ export interface CategorizePie extends PieModel {
 
   /** Indicates if partial scoring is enabled */
   partialScoring?: boolean;
+
+  /** Indicates if Rationale are enabled */
+  rationaleEnabled: boolean;
+
+  /** Indicates if Student Instructions are enabled */
+  studentInstructionsEnabled: boolean;
+
+  /** Indicates if Teacher Instructions are enabled */
+  teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/charting/index.ts
+++ b/packages/pie-models/src/pie/charting/index.ts
@@ -73,12 +73,12 @@ interface Answer {
  */
 export interface ChartingPie extends PieModel {
     /** Indicates if user can add more categories */
-    addCategoryEnabled: Boolean;
+    addCategoryEnabled: boolean;
 
     /** Indicates default value for a new category's label */
-    categoryDefaultLabel: String;
+    categoryDefaultLabel: string;
 
-    chartType: 'bar' | 'histogram' | 'lineCross' | 'lineDot' | 'dorPlot' | 'linePlot'
+    chartType: 'bar' | 'histogram' | 'lineCross' | 'lineDot' | 'dorPlot' | 'linePlot';
 
     /** Indicates marks that are set as answers; Note: alternates can be added having this form: alternateIndex */
     correctAnswer: Answer;
@@ -90,7 +90,7 @@ export interface ChartingPie extends PieModel {
     domain: ChartSettings;
 
     /** Indicates if user can edit default categories */
-    editCategoryEnabled: Boolean;
+    editCategoryEnabled: boolean;
 
     /** Indicates the chart line model */
     graph: Chart;
@@ -115,6 +115,15 @@ export interface ChartingPie extends PieModel {
 
     /** Indicates chart title */
     title?: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/drag-in-the-blank/index.ts
+++ b/packages/pie-models/src/pie/drag-in-the-blank/index.ts
@@ -71,6 +71,15 @@ export interface DragInTheBlankPie extends PieModel {
 
     /** Indicates value for rubric */
     rubric: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/drawing-response/index.ts
+++ b/packages/pie-models/src/pie/drawing-response/index.ts
@@ -28,6 +28,15 @@ export interface DrawingResponsePie extends PieModel {
 
     /** Indicates teacher instructions */
     teacherInstructions?: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/explicit-constructed-response/index.ts
+++ b/packages/pie-models/src/pie/explicit-constructed-response/index.ts
@@ -51,6 +51,15 @@ export interface ExplicitConstructedResponsePie extends PieModel {
 
     /** Indicates value for rubric */
     rubric: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/extended-text-entry/index.ts
+++ b/packages/pie-models/src/pie/extended-text-entry/index.ts
@@ -58,6 +58,15 @@ export interface ExtendedTextEntryPie extends PieModel {
 
   /** Indicates teacher instructions */
   teacherInstructions?: string;
+
+  /** Indicates if Rationale are enabled */
+  rationaleEnabled: boolean;
+
+  /** Indicates if Student Instructions are enabled */
+  studentInstructionsEnabled: boolean;
+
+  /** Indicates if Teacher Instructions are enabled */
+  teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/graph-lines/index.ts
+++ b/packages/pie-models/src/pie/graph-lines/index.ts
@@ -140,6 +140,15 @@ export interface GraphLinesPie extends PieModel {
 
     /** Indicates teacher instructions */
     teacherInstructions?: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/graphing/index.ts
+++ b/packages/pie-models/src/pie/graphing/index.ts
@@ -177,6 +177,15 @@ export interface GraphingPie extends PieModel {
 
     /** Indicates the tools that have to be displayed in toolbar */
     toolbarTools?: [Tool]
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/hotspot/index.ts
+++ b/packages/pie-models/src/pie/hotspot/index.ts
@@ -41,6 +41,15 @@ export interface HotspotPie extends PieModel {
 
   /** Indicates the value for rationale */
   rationale?: string;
+
+  /** Indicates if Rationale are enabled */
+  rationaleEnabled: boolean;
+
+  /** Indicates if Student Instructions are enabled */
+  studentInstructionsEnabled: boolean;
+
+  /** Indicates if Teacher Instructions are enabled */
+  teacherInstructionsEnabled: boolean;
 }
 
 

--- a/packages/pie-models/src/pie/inline-dropdown/index.ts
+++ b/packages/pie-models/src/pie/inline-dropdown/index.ts
@@ -64,6 +64,15 @@ export interface InlineDropdownPie extends PieModel {
 
     /** Indicates teacher instructions */
     teacherInstructions?: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/match/index.ts
+++ b/packages/pie-models/src/pie/match/index.ts
@@ -66,6 +66,15 @@ export interface MatchPie extends PieModel {
 
   /** Indicates teacher instructions */
   teacherInstructions?: string;
+
+  /** Indicates if Rationale are enabled */
+  rationaleEnabled: boolean;
+
+  /** Indicates if Student Instructions are enabled */
+  studentInstructionsEnabled: boolean;
+
+  /** Indicates if Teacher Instructions are enabled */
+  teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/math-inline/index.ts
+++ b/packages/pie-models/src/pie/math-inline/index.ts
@@ -104,6 +104,15 @@ export interface MathInlinePie extends PieModel {
 
     /** Extra buttons defined by user */
     customKeys?: string[];
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 

--- a/packages/pie-models/src/pie/multiple-choice/index.ts
+++ b/packages/pie-models/src/pie/multiple-choice/index.ts
@@ -41,6 +41,15 @@ export interface MultipleChoicePie extends PieModel {
 
   /** Indicates teacher instructions */
   teacherInstructions?: string;
+
+  /** Indicates if Rationale are enabled */
+  rationaleEnabled: boolean;
+
+  /** Indicates if Student Instructions are enabled */
+  studentInstructionsEnabled: boolean;
+
+  /** Indicates if Teacher Instructions are enabled */
+  teacherInstructionsEnabled: boolean;
 }
 
 

--- a/packages/pie-models/src/pie/placement-ordering/index.ts
+++ b/packages/pie-models/src/pie/placement-ordering/index.ts
@@ -97,6 +97,15 @@ export interface PlacementOrderingPie extends PieModel {
 
     /** Indicates teacher instructions */
     teacherInstructions?: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/pie-models/src/pie/select-text/index.ts
+++ b/packages/pie-models/src/pie/select-text/index.ts
@@ -64,6 +64,15 @@ export interface SelectTextPie extends PieModel {
 
   /** Indicates teacher instructions */
   teacherInstructions?: string;
+
+  /** Indicates if Rationale are enabled */
+  rationaleEnabled: boolean;
+
+  /** Indicates if Student Instructions are enabled */
+  studentInstructionsEnabled: boolean;
+
+  /** Indicates if Teacher Instructions are enabled */
+  teacherInstructionsEnabled: boolean;
 }
 
 

--- a/packages/pie-models/src/pie/text-entry/index.ts
+++ b/packages/pie-models/src/pie/text-entry/index.ts
@@ -52,6 +52,15 @@ export interface TextEntryPie extends PieModel {
 
     /** Indicates answer alignment */
     answerAlignment: 'left' | 'center' | 'right';
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /**

--- a/packages/placement-ordering/configure/src/__tests__/__snapshots__/design.test.jsx.snap
+++ b/packages/placement-ordering/configure/src/__tests__/__snapshots__/design.test.jsx.snap
@@ -49,7 +49,6 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
             "settings": true,
           },
           "rationale": Object {
-            "enabled": false,
             "label": "Rationale",
             "settings": true,
           },
@@ -62,7 +61,6 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
             "settings": false,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
@@ -71,7 +69,6 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
             "settings": true,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -80,10 +77,10 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
       groups={
         Object {
           "Properties": Object {
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": false,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
           "Settings": Object {
             "choiceLabel.enabled": undefined,
@@ -114,9 +111,12 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
           "partialScoring": true,
           "placementArea": false,
           "prompt": "Item Stem goes here",
+          "rationaleEnabled": false,
           "removeTilesAfterPlacing": true,
           "scoringType": "auto",
+          "studentInstructionsEnabled": false,
           "targetLabel": "Target Label goes here",
+          "teacherInstructionsEnabled": false,
         }
       }
       onChangeConfiguration={[Function]}
@@ -221,7 +221,6 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
             "settings": false,
           },
           "rationale": Object {
-            "enabled": false,
             "label": "Rationale",
             "settings": true,
           },
@@ -234,7 +233,6 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
             "settings": false,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
@@ -243,7 +241,6 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
             "settings": true,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -252,10 +249,10 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
       groups={
         Object {
           "Properties": Object {
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": false,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
           "Settings": Object {
             "choiceLabel.enabled": undefined,
@@ -286,9 +283,12 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
           "partialScoring": true,
           "placementArea": false,
           "prompt": "Item Stem goes here",
+          "rationaleEnabled": false,
           "removeTilesAfterPlacing": true,
           "scoringType": "auto",
+          "studentInstructionsEnabled": false,
           "targetLabel": "Target Label goes here",
+          "teacherInstructionsEnabled": false,
         }
       }
       onChangeConfiguration={[Function]}

--- a/packages/placement-ordering/configure/src/defaults.js
+++ b/packages/placement-ordering/configure/src/defaults.js
@@ -22,6 +22,9 @@ export default {
     removeTilesAfterPlacing: true,
     scoringType: 'auto',
     targetLabel: 'Target Label goes here',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     choiceLabel: {
@@ -69,7 +72,6 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
     },
     removeTilesAfterPlacing: {
       settings: false,
@@ -82,7 +84,6 @@ export default {
     studentInstructions: {
       settings: false,
       label: 'Student Instructions',
-      enabled: true,
     },
     targetLabel: {
       settings: true,
@@ -91,7 +92,6 @@ export default {
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: false,
     },
   }
 };

--- a/packages/placement-ordering/configure/src/design.jsx
+++ b/packages/placement-ordering/configure/src/design.jsx
@@ -89,6 +89,7 @@ export class Design extends React.Component {
       rationale = {},
       scoringType = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     return (
       <layout.ConfigLayout
@@ -120,12 +121,12 @@ export class Design extends React.Component {
                 toggle(feedback.label, true)
               },
               'Properties': {
-                'teacherInstructions.enabled': teacherInstructions.settings &&
-                  toggle(teacherInstructions.label, true),
-                'studentInstructions.enabled': studentInstructions.settings &&
-                  toggle(studentInstructions.label, true),
-                'rationale.enabled': rationale.settings &&
-                  toggle(rationale.label, true),
+                teacherInstructionsEnabled: teacherInstructions.settings &&
+                  toggle(teacherInstructions.label),
+                studentInstructionsEnabled: studentInstructions.settings &&
+                  toggle(studentInstructions.label),
+                rationaleEnabled: rationale.settings &&
+                  toggle(rationale.label),
                 scoringType: scoringType.settings &&
                   radio(scoringType.label, ['auto', 'rubric']),
               },
@@ -133,7 +134,7 @@ export class Design extends React.Component {
           />
         }
       >
-        {teacherInstructions.enabled && (
+        {teacherInstructionsEnabled && (
           <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
             <EditableHtml
               className={classes.prompt}
@@ -157,7 +158,7 @@ export class Design extends React.Component {
                 imageSupport={imageSupport}
               />
             </InputContainer>
-            {rationale.enabled && (
+            {rationaleEnabled && (
               <InputContainer label={rationale.label}
                               className={classes.promptHolder}>
                 <EditableHtml

--- a/packages/placement-ordering/controller/src/index.js
+++ b/packages/placement-ordering/controller/src/index.js
@@ -88,8 +88,8 @@ export function model(question, session, env, updateSession) {
     base.disabled = env.mode !== 'gather';
 
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-      base.rationale = question.rationale;
-      base.teacherInstructions = question.teacherInstructions;
+      base.rationale = question.rationaleEnabled ? question.rationale : null;
+      base.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
     } else {
       base.rationale = null;
       base.teacherInstructions = null;

--- a/packages/placement-ordering/docs/pie-schema.json
+++ b/packages/placement-ordering/docs/pie-schema.json
@@ -315,6 +315,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -330,7 +345,10 @@
     "alternateResponses",
     "choices",
     "element",
-    "id"
+    "id",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ConfigureProp": {

--- a/packages/placement-ordering/docs/pie-schema.json.md
+++ b/packages/placement-ordering/docs/pie-schema.json.md
@@ -139,6 +139,18 @@ The label for answer area if placement area is enabled
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/select-text/configure/src/__tests__/__snapshots__/design.test.jsx.snap
+++ b/packages/select-text/configure/src/__tests__/__snapshots__/design.test.jsx.snap
@@ -31,7 +31,6 @@ exports[`design snapshot renders all items except feedback 1`] = `
             "label": "Prompt",
           },
           "rationale": Object {
-            "enabled": false,
             "label": "Rationale",
             "settings": true,
           },
@@ -48,12 +47,10 @@ exports[`design snapshot renders all items except feedback 1`] = `
             "settings": true,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -70,10 +67,10 @@ exports[`design snapshot renders all items except feedback 1`] = `
       groups={
         Object {
           "Properties": Object {
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": false,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
           "Settings": Object {
             "feedback.enabled": false,
@@ -168,7 +165,6 @@ exports[`design snapshot renders all items except the content input 1`] = `
             "label": "Prompt",
           },
           "rationale": Object {
-            "enabled": false,
             "label": "Rationale",
             "settings": true,
           },
@@ -185,12 +181,10 @@ exports[`design snapshot renders all items except the content input 1`] = `
             "settings": true,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -207,10 +201,10 @@ exports[`design snapshot renders all items except the content input 1`] = `
       groups={
         Object {
           "Properties": Object {
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": false,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
           "Settings": Object {
             "feedback.enabled": false,
@@ -297,7 +291,6 @@ exports[`design snapshot renders all items with defaultProps 1`] = `
             "label": "Prompt",
           },
           "rationale": Object {
-            "enabled": false,
             "label": "Rationale",
             "settings": true,
           },
@@ -314,12 +307,10 @@ exports[`design snapshot renders all items with defaultProps 1`] = `
             "settings": true,
           },
           "studentInstructions": Object {
-            "enabled": true,
             "label": "Student Instructions",
             "settings": false,
           },
           "teacherInstructions": Object {
-            "enabled": false,
             "label": "Teacher Instructions",
             "settings": true,
           },
@@ -336,10 +327,10 @@ exports[`design snapshot renders all items with defaultProps 1`] = `
       groups={
         Object {
           "Properties": Object {
-            "rationale.enabled": undefined,
+            "rationaleEnabled": undefined,
             "scoringType": false,
-            "studentInstructions.enabled": false,
-            "teacherInstructions.enabled": undefined,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
           },
           "Settings": Object {
             "feedback.enabled": undefined,

--- a/packages/select-text/configure/src/defaultConfiguration.js
+++ b/packages/select-text/configure/src/defaultConfiguration.js
@@ -16,6 +16,9 @@ export default {
     text: '',
     tokens: tokens(),
     scoringType: 'auto',
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: false,
+    studentInstructionsEnabled: false
   },
   configuration: {
     selectionCount: {
@@ -37,7 +40,6 @@ export default {
     rationale: {
       settings: true,
       label: 'Rationale',
-      enabled: false,
     },
     scoringType: {
       settings: false,
@@ -46,12 +48,10 @@ export default {
     studentInstructions: {
       settings: false,
       label: 'Student Instructions',
-      enabled: true,
     },
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: false,
     },
     prompt: {
       label: 'Prompt'

--- a/packages/select-text/configure/src/design.jsx
+++ b/packages/select-text/configure/src/design.jsx
@@ -150,6 +150,7 @@ export class Design extends React.Component {
       scoringType = {},
       highlightChoices = {}
     } = configuration || {};
+    const { teacherInstructionsEnabled, rationaleEnabled } = model || {};
 
     log('[render] maxSelections:', model.maxSelections);
 
@@ -172,12 +173,11 @@ export class Design extends React.Component {
                 toggle(feedback.label, true),
               },
               'Properties': {
-                'teacherInstructions.enabled': teacherInstructions.settings &&
-                toggle(teacherInstructions.label, true),
-                'studentInstructions.enabled': studentInstructions.settings &&
-                toggle(studentInstructions.label, true),
-                'rationale.enabled': rationale.settings &&
-                toggle(rationale.label, true),
+                teacherInstructionsEnabled: teacherInstructions.settings &&
+                toggle(teacherInstructions.label),
+                studentInstructionsEnabled: studentInstructions.settings &&
+                toggle(studentInstructions.label),
+                rationaleEnabled: rationale.settings && toggle(rationale.label),
                 scoringType: scoringType.settings &&
                 radio(scoringType.label, ['auto', 'rubric']),
               },
@@ -186,7 +186,7 @@ export class Design extends React.Component {
         }
       >
         <div className={classes.container}>
-          {teacherInstructions.enabled && (
+          {teacherInstructionsEnabled && (
             <InputContainer label={teacherInstructions.label} className={classes.promptHolder}>
               <EditableHtml
                 className={classes.prompt}
@@ -207,7 +207,7 @@ export class Design extends React.Component {
             />
           </InputContainer>
 
-          {rationale.enabled && (
+          {rationaleEnabled && (
             <InputContainer label={rationale.label || ''} className={classes.promptHolder}>
               <EditableHtml
                 className={classes.prompt}

--- a/packages/select-text/controller/src/index.js
+++ b/packages/select-text/controller/src/index.js
@@ -130,8 +130,8 @@ export const model = (question, session, env) => {
         env.role === 'instructor' &&
         (env.mode === 'view' || env.mode === 'evaluate')
       ) {
-        out.rationale = question.rationale;
-        out.teacherInstructions = question.teacherInstructions;
+        out.rationale = question.rationaleEnabled ? question.rationale : null;
+        out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
       } else {
         out.rationale = null;
         out.teacherInstructions = null;

--- a/packages/select-text/docs/pie-schema.json
+++ b/packages/select-text/docs/pie-schema.json
@@ -264,6 +264,21 @@
       "type": "string",
       "title": "teacherInstructions"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -279,6 +294,9 @@
     "element",
     "id",
     "prompt",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled",
     "text",
     "tokens"
   ],

--- a/packages/select-text/docs/pie-schema.json.md
+++ b/packages/select-text/docs/pie-schema.json.md
@@ -97,6 +97,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/text-entry/configure/src/configure.jsx
+++ b/packages/text-entry/configure/src/configure.jsx
@@ -78,6 +78,7 @@ class Configure extends React.Component {
   render() {
     const { classes, model, configuration, imageSupport } = this.props;
     const { teacherInstructions = {} } = configuration || {};
+    const { teacherInstructionsEnabled } = model || {};
 
     // const feedbackConfig = modelToFeedbackConfig(model);
 
@@ -90,7 +91,7 @@ class Configure extends React.Component {
           compute), and the answer will be evaluated.
         </Typography>
 
-        {teacherInstructions.enabled && (
+        {teacherInstructionsEnabled && (
           <InputContainer label={teacherInstructions.label} className={classes.inputHolder}>
             <EditableHtml
               className={classes.input}

--- a/packages/text-entry/configure/src/defaults.js
+++ b/packages/text-entry/configure/src/defaults.js
@@ -15,13 +15,15 @@ export default {
     answerAlignment: 'left',
     prompt: 'Question Prompt goes here',
     allowDecimal: false,
-    allowThousandsSeparator: false
+    allowThousandsSeparator: false,
+    rationaleEnabled: false,
+    teacherInstructionsEnabled: true,
+    studentInstructionsEnabled: false
   },
   configuration: {
     teacherInstructions: {
       settings: true,
       label: 'Teacher Instructions',
-      enabled: true
     },
   }
 };

--- a/packages/text-entry/controller/src/index.js
+++ b/packages/text-entry/controller/src/index.js
@@ -61,7 +61,7 @@ export function model(question, session, env) {
       };
 
       if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-        out.teacherInstructions = question.teacherInstructions;
+        out.teacherInstructions = question.teacherInstructionsEnabled ? question.teacherInstructions : null;
       } else {
         out.teacherInstructions = null;
       }

--- a/packages/text-entry/docs/pie-schema.json
+++ b/packages/text-entry/docs/pie-schema.json
@@ -279,6 +279,21 @@
       "type": "string",
       "title": "answerAlignment"
     },
+    "rationaleEnabled": {
+      "description": "Indicates if Rationale are enabled",
+      "type": "boolean",
+      "title": "rationaleEnabled"
+    },
+    "studentInstructionsEnabled": {
+      "description": "Indicates if Student Instructions are enabled",
+      "type": "boolean",
+      "title": "studentInstructionsEnabled"
+    },
+    "teacherInstructionsEnabled": {
+      "description": "Indicates if Teacher Instructions are enabled",
+      "type": "boolean",
+      "title": "teacherInstructionsEnabled"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",
@@ -299,7 +314,10 @@
     "feedback",
     "id",
     "partialResponses",
-    "prompt"
+    "prompt",
+    "rationaleEnabled",
+    "studentInstructionsEnabled",
+    "teacherInstructionsEnabled"
   ],
   "definitions": {
     "ComplexFeedbackType": {

--- a/packages/text-entry/docs/pie-schema.json.md
+++ b/packages/text-entry/docs/pie-schema.json.md
@@ -99,6 +99,18 @@ This element must be one of the following enum values:
 * `left`
 * `right`
 
+# `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+# `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+# `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.


### PR DESCRIPTION
Moved rationale enabled flag from config.settings.rationale.enabled to model.rationaleEnabled.
Moved teacherInstructions enabled flag from config.settings.teacherInstructions.enabled to model.teacherInstructionsEnabled.
Moved studentInstructions enabled flag from config.settings.studentInstructions.enabled to model.studentInstructionsEnabled.

Updated tests and documentation.