### PR TITLE
fix: If a Number Line element has no correct answer, Evaluate mode should just show the student's response without any markup PD-1012

### DIFF
--- a/packages/number-line/controller/src/__tests__/index.test.js
+++ b/packages/number-line/controller/src/__tests__/index.test.js
@@ -443,4 +443,52 @@ describe('controller', () => {
       expect(noResult).toBeNull();
     });
   });
+
+  describe('getCorrectness', () => {
+    const item = {
+      'type': 'point',
+      'pointType': 'full',
+      'domainPosition': 0.5
+    };
+
+    test.each([
+      [{ noCorrectResponse: true }, 'unknown'],
+      [{ incorrect: [], correct: [] }, 'unanswered'],
+      [{ incorrect: [], notInAnswer: [], correct: [item] }, 'correct'],
+      [{ incorrect: [item], notInAnswer: [], correct: [] }, 'incorrect'],
+      [{ incorrect: [], notInAnswer: [item], correct: [item] }, 'partial']
+    ])('%j -> %s', (corrected, expected) => {
+        const correctness = controller.getCorrectness(corrected);
+
+        expect(correctness).toEqual(expected);
+      }
+    );
+  });
+
+  describe('getCorrected', () => {
+    const defaultCorrected = {
+      correct: [],
+      incorrect: [],
+      notInAnswer: [],
+    };
+    const noCorrectResponse = {
+      ...defaultCorrected,
+      noCorrectResponse: true
+    };
+    const answer = {
+      'type': 'point',
+      'pointType': 'full',
+      'domainPosition': 0.5
+    };
+
+    test.each([
+      [[answer], [], noCorrectResponse],
+      [[], [], defaultCorrected],
+    ])('%j, %j -> %s', (answer, correctResponse, expected) => {
+        const correctness = controller.getCorrected(answer, correctResponse);
+
+        expect(correctness).toEqual(expected);
+      }
+    );
+  });
 });

--- a/packages/number-line/controller/src/index.js
+++ b/packages/number-line/controller/src/index.js
@@ -33,6 +33,7 @@ const accumulateAnswer = correctResponse => (total, answer) => {
   const isCorrectResponse = correctResponse.some(cr => matches(cr)(answer));
   return total + (isCorrectResponse ? 1 : -1);
 };
+
 /**
  */
 export function outcome(model, session, env) {
@@ -47,6 +48,7 @@ export function outcome(model, session, env) {
       );
       const total = model.correctResponse.length;
       const score = numCorrect < 0 ? 0 : numCorrect / total;
+
       resolve({ score: partialScoringEnabled ? score : score === 1 ? 1 : 0 });
     }
   });
@@ -104,7 +106,16 @@ const matches = a => v => {
   });
 };
 
-const getCorrected = (answer, correctResponse) => {
+export const getCorrected = (answer, correctResponse) => {
+  if (isEmpty(correctResponse) && answer.length > 0) {
+    return {
+      correct: [],
+      incorrect: [],
+      notInAnswer: [],
+      noCorrectResponse: true
+    };
+  }
+
   return answer.reduce(
     (acc, a, index) => {
       const { correct, incorrect, notInAnswer } = acc;
@@ -131,8 +142,12 @@ const getCorrected = (answer, correctResponse) => {
   );
 };
 
-const getCorrectness = corrected => {
-  const { incorrect, correct, notInAnswer } = corrected;
+export const getCorrectness = corrected => {
+  const { incorrect, correct, notInAnswer, noCorrectResponse } = corrected;
+
+  if (noCorrectResponse) {
+    return 'unknown';
+  }
 
   if (incorrect.length === 0 && correct.length === 0) {
     return 'unanswered';
@@ -258,7 +273,7 @@ export const createCorrectResponseSession = (question, env) => {
         answer,
         id: '1'
       });
-    } else  {
+    } else {
       resolve(null);
     }
   });

--- a/packages/number-line/src/number-line/index.jsx
+++ b/packages/number-line/src/number-line/index.jsx
@@ -224,7 +224,7 @@ export class NumberLine extends React.Component {
         <div>
           <div style={{ width: adjustedWidth }}>
             <Toggle
-              show={isArray(model.correctResponse) && !model.emptyAnswer}
+              show={isArray(model.correctResponse) && model.correctResponse.length && !model.emptyAnswer}
               toggled={showCorrectAnswer}
               onToggle={onShowCorrectAnswer}
               initialValue={false}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1012