### PR TITLE
fix: Do not set session.value if placementArea is true.

### DIFF
--- a/packages/placement-ordering/controller/src/__tests__/index.test.js
+++ b/packages/placement-ordering/controller/src/__tests__/index.test.js
@@ -228,6 +228,40 @@ describe('index', () => {
         expect(noResult).toBeNull();
       });
     });
+
+    describe('session', () => {
+      const choices = [
+        { id: '1', label: 'a' },
+        { id: '2', label: 'b' }
+      ];
+      const env = { mode: 'gather' };
+      const updateSession = jest.fn();
+
+      it('sets session value if no placementArea', async () => {
+        const question = base({
+          choices,
+          lockChoiceOrder: false
+        });
+        const session = {};
+
+        await controller.model(question, session, env, updateSession);
+
+        expect(session.value.sort()).toEqual(['1', '2']);
+      });
+
+      it('does not set session value if placementArea = true', async () => {
+        const question = base({
+          choices,
+          lockChoiceOrder: false,
+          placementArea: true
+        });
+        const session = {};
+
+        await controller.model(question, session, env, updateSession);
+
+        expect(session.value).toBeUndefined();
+      });
+    });
   });
 
   describe('outcome', () => {

--- a/packages/placement-ordering/controller/src/index.js
+++ b/packages/placement-ordering/controller/src/index.js
@@ -87,7 +87,7 @@ export function model(question, session, env, updateSession) {
         'label'
       );
 
-      if (!session.shuffledValues) {
+      if (!session.shuffledValues && !normalizedQuestion.placementArea) {
           session.value = choices.map(m => m.id);
       }
     }

--- a/packages/placement-ordering/docs/demo/generate.js
+++ b/packages/placement-ordering/docs/demo/generate.js
@@ -46,7 +46,7 @@ exports.model = (id, element) => ({
   numberedGuides: false,
   orientation: 'vertical',
   partialScoring: false,
-  placementArea: false,
+  placementArea: true,
   scoringType: 'auto',
   targetLabel: 'Answers',
 });

--- a/packages/placement-ordering/docs/demo/session.js
+++ b/packages/placement-ordering/docs/demo/session.js
@@ -2,6 +2,6 @@ module.exports = [
   {
     id: '1',
     element: 'placement-ordering',
-    // value: ['c4', 'c1', 'c2', 'c3']
+    value: [undefined, 'c1', 'c2', undefined]
   }
 ];


### PR DESCRIPTION
https://user-images.githubusercontent.com/20281464/111593720-ea606580-87d2-11eb-9a66-ff3b26b31294.mov


https://user-images.githubusercontent.com/20281464/111593955-2abfe380-87d3-11eb-997c-40ed23b8fe69.mov

As you can see, previously, the session.value was always being set for placementArea: true.
Since that is incorrect, I removed it (only for placementArea: true)