### PR TITLE
fix: Multiple Select should report a question as "answered" as soon as a selection has been made PD-253

### DIFF
--- a/packages/multiple-choice/controller/src/__tests__/index.test.js
+++ b/packages/multiple-choice/controller/src/__tests__/index.test.js
@@ -68,10 +68,6 @@ describe('controller', () => {
         expect(result.keyMode).toEqual('letters');
       });
 
-      it('returns complete', () => {
-        expect(result.complete).toEqual({ min: 1 });
-      });
-
       it('returns choices', () => {
         expect(result.choices).toEqual(
           expect.arrayContaining([

--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -73,11 +73,6 @@ export async function model(question, session, env, updateSession) {
     keyMode: normalizedQuestion.choicePrefix,
     shuffle: !normalizedQuestion.lockChoiceOrder,
     choices,
-
-    //TODO: ok to return this in gather mode? gives a clue to how many answers are needed?
-    complete: {
-      min: normalizedQuestion.choices ? normalizedQuestion.choices.filter(c => c.correct).length : 0
-    },
     responseCorrect:
       env.mode === 'evaluate' ? isResponseCorrect(normalizedQuestion, session) : undefined
   };


### PR DESCRIPTION
Remove unintended clue about how many answer choices are correct.
This requires update of pie-ui/multiple-choice after PR is merged: https://github.com/pie-framework/pie-ui/pull/207
 PD-253