### PR TITLE
fix: modified regex to handle multiplication symbol issue PD-367

### DIFF
--- a/packages/explicit-constructed-response/configure/src/__tests__/markupUtils.test.jsx
+++ b/packages/explicit-constructed-response/configure/src/__tests__/markupUtils.test.jsx
@@ -24,6 +24,15 @@ describe('markupUtils', () => {
       expect(removeUnwantedCharacters('<div>foo\/bar</div>')).toEqual('<div>foo/bar</div>');
     });
 
+    it('should remove <br> and </br> tags', () => {
+      expect(removeUnwantedCharacters('<div>foo</br><br>bar</div>')).toEqual('<div>foobar</div>');
+    });
+
+    it('should not remove \\t character which has latex like \\times', () => {
+      expect(removeUnwantedCharacters('<div><span data-latex=\"\" data-raw=\"3\\times3\\div2\">3\\times3\\div2</span></div>'))
+      .toEqual("<div><span data-latex=\"\" data-raw=\"3\\times3\\div2\">3\\times3\\div2</span></div>");
+    });
+
   });
 
   describe('processMarkup', () => {

--- a/packages/explicit-constructed-response/configure/src/markupUtils.js
+++ b/packages/explicit-constructed-response/configure/src/markupUtils.js
@@ -2,7 +2,7 @@ import escape from 'lodash/escape';
 
 export const removeUnwantedCharacters = markup =>
   markup
-    .replace(/(\t)|(\n)|(\\t)|(\\n)/g, '')
+    .replace(/(\t+(?!imes))|(\n)|(\\t+(?!imes))|(\\n)/g, '')
     .replace(/\\"/g, '"').replace(/\\\//g, '/');
 
 const createElementFromHTML = (htmlString = '') => {


### PR DESCRIPTION
1. Added a fix for regex where \\t won't get removed for \\times, which is required for multiplication symbol.