### PR TITLE
PD-338: feat(markup): made sure brs are not removed anymore since they are handled in editable html

### DIFF
--- a/packages/explicit-constructed-response/configure/src/__tests__/markupUtils.test.jsx
+++ b/packages/explicit-constructed-response/configure/src/__tests__/markupUtils.test.jsx
@@ -24,10 +24,6 @@ describe('markupUtils', () => {
       expect(removeUnwantedCharacters('<div>foo\/bar</div>')).toEqual('<div>foo/bar</div>');
     });
 
-    it('should remove <br> and </br> tags', () => {
-      expect(removeUnwantedCharacters('<div>foo</br><br>bar</div>')).toEqual('<div>foobar</div>');
-    });
-
   });
 
   describe('processMarkup', () => {

--- a/packages/explicit-constructed-response/configure/src/__tests__/utils.test.js
+++ b/packages/explicit-constructed-response/configure/src/__tests__/utils.test.js
@@ -45,11 +45,6 @@ describe('processMarkup', () => {
     '<div> \/foobar </div>',
     '<div> /foobar </div>',
     'should replace \/ with / in the string');
-
-  assertProcessMarkup(
-    '<div> <br><br> </br> </div>',
-    '<div>   </div>',
-    'should remove <br> or </br> elements from the string');
 });
 
 describe('createSlateMarkup', () => {
@@ -106,9 +101,4 @@ describe('createSlateMarkup', () => {
     '<div> \/foobar </div>',
     '<div> /foobar </div>',
     'should replace \/ with / in the string');
-
-  assertCreateSlateMarkup(
-    '<div> <br><br> </br> </div>',
-    '<div>   </div>',
-    'should remove <br> or </br> elements from the string');
 });

--- a/packages/explicit-constructed-response/configure/src/markupUtils.js
+++ b/packages/explicit-constructed-response/configure/src/markupUtils.js
@@ -3,9 +3,7 @@ import escape from 'lodash/escape';
 export const removeUnwantedCharacters = markup =>
   markup
     .replace(/(\t)|(\n)|(\\t)|(\\n)/g, '')
-    .replace(/\\"/g, '"').replace(/\\\//g, '/')
-    // <br> causes an infinite normalizing in editable-html for some reason
-    .replace(/(<br>)|(<\/br>)/g, '');
+    .replace(/\\"/g, '"').replace(/\\\//g, '/');
 
 const createElementFromHTML = (htmlString = '') => {
   const div = document.createElement('div');

--- a/packages/explicit-constructed-response/docs/demo/generate.js
+++ b/packages/explicit-constructed-response/docs/demo/generate.js
@@ -1,6 +1,6 @@
 const choice = (l, v) => ({ label: l, value: v });
 
-const markup = '<p>The {{0}} jumped {{1}} the {{2}}</p>';
+const markup = '<p>The {{0}} <br> jumped {{1}} <br> the {{2}}</p>';
 
 exports.model = (id, element) => ({
   id,


### PR DESCRIPTION
PD-338: feat(markup): made sure brs are not removed anymore since they are handled in editable html