### PR TITLE
fix(math-inline): don't include rationale and teacher instructions in the item configuration for student gather - PD-810

### DIFF
--- a/packages/math-inline/controller/src/__tests__/index.test.jsx
+++ b/packages/math-inline/controller/src/__tests__/index.test.jsx
@@ -54,6 +54,14 @@ describe('model', () => {
     it('returns empty array for responses', () => {
       expect(result.config.responses).toEqual([]);
     });
+
+    it('returns null for rationale', () => {
+      expect(result.config.rationale).toEqual(null);
+    });
+
+    it('returns null for teacher instructions', () => {
+      expect(result.config.teacherInstructions).toEqual(null);
+    });
   });
 
   describe('view', () => {
@@ -974,7 +982,7 @@ describe('PD-610', () => {
     expect(result).toEqual({ score: 1 });
   });
 
-  
+
   it('scores 0', async () => {
     const session = {
       id: '1',
@@ -1024,7 +1032,7 @@ describe('PD-610', () => {
     expect(result).toEqual({ score: 1 });
   });
 
-  
+
   it('scores 0', async () => {
     const session = {
       id: '2',

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -311,6 +311,8 @@ export function model(question, session, env) {
       } else {
         out.rationale = null;
         out.teacherInstructions = null;
+        out.config.rationale = null;
+        out.config.teacherInstructions = null;
       }
 
       out.config.prompt = normalizedQuestion.promptEnabled


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-810