### PR TITLE
feat(placement-ordering): remove lockChoiceOrder from model and authoring PD-351

### DIFF
--- a/packages/placement-ordering/configure/src/__tests__/__snapshots__/design.test.jsx.snap
+++ b/packages/placement-ordering/configure/src/__tests__/__snapshots__/design.test.jsx.snap
@@ -24,10 +24,6 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
             "label": "Feedback",
             "settings": true,
           },
-          "lockChoiceOrder": Object {
-            "label": "Lock Choice Order",
-            "settings": true,
-          },
           "numberedGuides": Object {
             "label": "Numbered guides",
             "settings": true,
@@ -87,7 +83,6 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
             "choiceLabel.enabled": undefined,
             "enableImages": undefined,
             "feedbackEnabled": undefined,
-            "lockChoiceOrder": undefined,
             "numberedGuides": false,
             "orientation": undefined,
             "partialScoring": false,
@@ -103,7 +98,6 @@ exports[`Placement Ordering snapshot renders all default items 1`] = `
           "correctResponse": Array [],
           "enableImages": false,
           "feedbackEnabled": true,
-          "lockChoiceOrder": false,
           "numberedGuides": false,
           "orientation": "vertical",
           "partialScoring": true,
@@ -206,10 +200,6 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
             "label": "Feedback",
             "settings": true,
           },
-          "lockChoiceOrder": Object {
-            "label": "Lock Choice Order",
-            "settings": true,
-          },
           "numberedGuides": Object {
             "label": "Numbered guides",
             "settings": true,
@@ -269,7 +259,6 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
             "choiceLabel.enabled": undefined,
             "enableImages": undefined,
             "feedbackEnabled": undefined,
-            "lockChoiceOrder": undefined,
             "numberedGuides": false,
             "orientation": undefined,
             "partialScoring": false,
@@ -285,7 +274,6 @@ exports[`Placement Ordering snapshot renders custom items 1`] = `
           "correctResponse": Array [],
           "enableImages": false,
           "feedbackEnabled": true,
-          "lockChoiceOrder": false,
           "numberedGuides": false,
           "orientation": "vertical",
           "partialScoring": true,

--- a/packages/placement-ordering/configure/src/defaults.js
+++ b/packages/placement-ordering/configure/src/defaults.js
@@ -10,7 +10,6 @@ export default {
     correctResponse: [],
     enableImages: false,
     prompt: 'Item Stem goes here',
-    lockChoiceOrder: false,
     numberedGuides: false,
     orientation: 'vertical',
     partialScoring: true,
@@ -46,10 +45,6 @@ export default {
     prompt: {
       settings: true,
       label: 'Item Stem'
-    },
-    lockChoiceOrder: {
-      settings: true,
-      label: 'Lock Choice Order'
     },
     numberedGuides: {
       settings: true,

--- a/packages/placement-ordering/configure/src/design.jsx
+++ b/packages/placement-ordering/configure/src/design.jsx
@@ -91,8 +91,6 @@ export class Design extends React.Component {
       orientation = {},
       removeTilesAfterPlacing = {},
       partialScoring = {},
-      lockChoiceOrder = {},
-
       teacherInstructions = {},
       studentInstructions = {},
       rationale = {},
@@ -131,8 +129,6 @@ export class Design extends React.Component {
                   toggle(removeTilesAfterPlacing.label),
                 partialScoring:
                   partialScoring.settings && toggle(partialScoring.label),
-                lockChoiceOrder:
-                  lockChoiceOrder.settings && toggle(lockChoiceOrder.label),
                 feedbackEnabled:
                   feedback.settings && toggle(feedback.label)
               },

--- a/packages/placement-ordering/controller/src/__tests__/index.test.js
+++ b/packages/placement-ordering/controller/src/__tests__/index.test.js
@@ -9,7 +9,6 @@ describe('index', () => {
         promptEnabled: true,
         choices: [],
         correctResponse: [],
-        lockChoiceOrder: true,
         feedbackEnabled: true,
       },
       o
@@ -164,24 +163,6 @@ describe('index', () => {
       );
     });
 
-    describe('model - with updateSession', () => {
-      it('calls updateSession', async () => {
-        const session = { id: '1', element: 'placement-ordering' };
-        const env = { mode: 'gather' };
-        const question = base({
-          choices: [
-            { label: 'a', id: 'a' },
-            { label: 'b', id: 'b' },
-            { label: 'c', id: 'c' },
-          ],
-          lockChoiceOrder: false,
-        });
-        const updateSession = jest.fn().mockResolvedValue();
-        await controller.model(question, session, env, updateSession);
-        expect(updateSession).toHaveBeenCalled();
-      });
-    });
-
     describe('session not set', () => {
       const assertModelCorrectness = (session) => {
         it(`returns correctness: incorrect of session is ${JSON.stringify(
@@ -235,16 +216,14 @@ describe('index', () => {
         { id: '2', label: 'b' }
       ];
       const env = { mode: 'gather' };
-      const updateSession = jest.fn();
 
       it('sets session value if no placementArea', async () => {
         const question = base({
-          choices,
-          lockChoiceOrder: false
+          choices
         });
         const session = {};
 
-        await controller.model(question, session, env, updateSession);
+        await controller.model(question, session, env);
 
         expect(session.value.sort()).toEqual(['1', '2']);
       });
@@ -252,12 +231,11 @@ describe('index', () => {
       it('does not set session value if placementArea = true', async () => {
         const question = base({
           choices,
-          lockChoiceOrder: false,
           placementArea: true
         });
         const session = {};
 
-        await controller.model(question, session, env, updateSession);
+        await controller.model(question, session, env);
 
         expect(session.value).toBeUndefined();
       });

--- a/packages/placement-ordering/controller/src/defaults.js
+++ b/packages/placement-ordering/controller/src/defaults.js
@@ -4,7 +4,6 @@ export default {
   correctResponse: [],
   enableImages: false,
   prompt: 'Item Stem goes here',
-  lockChoiceOrder: false,
   numberedGuides: false,
   orientation: 'vertical',
   partialScoring: true,

--- a/packages/placement-ordering/controller/src/index.js
+++ b/packages/placement-ordering/controller/src/index.js
@@ -2,7 +2,7 @@ import { flattenCorrect, getAllCorrectResponses, score } from './scoring';
 
 import _ from 'lodash';
 import { getFeedbackForCorrectness } from '@pie-lib/feedback';
-import { lockChoices, getShuffledChoices, partialScoring } from '@pie-lib/controller-utils';
+import { partialScoring } from '@pie-lib/controller-utils';
 import debug from 'debug';
 
 import defaults from './defaults';
@@ -66,33 +66,19 @@ export const normalize = question => ({
  * @param {*} question
  * @param {*} session
  * @param {*} env
- * @param {*} updateSession - optional - a function that will set the properties passed into it on the session.
  */
-export function model(question, session, env, updateSession) {
+export function model(question, session, env) {
   return new Promise(async resolve => {
     const normalizedQuestion = normalize(question);
     const base = {};
-    let choices = normalizedQuestion.choices;
 
     base.outcomes = [];
     base.completeLength = (normalizedQuestion.correctResponse || []).length;
+    base.choices = normalizedQuestion.choices;
 
-    const lockChoiceOrder = lockChoices(normalizedQuestion, session, env);
-
-    if (!lockChoiceOrder && env.mode === 'gather') {
-      choices = await getShuffledChoices(
-        choices,
-        session,
-        updateSession,
-        'label'
-      );
-
-      if (!session.shuffledValues && !normalizedQuestion.placementArea) {
-          session.value = choices.map(m => m.id);
-      }
+    if (env.mode === 'gather' && !normalizedQuestion.placementArea) {
+      session.value = base.choices.map(m => m.id);
     }
-
-    base.choices = choices;
 
     log('[model] removing tileSize for the moment.');
 

--- a/packages/placement-ordering/docs/demo/generate.js
+++ b/packages/placement-ordering/docs/demo/generate.js
@@ -42,7 +42,6 @@ exports.model = (id, element) => ({
   feedbackEnabled: true,
   prompt: 'Arrange the fruits alphabetically',
   promptEnabled: true,
-  lockChoiceOrder: false,
   numberedGuides: false,
   orientation: 'vertical',
   partialScoring: false,


### PR DESCRIPTION
For Placement Ordering, remove the lockChoiceOrder setting from the model and authoring
https://illuminate.atlassian.net/browse/PD-351