### PR TITLE
fix: 4210: Select Text token alignment issues with some legacy content

### DIFF
--- a/packages/select-text/configure/src/__tests__/__snapshots__/design.test.jsx.snap
+++ b/packages/select-text/configure/src/__tests__/__snapshots__/design.test.jsx.snap
@@ -368,3 +368,131 @@ exports[`design snapshot renders all items with defaultProps 1`] = `
   </div>
 </ConfigLayout>
 `;
+
+exports[`design snapshot tokenizer renders without html entities 1`] = `
+<ConfigLayout
+  settings={
+    <Panel
+      configuration={
+        Object {
+          "correctAnswer": Object {
+            "label": "Correct Answers",
+            "settings": true,
+          },
+          "feedback": Object {
+            "label": "Feedback",
+            "settings": true,
+          },
+          "highlightChoices": Object {
+            "label": "Highlight choices",
+            "settings": true,
+          },
+          "mode": Object {
+            "label": "Mode",
+            "settings": true,
+          },
+          "partialScoring": Object {
+            "label": "Allow Partial Scoring",
+            "settings": false,
+          },
+          "prompt": Object {
+            "label": "Prompt",
+            "settings": true,
+          },
+          "rationale": Object {
+            "label": "Rationale",
+            "settings": true,
+          },
+          "scoringType": Object {
+            "label": "Scoring Type",
+            "settings": false,
+          },
+          "selectionCount": Object {
+            "label": "Selection count",
+            "settings": true,
+          },
+          "selections": Object {
+            "label": "Selections Available",
+            "settings": true,
+          },
+          "studentInstructions": Object {
+            "label": "Student Instructions",
+            "settings": false,
+          },
+          "teacherInstructions": Object {
+            "label": "Teacher Instructions",
+            "settings": true,
+          },
+          "text": Object {
+            "label": "Content",
+            "settings": true,
+          },
+          "tokens": Object {
+            "label": "Tokens",
+            "settings": true,
+          },
+        }
+      }
+      groups={
+        Object {
+          "Properties": Object {
+            "promptEnabled": undefined,
+            "rationaleEnabled": undefined,
+            "scoringType": false,
+            "studentInstructionsEnabled": false,
+            "teacherInstructionsEnabled": undefined,
+          },
+          "Settings": Object {
+            "feedbackEnabled": undefined,
+            "highlightChoices": undefined,
+            "partialScoring": false,
+          },
+        }
+      }
+      model={
+        Object {
+          "text": "<p>&#8220;Lucy?&#63; Are you using your time wisely to plan your project?&#33;&#33;&#33;&#8221; Mr. Wilson asked.</p><p>Lucy looked a little confused at first. &#195; Then she grinned and proudly stated, &#8220;Why, yes I am! I plan to make a bird feeder for that tree out our window!&#8221;</p>",
+          "tokens": Array [],
+        }
+      }
+      onChangeModel={[Function]}
+    />
+  }
+>
+  <div>
+    <TextField
+      label="Content"
+      multiline={true}
+      onChange={[Function]}
+      required={false}
+      select={false}
+      value="<p>&#8220;Lucy?&#63; Are you using your time wisely to plan your project?&#33;&#33;&#33;&#8221; Mr. Wilson asked.</p><p>Lucy looked a little confused at first. &#195; Then she grinned and proudly stated, &#8220;Why, yes I am! I plan to make a bird feeder for that tree out our window!&#8221;</p>"
+      variant="standard"
+    />
+    <Component
+      label="Tokens"
+    >
+      <WithStyles(Tokenizer)
+        onChange={[Function]}
+        text="<p>“Lucy?? Are you using your time wisely to plan your project?!!!” Mr. Wilson asked.</p><p>Lucy looked a little confused at first. Ã Then she grinned and proudly stated, “Why, yes I am! I plan to make a bird feeder for that tree out our window!”</p>"
+        tokens={Array []}
+      />
+    </Component>
+    <WithStyles(Chip)
+      label="Mode: None"
+    />
+    <WithStyles(Chip)
+      label="Selections Available: 0"
+    />
+    <WithStyles(Chip)
+      label="Correct Answers: 0"
+    />
+    <Component
+      label="Selection count (0:any)"
+      max={0}
+      min={0}
+      onChange={[Function]}
+    />
+  </div>
+</ConfigLayout>
+`;

--- a/packages/select-text/configure/src/__tests__/design.test.jsx
+++ b/packages/select-text/configure/src/__tests__/design.test.jsx
@@ -47,6 +47,23 @@ describe('design', () => {
       expect(w).toMatchSnapshot();
     });
 
+    it('tokenizer renders without html entities', () => {
+      expect(shallow(
+        <Design
+          model={{
+            text: "<p>&#8220;Lucy?&#63; Are you using your time wisely to plan your project?&#33;&#33;&#33;&#8221; Mr. Wilson asked.<\/p><p>Lucy looked a little confused at first. &#195; Then she grinned and proudly stated, &#8220;Why, yes I am! I plan to make a bird feeder for that tree out our window!&#8221;<\/p>",
+            tokens: []
+          }}
+          configuration={defaultValues.configuration}
+          classes={{}}
+          className={'foo'}
+          onModelChanged={onChange}
+          onPromptChanged={onPromptChanged}
+          onRationaleChanged={onRationaleChanged}
+        />
+      )).toMatchSnapshot();
+    });
+
     it('renders all items except feedback', () => {
       const defaultConfiguration = defaultValues.configuration;
 

--- a/packages/select-text/configure/src/design.jsx
+++ b/packages/select-text/configure/src/design.jsx
@@ -17,6 +17,7 @@ import debug from 'debug';
 import EditableHtml from '@pie-lib/editable-html';
 
 const { Panel, toggle, radio } = settings;
+const htmlCodeRegex = /&#(\d+);/g;
 
 const log = debug('@pie-element:select-text:configure');
 
@@ -261,7 +262,7 @@ export class Design extends React.Component {
             >
               <Tokenizer
                 className={classes.tokenizer}
-                text={model.text}
+                text={model.text && model.text.replace(htmlCodeRegex, (match, dec) => String.fromCharCode(dec))}
                 tokens={model.tokens}
                 onChange={this.changeTokens}
               />

--- a/packages/select-text/controller/src/__tests__/index.test.js
+++ b/packages/select-text/controller/src/__tests__/index.test.js
@@ -287,6 +287,19 @@ describe('model', () => {
     assert('correctness undefined in view', q(), {}, e({ mode: 'evaluate' }), {
       correctness: 'incorrect'
     });
+
+    it('removes html entities from text', async () => {
+      const result = await model(
+        {
+          ...q(),
+          text: "<p>&#8220;Lucy?&#63; Are you using your time wisely to plan your project?&#33;&#33;&#33;&#8221; Mr. Wilson asked.<\/p><p>Lucy looked a little confused at first. &#195; Then she grinned and proudly stated, &#8220;Why, yes I am! I plan to make a bird feeder for that tree out our window!&#8221;<\/p>"
+        },
+        s(),
+        e()
+      );
+
+      expect(result.text).toEqual(`<p>“Lucy?? Are you using your time wisely to plan your project?!!!” Mr. Wilson asked.</p><p>Lucy looked a little confused at first. Ã Then she grinned and proudly stated, “Why, yes I am! I plan to make a bird feeder for that tree out our window!”</p>`);
+    });
   });
 
   describe('feedback', () => {

--- a/packages/select-text/controller/src/index.js
+++ b/packages/select-text/controller/src/index.js
@@ -5,6 +5,7 @@ import { partialScoring } from '@pie-lib/controller-utils';
 import defaults from './defaults';
 
 const log = debug('@pie-element:select-text:controller');
+const htmlCodeRegex = /&#(\d+);/g;
 
 const buildTokens = (tokens, evaluateMode) => {
   return tokens.map(t =>
@@ -132,7 +133,7 @@ export const model = (question, session, env) => {
         prompt: normalizedQuestion.promptEnabled
           ? normalizedQuestion.prompt
           : null,
-        text: normalizedQuestion.text,
+        text: normalizedQuestion.text && normalizedQuestion.text.replace(htmlCodeRegex, (match, dec) => String.fromCharCode(dec)),
         disabled: env.mode !== 'gather',
         maxSelections: normalizedQuestion.maxSelections,
         correctness,


### PR DESCRIPTION
Removed html entities from text in order to prevent having issues with tokens  offsets.