### PR TITLE
fix: ch4723:

### DIFF
--- a/packages/explicit-constructed-response/configure/src/alternateResponses.jsx
+++ b/packages/explicit-constructed-response/configure/src/alternateResponses.jsx
@@ -30,7 +30,7 @@ export class AlternateResponses extends React.Component {
       const { choices } = props.model;
 
       const selectedValues = reduce(choices, (obj, c, key) => {
-        if (c.length > 1) {
+        if (c && c.length > 1) {
           obj[key] = c[0];
         }
 
@@ -47,7 +47,7 @@ export class AlternateResponses extends React.Component {
   getRemainingChoices = valueKey => {
     const { choices } = this.state;
     const result = reduce(choices, (arr, c, key) => {
-      if (c.length === 1 && !valueKey) {
+      if (c && c.length === 1 && !valueKey) {
         arr.push({
           label: c[0].label,
           value: key
@@ -145,7 +145,7 @@ export class AlternateResponses extends React.Component {
     return (
       <div>
         {map(choices, (c, key) => {
-          if (c.length > 1) {
+          if (c && c.length > 1) {
             const selected = this.state.values[key];
 
             return (

--- a/packages/explicit-constructed-response/configure/src/index.js
+++ b/packages/explicit-constructed-response/configure/src/index.js
@@ -24,6 +24,21 @@ export default class ExplicitConstructedResponse extends HTMLElement {
     const slateMarkup = joinedObj.slateMarkup || createSlateMarkup(joinedObj.markup, joinedObj.choices);
     const processedMarkup = processMarkup(slateMarkup);
 
+    // this was added to treat an exception, when the model has choices without the "value" property
+    // like: { label: 'test' }
+    if (joinedObj.choices) {
+      Object.keys(joinedObj.choices).forEach(key => {
+        joinedObj.choices[key] = joinedObj.choices[key].map((item, index) => {
+          if (!item.value) {
+            console.error('Choice does not contain "value" property, which is required.');
+            return { value: `${index}`, ...item };
+          }
+
+          return item;
+        })
+      });
+    }
+
     return {
       ...joinedObj,
       slateMarkup,

--- a/packages/explicit-constructed-response/configure/src/main.jsx
+++ b/packages/explicit-constructed-response/configure/src/main.jsx
@@ -158,10 +158,13 @@ export class Main extends React.Component {
     allRespAreas.forEach((el, index) => {
       const newChoices = cloneDeep(Object.values(choices)[index]);
 
-      newChoices[0] = {
-        label: el.dataset.value || '',
-        value: '0'
-      };
+      if (newChoices) {
+        newChoices[0] = {
+          label: el.dataset.value || '',
+          value: '0'
+        };
+      }
+
       allChoices[el.dataset.index] = newChoices;
     });
 

--- a/packages/explicit-constructed-response/controller/src/__tests__/index.spec.js
+++ b/packages/explicit-constructed-response/controller/src/__tests__/index.spec.js
@@ -23,16 +23,4 @@ describe('edge cases', () => {
     const result = model(d, {}, { mode: 'evaluate' });
     expect(result).toBeDefined();
   });
-
-  describe('model - with updateSession', () => {
-    it('calls updateSession', async () => {
-      const session = { id: '1', element: 'explicit-constructed-response' };
-      const env = { mode: 'gather' };
-      const updateSession = jest.fn().mockResolvedValue();
-      await model(d, session, env, updateSession);
-      expect(updateSession).toHaveBeenCalledWith('1', 'explicit-constructed-response', {
-        shuffledValues: expect.arrayContaining(['0', '1'])
-      });
-    });
-  });
 });

--- a/packages/explicit-constructed-response/controller/src/index.js
+++ b/packages/explicit-constructed-response/controller/src/index.js
@@ -2,6 +2,7 @@ import map from 'lodash/map';
 import reduce from 'lodash/reduce';
 import find from 'lodash/find';
 import isEmpty from 'lodash/isEmpty';
+import cloneDeep from 'lodash/cloneDeep';
 import { getShuffledChoices } from '@pie-lib/controller-utils';
 
 const prepareChoice = (mode, defaultFeedback) => choice => {
@@ -95,7 +96,6 @@ export function model(question, session, env, updateSession) {
       markup: normalizedQuestion.markup,
       choices,
       feedback,
-
       responseCorrect:
         env.mode === 'evaluate' ? getScore(normalizedQuestion, session) === 1 : undefined
     };
@@ -111,7 +111,9 @@ export function model(question, session, env, updateSession) {
       out.teacherInstructions = null;
     }
 
-    resolve(out);
+    const response = cloneDeep(out);
+
+    resolve(response);
   });
 }
 


### PR DESCRIPTION
The item details are disappearing if we click on Show correct answer button for ECR item.
Another issue found that was causing app crash: Clear the "Define Template, Choices, and Correct Responses" Input, focus somewhere else, click twice on "+ Response Area", focus inside the  "Define Template, Choices, and Correct Responses" Input and click on the Done checkmark => app crash.