### PR TITLE
fix: In LP, erroneous score data being returned for some ECRs. PD-570

### DIFF
--- a/packages/explicit-constructed-response/controller/src/index.js
+++ b/packages/explicit-constructed-response/controller/src/index.js
@@ -142,16 +142,17 @@ export const getScore = (config, session) => {
     return 0;
   }
 
-  const maxScore = Object.keys(config.choices).length;
+  const responseAreas = config.markup && config.markup.match(/\{\{(.)\}\}/g);
+  const maxScore = responseAreas ? responseAreas.length : 0;
   const correctCount = reduce(config.choices, (total, respArea, key) => {
     const chosenValue = value && value[key];
 
     if (isEmpty(chosenValue) || !find(respArea, c => prepareVal(c.label) === prepareVal(chosenValue))) {
-      return total - 1;
+      return total;
     }
 
-    return total;
-  }, maxScore);
+    return total + 1;
+  }, 0);
 
   const str = maxScore ? (correctCount / maxScore).toFixed(2) : 0;
 


### PR DESCRIPTION
(Use rsponseAreas to determine the max score instead of choices number).