### PR TITLE
Moved rationale, teacherInstructions and studentInstructions enabled …

### DIFF
--- a/packages/ebsr/configure/package.json
+++ b/packages/ebsr/configure/package.json
@@ -7,7 +7,7 @@
   "author": "",
   "dependencies": {
     "@material-ui/core": "^3.9.2",
-    "@pie-element/multiple-choice": "^3.9.0",
+    "@pie-element/multiple-choice": "^4.0.0",
     "@pie-framework/pie-configure-events": "^1.2.0",
     "@pie-lib/config-ui": "^10.7.32",
     "lodash": "^4.17.15",

--- a/packages/ebsr/configure/src/defaults.js
+++ b/packages/ebsr/configure/src/defaults.js
@@ -35,8 +35,7 @@ const defaultConfig = {
   },
   rationale: {
     settings: true,
-    label: 'Rationale',
-    enabled: true,
+    label: 'Rationale'
   },
   scoringType: {
     settings: false,
@@ -49,13 +48,11 @@ const defaultConfig = {
   },
   studentInstructions: {
     settings: false,
-    label: 'Student Instructions',
-    enabled: true,
+    label: 'Student Instructions'
   },
   teacherInstructions: {
     settings: true,
-    label: 'Teacher Instructions',
-    enabled: true,
+    label: 'Teacher Instructions'
   }
 };
 
@@ -69,6 +66,9 @@ export default {
       choicePrefix: 'numbers',
       partialScoring: false,
       prompt: 'Prompt A',
+      rationaleEnabled: false,
+      teacherInstructionsEnabled: false,
+      studentInstructionsEnabled: false
     },
     partB: {
       choiceMode: 'radio',
@@ -76,6 +76,9 @@ export default {
       choicePrefix: 'numbers',
       partialScoring: false,
       prompt: 'Prompt B',
+      rationaleEnabled: false,
+      teacherInstructionsEnabled: false,
+      studentInstructionsEnabled: false
     },
   },
   configuration: {

--- a/packages/ebsr/configure/src/main.jsx
+++ b/packages/ebsr/configure/src/main.jsx
@@ -107,12 +107,11 @@ export class Main extends React.Component {
                     toggle(sequentialChoiceLabelsA.label, true),
                   'partA.feedback.enabled': feedbackA.settings &&
                     toggle(feedbackA.label, true),
-                  'partA.teacherInstructions.enabled': teacherInstructionsA.settings &&
-                    toggle(teacherInstructionsA.label, true),
-                  'partA.studentInstructions.enabled': studentInstructionsA.settings &&
-                    toggle(studentInstructionsA.label, true),
-                  'partA.rationale.enabled': rationaleA.settings &&
-                    toggle(rationaleA.label, true)
+                  'partA.teacherInstructionsEnabled': teacherInstructionsA.settings &&
+                    toggle(teacherInstructionsA.label),
+                  'partA.studentInstructionsEnabled': studentInstructionsA.settings &&
+                    toggle(studentInstructionsA.label),
+                  'partA.rationaleEnabled': rationaleA.settings && toggle(rationaleA.label)
                 },
                 [`Settings ${secondPart}`]: {
                   'partB.choiceMode':
@@ -132,12 +131,11 @@ export class Main extends React.Component {
                     toggle(sequentialChoiceLabelsB.label, true),
                   'partB.feedback.enabled': feedbackB.settings &&
                     toggle(feedbackB.label, true),
-                  'partB.teacherInstructions.enabled': teacherInstructionsB.settings &&
-                    toggle(teacherInstructionsB.label, true),
-                  'partB.studentInstructions.enabled': studentInstructionsB.settings &&
-                    toggle(studentInstructionsB.label, true),
-                  'partB.rationale.enabled': rationaleB.settings &&
-                    toggle(rationaleB.label, true)
+                  'partB.teacherInstructionsEnabled': teacherInstructionsB.settings &&
+                    toggle(teacherInstructionsB.label),
+                  'partB.studentInstructionsEnabled': studentInstructionsB.settings &&
+                    toggle(studentInstructionsB.label),
+                  'partB.rationaleEnabled': rationaleB.settings && toggle(rationaleB.label)
                 }
               }}
             />

--- a/packages/ebsr/controller/src/index.js
+++ b/packages/ebsr/controller/src/index.js
@@ -17,7 +17,7 @@ const prepareChoice = (model, env, defaultFeedback) => choice => {
     env.role === 'instructor' &&
     (env.mode === 'view' || env.mode === 'evaluate')
   ) {
-    out.rationale = choice.rationale;
+    out.rationale = model.rationaleEnabled ? choice.rationale : null;
   } else {
     out.rationale = null;
   }
@@ -73,11 +73,11 @@ export async function model(question, session, env, updateSession) {
   const partB = parsePart(question.partB, 'partB', session, env);
 
   if (!question.partA.lockChoiceOrder) {
-    partA.choices = await getShuffledChoices(question.partA.choices, session, updateSession, 'value');
+    partA.choices = await getShuffledChoices(partA.choices, session, updateSession, 'value');
   }
 
   if (!question.partB.lockChoiceOrder) {
-    partB.choices = await getShuffledChoices(question.partB.choices, session, updateSession, 'value');
+    partB.choices = await getShuffledChoices(partB.choices, session, updateSession, 'value');
   }
 
   if (question.partLabels) {
@@ -89,8 +89,8 @@ export async function model(question, session, env, updateSession) {
   }
 
   if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {
-    partA.teacherInstructions = question.partA.teacherInstructions;
-    partB.teacherInstructions = question.partB.teacherInstructions;
+    partA.teacherInstructions = question.partA.teacherInstructionsEnabled ? question.partA.teacherInstructions : null;
+    partB.teacherInstructions = question.partB.teacherInstructionsEnabled ? question.partB.teacherInstructions : null;
   } else {
     partA.teacherInstructions = null;
     partB.teacherInstructions = null;

--- a/packages/ebsr/docs/pie-schema.json
+++ b/packages/ebsr/docs/pie-schema.json
@@ -83,13 +83,31 @@
           "description": "Indicates teacher instructions",
           "type": "string",
           "title": "teacherInstructions"
+        },
+        "rationaleEnabled": {
+          "description": "Indicates if Rationale are enabled",
+          "type": "boolean",
+          "title": "rationaleEnabled"
+        },
+        "studentInstructionsEnabled": {
+          "description": "Indicates if Student Instructions are enabled",
+          "type": "boolean",
+          "title": "studentInstructionsEnabled"
+        },
+        "teacherInstructionsEnabled": {
+          "description": "Indicates if Teacher Instructions are enabled",
+          "type": "boolean",
+          "title": "teacherInstructionsEnabled"
         }
       },
       "required": [
         "choiceMode",
         "choicePrefix",
         "choices",
-        "prompt"
+        "prompt",
+        "rationaleEnabled",
+        "studentInstructionsEnabled",
+        "teacherInstructionsEnabled"
       ]
     },
     "partB": {
@@ -172,13 +190,31 @@
           "description": "Indicates teacher instructions",
           "type": "string",
           "title": "teacherInstructions"
+        },
+        "rationaleEnabled": {
+          "description": "Indicates if Rationale are enabled",
+          "type": "boolean",
+          "title": "rationaleEnabled"
+        },
+        "studentInstructionsEnabled": {
+          "description": "Indicates if Student Instructions are enabled",
+          "type": "boolean",
+          "title": "studentInstructionsEnabled"
+        },
+        "teacherInstructionsEnabled": {
+          "description": "Indicates if Teacher Instructions are enabled",
+          "type": "boolean",
+          "title": "teacherInstructionsEnabled"
         }
       },
       "required": [
         "choiceMode",
         "choicePrefix",
         "choices",
-        "prompt"
+        "prompt",
+        "rationaleEnabled",
+        "studentInstructionsEnabled",
+        "teacherInstructionsEnabled"
       ]
     },
     "partLabels": {
@@ -595,13 +631,31 @@
           "description": "Indicates teacher instructions",
           "type": "string",
           "title": "teacherInstructions"
+        },
+        "rationaleEnabled": {
+          "description": "Indicates if Rationale are enabled",
+          "type": "boolean",
+          "title": "rationaleEnabled"
+        },
+        "studentInstructionsEnabled": {
+          "description": "Indicates if Student Instructions are enabled",
+          "type": "boolean",
+          "title": "studentInstructionsEnabled"
+        },
+        "teacherInstructionsEnabled": {
+          "description": "Indicates if Teacher Instructions are enabled",
+          "type": "boolean",
+          "title": "teacherInstructionsEnabled"
         }
       },
       "required": [
         "choiceMode",
         "choicePrefix",
         "choices",
-        "prompt"
+        "prompt",
+        "rationaleEnabled",
+        "studentInstructionsEnabled",
+        "teacherInstructionsEnabled"
       ]
     },
     "Choice": {

--- a/packages/ebsr/docs/pie-schema.json.md
+++ b/packages/ebsr/docs/pie-schema.json.md
@@ -72,6 +72,18 @@ Indicates student instructions
 
 Indicates teacher instructions
 
+## `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+## `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+## `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
+
 # `partB` (object, required)
 
 Properties of the `partB` object:
@@ -138,6 +150,18 @@ Indicates student instructions
 ## `teacherInstructions` (string)
 
 Indicates teacher instructions
+
+## `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+## `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+## `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
 
 # `partLabels` (boolean, required)
 
@@ -460,6 +484,18 @@ Indicates student instructions
 ### `teacherInstructions` (string)
 
 Indicates teacher instructions
+
+### `rationaleEnabled` (boolean, required)
+
+Indicates if Rationale are enabled
+
+### `studentInstructionsEnabled` (boolean, required)
+
+Indicates if Student Instructions are enabled
+
+### `teacherInstructionsEnabled` (boolean, required)
+
+Indicates if Teacher Instructions are enabled
 
 ## `Choice` (object)
 

--- a/packages/pie-models/src/pie/ebsr/index.ts
+++ b/packages/pie-models/src/pie/ebsr/index.ts
@@ -37,6 +37,15 @@ export interface Part {
 
     /** Indicates teacher instructions */
     teacherInstructions?: string;
+
+    /** Indicates if Rationale are enabled */
+    rationaleEnabled: boolean;
+
+    /** Indicates if Student Instructions are enabled */
+    studentInstructionsEnabled: boolean;
+
+    /** Indicates if Teacher Instructions are enabled */
+    teacherInstructionsEnabled: boolean;
 }
 
 /** NOTE: teacherInstructions, studentInstructions, rationale & rubric


### PR DESCRIPTION
…flag in model because it's needed in controller.

BREAKING CHANGE: `enabled` property from `configuration.rationale.enabled` moved to `model.rationaleEnabled`. Same applies to teacherInstructions/studentInstructions.