### PR TITLE
fix: Toolbar visible only on focus - PD-142.

### DIFF
--- a/packages/drag-in-the-blank/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/drag-in-the-blank/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -134,7 +134,6 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
         }
         toolbarOpts={
           Object {
-            "alwaysVisible": true,
             "position": "top",
           }
         }
@@ -310,7 +309,6 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
         }
         toolbarOpts={
           Object {
-            "alwaysVisible": true,
             "position": "top",
           }
         }

--- a/packages/drag-in-the-blank/configure/src/main.jsx
+++ b/packages/drag-in-the-blank/configure/src/main.jsx
@@ -217,10 +217,7 @@ export class Main extends React.Component {
             </Typography>
             <EditableHtml
               activePlugins={ALL_PLUGINS}
-              toolbarOpts={{
-                position: 'top',
-                alwaysVisible: true
-              }}
+              toolbarOpts={{ position: 'top' }}
               responseAreaProps={{
                 type: 'drag-in-the-blank',
                 options: {

--- a/packages/explicit-constructed-response/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/explicit-constructed-response/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -131,7 +131,6 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
         }
         toolbarOpts={
           Object {
-            "alwaysVisible": true,
             "position": "top",
           }
         }
@@ -317,7 +316,6 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
         }
         toolbarOpts={
           Object {
-            "alwaysVisible": true,
             "position": "top",
           }
         }

--- a/packages/explicit-constructed-response/configure/src/main.jsx
+++ b/packages/explicit-constructed-response/configure/src/main.jsx
@@ -262,10 +262,7 @@ export class Main extends React.Component {
             </Typography>
             <EditableHtml
               activePlugins={ALL_PLUGINS}
-              toolbarOpts={{
-                position: 'top',
-                alwaysVisible: true
-              }}
+              toolbarOpts={{ position: 'top' }}
               responseAreaProps={{
                 type: 'explicit-constructed-response',
                 options: {

--- a/packages/inline-dropdown/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/inline-dropdown/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -169,7 +169,6 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
         }
         toolbarOpts={
           Object {
-            "alwaysVisible": true,
             "position": "top",
           }
         }
@@ -321,7 +320,6 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
         }
         toolbarOpts={
           Object {
-            "alwaysVisible": true,
             "position": "top",
           }
         }

--- a/packages/inline-dropdown/configure/src/main.jsx
+++ b/packages/inline-dropdown/configure/src/main.jsx
@@ -418,10 +418,7 @@ export class Main extends React.Component {
             />
             <EditableHtml
               activePlugins={ALL_PLUGINS}
-              toolbarOpts={{
-                position: 'top',
-                alwaysVisible: true
-              }}
+              toolbarOpts={{ position: 'top' }}
               responseAreaProps={{
                 type: 'inline-dropdown',
                 options: {


### PR DESCRIPTION
The response template formatting toolbar should behave like other PIE formatting toolbars: it should appear only when the field with which it is associated has focus. This applies to the following item types: explicit-constructed-response, inline-dropdown, drag-in-the-blank.
PD-142.