### PR TITLE
fix: PIE-188 - upgrade @pie-lib/math-evaluator@^0.6.0

### DIFF
--- a/packages/math-inline/controller/package.json
+++ b/packages/math-inline/controller/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@pie-lib/controller-utils": "^0.2.3",
     "@pie-lib/feedback": "^0.4.9",
+    "@pie-lib/math-evaluator": "^0.6.0",
     "debug": "^3.1.0",
     "lodash": "^4.17.15"
   },

--- a/packages/math-inline/controller/src/__tests__/index.test.jsx
+++ b/packages/math-inline/controller/src/__tests__/index.test.jsx
@@ -18,11 +18,7 @@ const defaultModel = {
       validation: 'literal'
     }
   ],
-  customKeys: [
-    '\\left(\\right)',
-    '\\frac{}{}',
-    'x\\frac{}{}'
-  ],
+  customKeys: ['\\left(\\right)', '\\frac{}{}', 'x\\frac{}{}'],
   id: 1
 };
 
@@ -141,7 +137,6 @@ describe('model', () => {
       expect(result.correctness.score).toEqual('100%');
     });
 
-
     it('returns correct for correctness with text nodes too in symbolic', async () => {
       question = mkQuestion();
       session = { completeAnswer: '72\\div12=6eggs' };
@@ -162,11 +157,11 @@ describe('model', () => {
             id: '1',
             answer: '8-4',
             alternates: {
-              '1': '4−2',
+              '1': '4−2'
             },
             validation: 'literal'
           }
-        ],
+        ]
       });
 
       env = { mode: 'evaluate' };
@@ -196,7 +191,6 @@ describe('model', () => {
 
       expect(result.correctness.correctness).toEqual('correct');
       expect(result.correctness.score).toEqual('100%');
-
     });
 
     it('returns correct for correctness in cdot vs times situations', async () => {
@@ -208,11 +202,11 @@ describe('model', () => {
             id: '1',
             answer: '8\\cdot4',
             alternates: {
-              '1': '4\\times2',
+              '1': '4\\times2'
             },
             validation: 'literal'
           }
-        ],
+        ]
       });
 
       env = { mode: 'evaluate' };
@@ -345,7 +339,9 @@ describe('outcome', () => {
   });
 
   const returnOutcome = session => {
-    it(`returns score: 0 and empty: true if session is ${JSON.stringify(session)}`, async () => {
+    it(`returns score: 0 and empty: true if session is ${JSON.stringify(
+      session
+    )}`, async () => {
       let outcomeResult = await outcome(question, session, env);
 
       expect(outcomeResult).toEqual({ score: 0, empty: true });
@@ -375,11 +371,7 @@ describe('createCorrectResponseSession', () => {
         validation: 'literal'
       }
     ],
-    customKeys: [
-      '\\left(\\right)',
-      '\\frac{}{}',
-      'x\\frac{}{}'
-    ]
+    customKeys: ['\\left(\\right)', '\\frac{}{}', 'x\\frac{}{}']
   };
 
   it('returns correct response if role is instructor and mode is gather', async () => {
@@ -415,15 +407,71 @@ describe('createCorrectResponseSession', () => {
   });
 
   it('returns null if mode is evaluate', async () => {
-    const noResult = await createCorrectResponseSession(question, { mode: 'evaluate', role: 'instructor' });
+    const noResult = await createCorrectResponseSession(question, {
+      mode: 'evaluate',
+      role: 'instructor'
+    });
 
     expect(noResult).toBeNull();
   });
 
   it('returns null if role is student', async () => {
-    const noResult = await createCorrectResponseSession(question, { mode: 'gather', role: 'student' });
+    const noResult = await createCorrectResponseSession(question, {
+      mode: 'gather',
+      role: 'student'
+    });
 
     expect(noResult).toBeNull();
   });
-});
 
+  describe('PIE-188', () => {
+    it('works', async () => {
+      const question = {
+        responseType: 'Advanced Multi',
+        expression: '{{response}}',
+        equationEditor: 'everything',
+        responses: [
+          {
+            alternates: {},
+            answer: '1530',
+            validation: 'symbolic',
+            id: '1',
+            allowSpaces: true
+          }
+        ],
+        id: '1',
+        element: 'math-inline',
+        customKeys: [
+          '<',
+          '\\le',
+          '\\ge',
+          '>',
+          '\\frac{}{}',
+          'x^{}',
+          '\\left(\\right)'
+        ]
+      };
+      const session = {
+        id: '1',
+        answers: {
+          r1: {
+            value: '\\odot'
+          }
+        },
+        completeAnswer: '\\odot'
+      };
+      const env = { mode: 'evaluate' };
+
+      try {
+        await model(question, session, env);
+      } catch (e) {
+        console.error('>>');
+        console.log(e);
+        fail(e);
+      }
+      await expect(model(question, session, env)).resolves.toMatchObject({
+        correctness: { correct: false }
+      });
+    });
+  });
+});

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -114,6 +114,12 @@ function getIsAnswerCorrect(correctResponseItem, answerItem) {
         }
       }
     } else {
+      console.log(
+        'A:',
+        processAnswerItem(correctResponse.answer),
+        'B:',
+        processAnswerItem(answerItem)
+      );
       answerCorrect = areValuesEqual(
         processAnswerItem(correctResponse.answer),
         processAnswerItem(answerItem),
@@ -173,7 +179,7 @@ export const normalize = question => ({
   rationaleEnabled: true,
   teacherInstructionsEnabled: true,
   studentInstructionsEnabled: true,
-  ...question,
+  ...question
 });
 
 export function model(question, session, env) {
@@ -211,7 +217,9 @@ export function model(question, session, env) {
         env.role === 'instructor' &&
         (env.mode === 'view' || env.mode === 'evaluate')
       ) {
-        out.rationale = normalizedQuestion.rationaleEnabled ? normalizedQuestion.rationale : null;
+        out.rationale = normalizedQuestion.rationaleEnabled
+          ? normalizedQuestion.rationale
+          : null;
         out.teacherInstructions = normalizedQuestion.teacherInstructionsEnabled
           ? normalizedQuestion.teacherInstructions
           : null;
@@ -220,7 +228,9 @@ export function model(question, session, env) {
         out.teacherInstructions = null;
       }
 
-      out.config.prompt = normalizedQuestion.promptEnabled ? normalizedQuestion.prompt : null;
+      out.config.prompt = normalizedQuestion.promptEnabled
+        ? normalizedQuestion.prompt
+        : null;
 
       log('out: ', out);
       resolve(out);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,6 +1777,18 @@
     invariant "^2.2.4"
     lodash "^4.17.10"
 
+"@pie-framework/math-expressions@2.0.0-alpha24":
+  version "2.0.0-alpha24"
+  resolved "https://registry.yarnpkg.com/@pie-framework/math-expressions/-/math-expressions-2.0.0-alpha24.tgz#4f0440872ac3a522b6d412ab81a5f55e116e03ed"
+  integrity sha512-qS2vRRIvlBsvoJw7QD/EpFE6llIe6ZQl1b+oXNNbwIWlIZ2jCHTCcuZVVZeXYGFWpagLrI4FTjxYnWyeYm+iJQ==
+  dependencies:
+    babel-cli "^6.26.0"
+    mathjs "^4.4.2"
+    number-theory "*"
+    numeric "*"
+    seedrandom "^3.0.5"
+    xml-parser "*"
+
 "@pie-framework/mathquill@^0.10.3":
   version "0.10.4"
   resolved "https://registry.yarnpkg.com/@pie-framework/mathquill/-/mathquill-0.10.4.tgz#6725a1ab29381479d75439e97ad4934b86ed0991"
@@ -2081,6 +2093,15 @@
   dependencies:
     jsesc "^2.5.2"
     math-expressions "^2.0.0-alpha1"
+    mathjs "^5.4.1"
+
+"@pie-lib/math-evaluator@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@pie-lib/math-evaluator/-/math-evaluator-0.6.0.tgz#931636533fe45a7a175912a1c31d438e0f7e26e4"
+  integrity sha512-EGkbKciA+/TOGAsrXYS+pnR2uKRcwgx09yaS5L+oa4Eqs8ZnfvyKSQV0BnxQwMZRMOd0v6LTjxMhi9AgZ29pEg==
+  dependencies:
+    "@pie-framework/math-expressions" "2.0.0-alpha24"
+    jsesc "^2.5.2"
     mathjs "^5.4.1"
 
 "@pie-lib/math-input@^6.3.5":
@@ -11250,6 +11271,11 @@ seed-random@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/seed-random/-/seed-random-2.2.0.tgz#2a9b19e250a817099231a5b99a4daf80b7fbed54"
   integrity sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ=
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 selection-is-backward@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
* math-evaluator uses the new @pie-framework/math-expressions to handle
unknown latex commands. [See math-expressions change][me]

[me]: https://github.com/pie-framework/math-expressions/pull/1