### PR TITLE
PD-1002 fix: Shuffle choices only if user is in gather mode. (at evaluate, at least, the order is important)

### DIFF
--- a/packages/placement-ordering/controller/src/index.js
+++ b/packages/placement-ordering/controller/src/index.js
@@ -78,7 +78,7 @@ export function model(question, session, env, updateSession) {
 
     const lockChoiceOrder = lockChoices(normalizedQuestion, session, env);
 
-    if (!lockChoiceOrder) {
+    if (!lockChoiceOrder && env.mode === 'gather') {
       choices = await getShuffledChoices(
         choices,
         session,


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1002