### PR TITLE
fix: Instead of resetting the entire session object, update its properties.

### DIFF
--- a/packages/math-inline/docs/demo/generate.js
+++ b/packages/math-inline/docs/demo/generate.js
@@ -1,6 +1,4 @@
-exports.model = (id, element) => ({
-  id,
-  element,
+const initialModel = {
   customKeys: [],
   equationEditor: 'geometry',
   responseType: 'Advanced Multi',
@@ -16,4 +14,26 @@ exports.model = (id, element) => ({
   ],
   rationale:
     '<p>The correct answer is:</p><ul><li><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>r</mi><mo>=</mo><msqrt><mfrac><mi>V</mi><mrow><mn>7</mn><mi>&#960;</mi></mrow></mfrac></msqrt></math></li></ul>',
+}
+
+const E262456 = {
+  'equationEditor': 3,
+  'prompt': '<p><strong>B.</strong> Find the value of the expression that you wrote in part A to find how much money the band members made.</p>\n\n<p>Use the on-screen keyboard to type your answer in the box below.</p>\n',
+  'expression': '${{response}}',
+  'responses': [
+    {
+      'allowSpaces': true,
+      'validation': 'symbolic',
+      'answer': '$410',
+      'id': '1'
+    }
+  ],
+  'responseType': 'Advanced Multi'
+}
+
+
+exports.model = (id, element) => ({
+  id,
+  element,
+  ...E262456
 });

--- a/packages/math-inline/docs/demo/session.js
+++ b/packages/math-inline/docs/demo/session.js
@@ -2,10 +2,10 @@ module.exports = [
   {
     id: '1',
     element: 'math-inline',
-    answers: {
-      r1: { value: '72\\div12' },
-      r2: { value: '2' }
-    },
-    completeAnswer: '72\\div12=6'
+    // answers: {
+    //   r1: { value: '72\\div12' },
+    //   r2: { value: '2' }
+    // },
+    // completeAnswer: '72\\div12=6',
   }
 ];

--- a/packages/math-inline/src/index.js
+++ b/packages/math-inline/src/index.js
@@ -40,7 +40,10 @@ export default class MathInline extends HTMLElement {
   }
 
   sessionChanged(s) {
-    this._session = s;
+    Object.keys(s).map(key => {
+      this._session[key] = s[key];
+    });
+
     this.sessionChangedEventCaller(this._session);
     log('session: ', this._session);
   }


### PR DESCRIPTION
Apparently, math-inline **doesn't update the session object, but replaces it** with an entirely new object (different address).
Because of this, the _session in catalog-demo does not get updated (check video):




https://user-images.githubusercontent.com/20281464/111614514-5a2d1b00-87e8-11eb-9f45-713aec98b272.mov




In order to fix this, I'm just updating session properties, without updating the entire object:





https://user-images.githubusercontent.com/20281464/111615071-ffe08a00-87e8-11eb-8629-982f262cce8c.mov

Issue found while investigating https://illuminate.atlassian.net/browse/PD-385