### PR TITLE
fix: ch6025: 

### DIFF
--- a/packages/ebsr/configure/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/ebsr/configure/src/__tests__/__snapshots__/index.test.js.snap
@@ -7,7 +7,6 @@ Object {
     "choicePrefix": "numbers",
     "choices": Array [],
     "feedbackEnabled": true,
-    "partialScoring": false,
     "prompt": "Prompt A",
     "promptEnabled": true,
     "rationale": "",
@@ -21,7 +20,6 @@ Object {
     "choicePrefix": "numbers",
     "choices": Array [],
     "feedbackEnabled": true,
-    "partialScoring": false,
     "prompt": "Prompt B",
     "promptEnabled": true,
     "rationale": "",
@@ -32,6 +30,7 @@ Object {
   },
   "partLabelType": "Letters",
   "partLabels": true,
+  "partialScoring": false,
 }
 `;
 
@@ -42,7 +41,6 @@ Object {
     "choicePrefix": "numbers",
     "choices": Array [],
     "feedbackEnabled": true,
-    "partialScoring": false,
     "prompt": "Prompt A",
     "promptEnabled": true,
     "rationale": "foo",
@@ -56,7 +54,6 @@ Object {
     "choicePrefix": "numbers",
     "choices": Array [],
     "feedbackEnabled": true,
-    "partialScoring": false,
     "prompt": "Prompt B",
     "promptEnabled": true,
     "rationale": "",
@@ -67,5 +64,6 @@ Object {
   },
   "partLabelType": "Letters",
   "partLabels": true,
+  "partialScoring": false,
 }
 `;

--- a/packages/ebsr/configure/src/__tests__/index.test.js
+++ b/packages/ebsr/configure/src/__tests__/index.test.js
@@ -5,8 +5,6 @@ import { choiceUtils as utils } from '@pie-lib/config-ui';
 import ReactDOM from 'react-dom';
 import defaults from '../defaults';
 import { Main } from '../main';
-import merge from 'lodash/merge';
-import MultipleChoiceConfigure from '@pie-element/multiple-choice/configure/lib';
 import EbsrConfigure from '../index';
 
 jest.mock('react-dom', () => ({
@@ -453,15 +451,11 @@ describe('main', () => {
     assertOnModelChanged(
       'changes partA - partialScoring',
       {
-        partA: {
-          partialScoring: false
-        }
+        partialScoring: false,
       },
       {
         ...model,
-        partA: {
-          partialScoring: false
-        }
+        partialScoring: false
       }
     );
     assertOnModelChanged(
@@ -481,15 +475,11 @@ describe('main', () => {
     assertOnModelChanged(
       'changes partA - scoringType',
       {
-        partA: {
-          scoringType: 'auto'
-        }
+        scoringType: 'auto'
       },
       {
         ...model,
-        partA: {
-          scoringType: 'auto'
-        }
+        scoringType: 'auto'
       }
     );
     assertOnModelChanged(
@@ -523,15 +513,11 @@ describe('main', () => {
     assertOnModelChanged(
       'changes partB - partialScoring',
       {
-        partB: {
-          partialScoring: false
-        }
+        partialScoring: false
       },
       {
         ...model,
-        partB: {
-          partialScoring: false
-        }
+        partialScoring: false
       }
     );
     assertOnModelChanged(
@@ -551,15 +537,11 @@ describe('main', () => {
     assertOnModelChanged(
       'changes partB - scoringType',
       {
-        partB: {
-          scoringType: 'auto'
-        }
+        scoringType: 'auto'
       },
       {
         ...model,
-        partB: {
-          scoringType: 'auto'
-        }
+        scoringType: 'auto'
       }
     );
   });

--- a/packages/ebsr/configure/src/defaults.js
+++ b/packages/ebsr/configure/src/defaults.js
@@ -24,10 +24,6 @@ const defaultConfig = {
     settings: true,
     label: 'Lock Choice Order'
   },
-  partialScoring: {
-    settings: false,
-    label: 'Allow Partial Scoring'
-  },
   prompt: {
     settings: true,
     label: 'Prompt'
@@ -35,10 +31,6 @@ const defaultConfig = {
   rationale: {
     settings: true,
     label: 'Rationale'
-  },
-  scoringType: {
-    settings: false,
-    label: 'Scoring Type'
   },
   studentInstructions: {
     settings: false,
@@ -54,7 +46,6 @@ const partModel = base => ({
   choiceMode: 'radio',
   choices: [],
   choicePrefix: 'numbers',
-  partialScoring: false,
   prompt: 'Prompt',
   rationaleEnabled: true,
   feedbackEnabled: true,
@@ -70,19 +61,24 @@ export default {
   model: {
     partLabels: true,
     partLabelType: 'Letters',
+    partialScoring: false,
     partA: partModel({ prompt: 'Prompt A' }),
     partB: partModel({ prompt: 'Prompt B' })
   },
   configuration: {
+    partialScoring: {
+      settings: false,
+      label: 'Allow Partial Scoring'
+    },
+    scoringType: {
+      settings: false,
+      label: 'Scoring Type'
+    },
     partA: {
       ...cloneDeep(defaultConfig),
       choiceMode: {
         settings: false,
         label: 'Response Type'
-      },
-      partialScoring: {
-        settings: false,
-        label: 'Allow Partial Scoring'
       }
     },
     partB: cloneDeep(defaultConfig),

--- a/packages/ebsr/configure/src/index.js
+++ b/packages/ebsr/configure/src/index.js
@@ -23,14 +23,10 @@ defineMultipleChoice();
 const prepareCustomizationObject = (config, model) => {
   const configuration = defaults(config, sensibleDefaults.configuration);
   configuration.settingsPanelDisabled = true;
-  // it is required for ebsr partA not to allow changing response type and enable partial scoring
+  // it is required for ebsr partA not to allow changing response type
   configuration.partA.choiceMode = {
     settings: false,
     label: 'Response Type'
-  };
-  configuration.partA.partialScoring = {
-    settings: false,
-    label: 'Allow Partial Scoring',
   };
 
   return {

--- a/packages/ebsr/configure/src/main.jsx
+++ b/packages/ebsr/configure/src/main.jsx
@@ -35,30 +35,26 @@ export class Main extends React.Component {
       onConfigurationChanged
     } = this.props;
     const { partLabelType } = model;
-    const { partA, partB, ...generalConfiguration } = configuration;
+    const { partA, partB, partialScoring, scoringType, ...generalConfiguration } = configuration;
     const {
       feedback: feedbackA = {},
       choiceMode: choiceModeA = {},
       choicePrefix: choicePrefixA = {},
-      partialScoring: partialScoringA = {},
       lockChoiceOrder: lockChoiceOrderA = {},
       prompt: promptA = {},
       teacherInstructions: teacherInstructionsA = {},
       studentInstructions: studentInstructionsA = {},
-      rationale: rationaleA = {},
-      scoringType: scoringTypeA = {}
+      rationale: rationaleA = {}
     } = partA || {};
     const {
       feedback: feedbackB = {},
       choiceMode: choiceModeB = {},
       choicePrefix: choicePrefixB = {},
-      partialScoring: partialScoringB = {},
       lockChoiceOrder: lockChoiceOrderB = {},
       prompt: promptB = {},
       teacherInstructions: teacherInstructionsB = {},
       studentInstructions: studentInstructionsB = {},
-      rationale: rationaleB = {},
-      scoringType: scoringTypeB = {}
+      rationale: rationaleB = {}
     } = partB || {};
     const type = partLabelType || 'Numbers';
     const typeIsNumber = type === 'Numbers';
@@ -80,7 +76,11 @@ export class Main extends React.Component {
                     generalConfiguration.partLabels.settings &&
                     toggle(generalConfiguration.partLabels.label),
                   partLabelType:
-                    model.partLabels && dropdown('', ['Numbers', 'Letters'])
+                    model.partLabels && dropdown('', ['Numbers', 'Letters']),
+                  partialScoring:
+                    partialScoring.settings && toggle(partialScoring.label),
+                  scoringType:
+                    scoringType.settings && radio(scoringType.label, ['auto', 'rubric'])
                 },
                 [`Settings ${firstPart}`]: {
                   'partA.choiceMode':
@@ -89,13 +89,8 @@ export class Main extends React.Component {
                   'partA.choicePrefix':
                     choicePrefixA.settings &&
                     radio(choicePrefixA.label, ['numbers', 'letters']),
-                  'partA.partialScoring':
-                    partialScoringA.settings && toggle(partialScoringA.label),
                   'partA.lockChoiceOrder':
                     lockChoiceOrderA.settings && toggle(lockChoiceOrderA.label),
-                  'partA.scoringType':
-                    scoringTypeA.settings &&
-                    radio(scoringTypeA.label, ['auto', 'rubric'])
                 },
                 [`Properties ${firstPart}`]: {
                   'partA.feedbackEnabled': feedbackA.settings &&
@@ -118,13 +113,8 @@ export class Main extends React.Component {
                   'partB.choicePrefix':
                     choicePrefixB.settings &&
                     radio(choicePrefixB.label, ['numbers', 'letters']),
-                  'partB.partialScoring':
-                    partialScoringB.settings && toggle(partialScoringB.label),
                   'partB.lockChoiceOrder':
-                    lockChoiceOrderB.settings && toggle(lockChoiceOrderB.label),
-                  'partA.scoringType':
-                    scoringTypeB.settings &&
-                    radio(scoringTypeB.label, ['auto', 'rubric'])
+                    lockChoiceOrderB.settings && toggle(lockChoiceOrderB.label)
                 },
                 [`Properties ${secondPart}`]: {
                   'partB.feedbackEnabled':

--- a/packages/ebsr/docs/config-schema.json
+++ b/packages/ebsr/docs/config-schema.json
@@ -103,22 +103,6 @@
             }
           }
         },
-        "partialScoring": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
         "prompt": {
           "title": "ConfigureProp",
           "type": "object",
@@ -136,22 +120,6 @@
           }
         },
         "rationale": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
-        "scoringType": {
           "title": "ConfigureProp",
           "type": "object",
           "properties": {
@@ -301,22 +269,6 @@
             }
           }
         },
-        "partialScoring": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
         "prompt": {
           "title": "ConfigureProp",
           "type": "object",
@@ -334,22 +286,6 @@
           }
         },
         "rationale": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
-        "scoringType": {
           "title": "ConfigureProp",
           "type": "object",
           "properties": {
@@ -400,6 +336,38 @@
       }
     },
     "partLabels": {
+      "title": "ConfigureProp",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        }
+      }
+    },
+    "partialScoring": {
+      "title": "ConfigureProp",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        }
+      }
+    },
+    "scoringType": {
       "title": "ConfigureProp",
       "type": "object",
       "properties": {
@@ -533,22 +501,6 @@
             }
           }
         },
-        "partialScoring": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
         "prompt": {
           "title": "ConfigureProp",
           "type": "object",
@@ -566,22 +518,6 @@
           }
         },
         "rationale": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
-        "scoringType": {
           "title": "ConfigureProp",
           "type": "object",
           "properties": {

--- a/packages/ebsr/docs/config-schema.json.md
+++ b/packages/ebsr/docs/config-schema.json.md
@@ -78,18 +78,6 @@ Indicates if the item has to be displayed in the Settings Panel
 
 Indicates the label for the item that has to be displayed in the Settings Panel
 
-## `partialScoring` (object)
-
-Properties of the `partialScoring` object:
-
-### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
 ## `prompt` (object)
 
 Properties of the `prompt` object:
@@ -105,18 +93,6 @@ Indicates the label for the item that has to be displayed in the Settings Panel
 ## `rationale` (object)
 
 Properties of the `rationale` object:
-
-### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
-## `scoringType` (object)
-
-Properties of the `scoringType` object:
 
 ### `settings` (boolean)
 
@@ -226,18 +202,6 @@ Indicates if the item has to be displayed in the Settings Panel
 
 Indicates the label for the item that has to be displayed in the Settings Panel
 
-## `partialScoring` (object)
-
-Properties of the `partialScoring` object:
-
-### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
 ## `prompt` (object)
 
 Properties of the `prompt` object:
@@ -253,18 +217,6 @@ Indicates the label for the item that has to be displayed in the Settings Panel
 ## `rationale` (object)
 
 Properties of the `rationale` object:
-
-### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
-## `scoringType` (object)
-
-Properties of the `scoringType` object:
 
 ### `settings` (boolean)
 
@@ -301,6 +253,30 @@ Indicates the label for the item that has to be displayed in the Settings Panel
 # `partLabels` (object)
 
 Properties of the `partLabels` object:
+
+## `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+## `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+# `partialScoring` (object)
+
+Properties of the `partialScoring` object:
+
+## `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+## `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+# `scoringType` (object)
+
+Properties of the `scoringType` object:
 
 ## `settings` (boolean)
 
@@ -404,18 +380,6 @@ Indicates if the item has to be displayed in the Settings Panel
 
 Indicates the label for the item that has to be displayed in the Settings Panel
 
-### `partialScoring` (object)
-
-Properties of the `partialScoring` object:
-
-#### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-#### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
 ### `prompt` (object)
 
 Properties of the `prompt` object:
@@ -431,18 +395,6 @@ Indicates the label for the item that has to be displayed in the Settings Panel
 ### `rationale` (object)
 
 Properties of the `rationale` object:
-
-#### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-#### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
-### `scoringType` (object)
-
-Properties of the `scoringType` object:
 
 #### `settings` (boolean)
 

--- a/packages/ebsr/docs/pie-schema.json
+++ b/packages/ebsr/docs/pie-schema.json
@@ -55,11 +55,6 @@
           "type": "string",
           "title": "choicePrefix"
         },
-        "partialScoring": {
-          "description": "Indicates if partial scoring should be used",
-          "type": "boolean",
-          "title": "partialScoring"
-        },
         "prompt": {
           "description": "The question prompt or item stem",
           "type": "string",
@@ -69,15 +64,6 @@
           "description": "Indicates if the prompt is enabled",
           "type": "boolean",
           "title": "promptEnabled"
-        },
-        "scoringType": {
-          "description": "Indicates scoring type",
-          "enum": [
-            "auto",
-            "rubric"
-          ],
-          "type": "string",
-          "title": "scoringType"
         },
         "studentInstructions": {
           "description": "Indicates student instructions",
@@ -173,11 +159,6 @@
           "type": "string",
           "title": "choicePrefix"
         },
-        "partialScoring": {
-          "description": "Indicates if partial scoring should be used",
-          "type": "boolean",
-          "title": "partialScoring"
-        },
         "prompt": {
           "description": "The question prompt or item stem",
           "type": "string",
@@ -187,15 +168,6 @@
           "description": "Indicates if the prompt is enabled",
           "type": "boolean",
           "title": "promptEnabled"
-        },
-        "scoringType": {
-          "description": "Indicates scoring type",
-          "enum": [
-            "auto",
-            "rubric"
-          ],
-          "type": "string",
-          "title": "scoringType"
         },
         "studentInstructions": {
           "description": "Indicates student instructions",
@@ -252,6 +224,20 @@
       ],
       "type": "string",
       "title": "partLabelType"
+    },
+    "partialScoring": {
+      "description": "Indicates if partial scoring should be used",
+      "type": "boolean",
+      "title": "partialScoring"
+    },
+    "scoringType": {
+      "description": "Indicates scoring type",
+      "enum": [
+        "auto",
+        "rubric"
+      ],
+      "type": "string",
+      "title": "scoringType"
     },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
@@ -373,22 +359,6 @@
             }
           }
         },
-        "partialScoring": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
         "prompt": {
           "title": "ConfigureProp",
           "type": "object",
@@ -406,22 +376,6 @@
           }
         },
         "rationale": {
-          "title": "ConfigureProp",
-          "type": "object",
-          "properties": {
-            "settings": {
-              "description": "Indicates if the item has to be displayed in the Settings Panel",
-              "type": "boolean",
-              "title": "settings"
-            },
-            "label": {
-              "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
-              "type": "string",
-              "title": "label"
-            }
-          }
-        },
-        "scoringType": {
           "title": "ConfigureProp",
           "type": "object",
           "properties": {
@@ -539,11 +493,6 @@
           "type": "string",
           "title": "choicePrefix"
         },
-        "partialScoring": {
-          "description": "Indicates if partial scoring should be used",
-          "type": "boolean",
-          "title": "partialScoring"
-        },
         "prompt": {
           "description": "The question prompt or item stem",
           "type": "string",
@@ -553,15 +502,6 @@
           "description": "Indicates if the prompt is enabled",
           "type": "boolean",
           "title": "promptEnabled"
-        },
-        "scoringType": {
-          "description": "Indicates scoring type",
-          "enum": [
-            "auto",
-            "rubric"
-          ],
-          "type": "string",
-          "title": "scoringType"
         },
         "studentInstructions": {
           "description": "Indicates student instructions",

--- a/packages/ebsr/docs/pie-schema.json.md
+++ b/packages/ebsr/docs/pie-schema.json.md
@@ -44,10 +44,6 @@ This element must be one of the following enum values:
 * `letters`
 * `numbers`
 
-## `partialScoring` (boolean)
-
-Indicates if partial scoring should be used
-
 ## `prompt` (string, required)
 
 The question prompt or item stem
@@ -55,15 +51,6 @@ The question prompt or item stem
 ## `promptEnabled` (boolean)
 
 Indicates if the prompt is enabled
-
-## `scoringType` (string, enum)
-
-Indicates scoring type
-
-This element must be one of the following enum values:
-
-* `auto`
-* `rubric`
 
 ## `studentInstructions` (string)
 
@@ -131,10 +118,6 @@ This element must be one of the following enum values:
 * `letters`
 * `numbers`
 
-## `partialScoring` (boolean)
-
-Indicates if partial scoring should be used
-
 ## `prompt` (string, required)
 
 The question prompt or item stem
@@ -142,15 +125,6 @@ The question prompt or item stem
 ## `promptEnabled` (boolean)
 
 Indicates if the prompt is enabled
-
-## `scoringType` (string, enum)
-
-Indicates scoring type
-
-This element must be one of the following enum values:
-
-* `auto`
-* `rubric`
 
 ## `studentInstructions` (string)
 
@@ -188,6 +162,19 @@ This element must be one of the following enum values:
 
 * `Letters`
 * `Numbers`
+
+# `partialScoring` (boolean)
+
+Indicates if partial scoring should be used
+
+# `scoringType` (string, enum)
+
+Indicates scoring type
+
+This element must be one of the following enum values:
+
+* `auto`
+* `rubric`
 
 # `id` (string, required)
 
@@ -279,18 +266,6 @@ Indicates if the item has to be displayed in the Settings Panel
 
 Indicates the label for the item that has to be displayed in the Settings Panel
 
-### `partialScoring` (object)
-
-Properties of the `partialScoring` object:
-
-#### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-#### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
 ### `prompt` (object)
 
 Properties of the `prompt` object:
@@ -306,18 +281,6 @@ Indicates the label for the item that has to be displayed in the Settings Panel
 ### `rationale` (object)
 
 Properties of the `rationale` object:
-
-#### `settings` (boolean)
-
-Indicates if the item has to be displayed in the Settings Panel
-
-#### `label` (string)
-
-Indicates the label for the item that has to be displayed in the Settings Panel
-
-### `scoringType` (object)
-
-Properties of the `scoringType` object:
 
 #### `settings` (boolean)
 
@@ -405,10 +368,6 @@ This element must be one of the following enum values:
 * `letters`
 * `numbers`
 
-### `partialScoring` (boolean)
-
-Indicates if partial scoring should be used
-
 ### `prompt` (string, required)
 
 The question prompt or item stem
@@ -416,15 +375,6 @@ The question prompt or item stem
 ### `promptEnabled` (boolean)
 
 Indicates if the prompt is enabled
-
-### `scoringType` (string, enum)
-
-Indicates scoring type
-
-This element must be one of the following enum values:
-
-* `auto`
-* `rubric`
 
 ### `studentInstructions` (string)
 

--- a/packages/pie-models/src/pie/ebsr/index.ts
+++ b/packages/pie-models/src/pie/ebsr/index.ts
@@ -23,17 +23,11 @@ export interface Part {
     /** What key should be displayed before choices.  */
     choicePrefix: 'letters' | 'numbers';
 
-    /** Indicates if partial scoring should be used */
-    partialScoring?: boolean;
-
     /**  The question prompt or item stem */
     prompt: string;
 
     /**  Indicates if the prompt is enabled */
     promptEnabled?: boolean;
-
-    /** Indicates scoring type */
-    scoringType?: 'auto' | 'rubric';
 
     /** Indicates student instructions */
     studentInstructions?: string;
@@ -75,6 +69,12 @@ export interface EbsrPie extends PieModel {
 
     /** Indicates what type should have part labels if they are enabled */
     partLabelType: 'Letters' | 'Numbers';
+
+    /** Indicates if partial scoring should be used */
+    partialScoring?: boolean;
+
+    /** Indicates scoring type */
+    scoringType?: 'auto' | 'rubric';
 }
 
 interface PartConfiguration {
@@ -110,11 +110,6 @@ interface PartConfiguration {
     lockChoiceOrder?: ConfigureProp;
 
     /**
-     * Indicates whether the settings panel wil allow the author to modify settings for partial scoring
-     */
-    partialScoring?: ConfigureProp;
-
-    /**
      * Indicates whether the Edit prompt input should be displayed
      */
     prompt?: ConfigureProp;
@@ -123,11 +118,6 @@ interface PartConfiguration {
      * Rationale configuration
      */
     rationale?: ConfigureProp;
-
-    /**
-     * Indicates whether the Scoring type option should be displayed
-     */
-    scoringType?: ConfigureProp;
 
     /**
      * Student Instructions configuration
@@ -159,4 +149,14 @@ export interface EbsrConfigure extends PromptConfig {
      * Part labels (Configuration for both parts)
      */
     partLabels?: ConfigureProp;
+
+    /**
+     * Indicates whether the settings panel wil allow the author to modify settings for partial scoring
+     */
+    partialScoring?: ConfigureProp;
+
+    /**
+     * Indicates whether the Scoring type option should be displayed
+     */
+    scoringType?: ConfigureProp;
 }


### PR DESCRIPTION
fix for Dichotomous scoring type: EBSR should be scored as 1/1 if both parts are correct, and as 0/1 if either part is wrong.

BREAKING CHANGE: replaced `model.partA.partialScoring` and `model.partB.partialScoring` with `model.partialScoring`, replaced `model.partA.scoringType` and `model.partB.scoringType` with `model.scoringType`, replaced `configuration.partA.partialScoring` and `configuration.partB.partialScoring` with `configuration.partialScoring`, replaced `configuration.partA.scoringType` and `configuration.partB.scoringType` with `configuration.scoringType`
feat: ch4719: Scoring settings for EBSR are not correct (partial scoring).

Updated docs.