### PR TITLE
fix(math-inline): fix session value setting

### DIFF
--- a/packages/math-inline/src/index.js
+++ b/packages/math-inline/src/index.js
@@ -40,7 +40,9 @@ export default class MathInline extends HTMLElement {
   }
 
   sessionChanged(s) {
-    this._session = s;
+    this._session.answers = s.answers;
+    this._session.response = s.response;
+    this._session.completeAnswer = s.completeAnswer;
     this.sessionChangedEventCaller(this._session);
     log('session: ', this._session);
   }


### PR DESCRIPTION
Since the reference was being overwritten entirely, it was freaking out - session was losing values and updates weren't being passed on.