### PR TITLE
feat(drawing-response) : added option for toolbar editor position

### DIFF
--- a/packages/drawing-response/configure/src/__tests__/__snapshots__/root.test.jsx.snap
+++ b/packages/drawing-response/configure/src/__tests__/__snapshots__/root.test.jsx.snap
@@ -56,6 +56,11 @@ exports[`Root snapshot renders 1`] = `
         <EditableHtml
           markup="Test Prompt"
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </Component>
       <div>

--- a/packages/drawing-response/configure/src/defaults.js
+++ b/packages/drawing-response/configure/src/defaults.js
@@ -9,6 +9,7 @@ export default {
     promptEnabled: true,
     teacherInstructionsEnabled: true,
     studentInstructionsEnabled: true,
+    toolbarEditorPosition: 'bottom',
   },
   configuration: {
     backgroundImage: {

--- a/packages/drawing-response/configure/src/root.jsx
+++ b/packages/drawing-response/configure/src/root.jsx
@@ -61,6 +61,16 @@ export class Root extends React.Component {
       configuration || {};
     const { teacherInstructionsEnabled, promptEnabled } =
       model || {};
+    const toolbarOpts = {};
+
+    switch (model.toolbarEditorPosition) {
+      case 'top':
+        toolbarOpts.position = 'top';
+        break;
+      default:
+        toolbarOpts.position = 'bottom';
+        break;
+    }
 
     return (
       <div className={classes.base}>
@@ -98,6 +108,7 @@ export class Root extends React.Component {
                   onChange={this.onTeacherInstructionsChanged}
                   imageSupport={imageSupport}
                   nonEmpty={false}
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}
@@ -107,6 +118,7 @@ export class Root extends React.Component {
                 <EditableHtml
                   markup={model.prompt}
                   onChange={this.onPromptChanged}
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}

--- a/packages/drawing-response/docs/demo/generate.js
+++ b/packages/drawing-response/docs/demo/generate.js
@@ -3,6 +3,7 @@ exports.model = (id, element) => ({
   element,
   prompt: 'This is the question prompt',
   promptEnabled: true,
+  toolbarEditorPosition: 'top',
   imageUrl: '',
   imageDimensions: {
     height: 0,

--- a/packages/drawing-response/docs/demo/generate.js
+++ b/packages/drawing-response/docs/demo/generate.js
@@ -3,7 +3,7 @@ exports.model = (id, element) => ({
   element,
   prompt: 'This is the question prompt',
   promptEnabled: true,
-  toolbarEditorPosition: 'top',
+  toolbarEditorPosition: 'bottom',
   imageUrl: '',
   imageDimensions: {
     height: 0,

--- a/packages/drawing-response/docs/pie-schema.json
+++ b/packages/drawing-response/docs/pie-schema.json
@@ -63,6 +63,16 @@
       "type": "boolean",
       "title": "teacherInstructionsEnabled"
     },
+    "toolbarEditorPosition": {
+      "description": "Indicates the editor's toolbar position which can be 'bottom' or 'top'",
+      "default": ": 'bottom'",
+      "enum": [
+        "bottom",
+        "top"
+      ],
+      "type": "string",
+      "title": "toolbarEditorPosition"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/drawing-response/docs/pie-schema.json.md
+++ b/packages/drawing-response/docs/pie-schema.json.md
@@ -46,6 +46,17 @@ Indicates if Student Instructions are enabled
 
 Indicates if Teacher Instructions are enabled
 
+# `toolbarEditorPosition` (string, enum)
+
+Indicates the editor's toolbar position which can be 'bottom' or 'top'
+
+This element must be one of the following enum values:
+
+* `bottom`
+* `top`
+
+Default: `": 'bottom'"`
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/pie-models/src/pie/drawing-response/index.ts
+++ b/packages/pie-models/src/pie/drawing-response/index.ts
@@ -37,6 +37,12 @@ export interface DrawingResponsePie extends PieModel {
 
     /** Indicates if Teacher Instructions are enabled */
     teacherInstructionsEnabled: boolean;
+    
+    /**
+     * Indicates the editor's toolbar position which can be 'bottom' or 'top'
+     * @default: 'bottom'
+     */
+    toolbarEditorPosition?: 'bottom' | 'top';
 }
 
 /**


### PR DESCRIPTION
<img width="1671" alt="Screenshot 2021-07-12 at 12 04 39" src="https://user-images.githubusercontent.com/26737238/125260849-67c35f00-e309-11eb-8e8a-a63704a082f2.png">
<img width="1663" alt="Screenshot 2021-07-12 at 12 04 31" src="https://user-images.githubusercontent.com/26737238/125260871-6abe4f80-e309-11eb-8eb9-bbd940d3659e.png">
@alextkd 