### PR TITLE
feat(drag-in-the-blank) :  toolbar editor position

### DIFF
--- a/packages/drag-in-the-blank/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/drag-in-the-blank/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -89,6 +89,7 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
             "slateMarkup": "<span data-type=\\"drag_in_the_blank\\" data-index=\\"0\\" data-id=\\"0\\" data-value=\\"&lt;div&gt;6&lt;/div&gt;\\"></span> + <span data-type=\\"drag_in_the_blank\\" data-index=\\"1\\" data-id=\\"1\\" data-value=\\"&lt;div&gt;9&lt;/div&gt;\\"></span> = 15",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": true,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChangeConfiguration={[Function]}
@@ -104,6 +105,11 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
           markup=""
           nonEmpty={false}
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </InputContainer>
       <InputContainer
@@ -114,6 +120,11 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
           markup="<p>Solve the equation below.</p>"
           nonEmpty={false}
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </InputContainer>
       <WithStyles(Typography)>
@@ -144,7 +155,7 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
         }
         toolbarOpts={
           Object {
-            "position": "top",
+            "position": "bottom",
           }
         }
       />
@@ -187,9 +198,15 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
             "slateMarkup": "<span data-type=\\"drag_in_the_blank\\" data-index=\\"0\\" data-id=\\"0\\" data-value=\\"&lt;div&gt;6&lt;/div&gt;\\"></span> + <span data-type=\\"drag_in_the_blank\\" data-index=\\"1\\" data-id=\\"1\\" data-value=\\"&lt;div&gt;9&lt;/div&gt;\\"></span> = 15",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": true,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChange={[Function]}
+        toolbarOpts={
+          Object {
+            "position": "bottom",
+          }
+        }
       />
       <InputContainer
         label="Rationale"
@@ -197,6 +214,11 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
         <EditableHtml
           markup="<p>A correct response is shown below:</p><ul><li>2/6 = 1/3</li><li>4/8 = 1/2</li><li>6/10 = 3/5</li><li>9/12 = 3/4</li></ul>"
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </InputContainer>
     </div>
@@ -293,6 +315,7 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
             "slateMarkup": "<span data-type=\\"drag_in_the_blank\\" data-index=\\"0\\" data-id=\\"0\\" data-value=\\"&lt;div&gt;6&lt;/div&gt;\\"></span> + <span data-type=\\"drag_in_the_blank\\" data-index=\\"1\\" data-id=\\"1\\" data-value=\\"&lt;div&gt;9&lt;/div&gt;\\"></span> = 15",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": false,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChangeConfiguration={[Function]}
@@ -329,7 +352,7 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
         }
         toolbarOpts={
           Object {
-            "position": "top",
+            "position": "bottom",
           }
         }
       />
@@ -372,9 +395,15 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
             "slateMarkup": "<span data-type=\\"drag_in_the_blank\\" data-index=\\"0\\" data-id=\\"0\\" data-value=\\"&lt;div&gt;6&lt;/div&gt;\\"></span> + <span data-type=\\"drag_in_the_blank\\" data-index=\\"1\\" data-id=\\"1\\" data-value=\\"&lt;div&gt;9&lt;/div&gt;\\"></span> = 15",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": false,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChange={[Function]}
+        toolbarOpts={
+          Object {
+            "position": "bottom",
+          }
+        }
       />
     </div>
   </ConfigLayout>

--- a/packages/drag-in-the-blank/configure/src/choices.jsx
+++ b/packages/drag-in-the-blank/configure/src/choices.jsx
@@ -53,7 +53,8 @@ export class Choices extends React.Component {
     duplicates: PropTypes.bool,
     model: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired
+    classes: PropTypes.object.isRequired,
+    toolbarOpts: PropTypes.object
   };
 
   state = {
@@ -199,6 +200,7 @@ export class Choices extends React.Component {
     const {
       classes,
       duplicates,
+      toolbarOpts
     } = this.props;
     const visibleChoices = this.getVisibleChoices() || [];
 
@@ -249,6 +251,7 @@ export class Choices extends React.Component {
                         });
                       }}
                       disableUnderline
+                      toolbarOpts={toolbarOpts}
                     />
                   </div>
                 );

--- a/packages/drag-in-the-blank/configure/src/defaults.js
+++ b/packages/drag-in-the-blank/configure/src/defaults.js
@@ -12,7 +12,8 @@ export default {
     rationaleEnabled: true,
     promptEnabled: true,
     teacherInstructionsEnabled: true,
-    studentInstructionsEnabled: true
+    studentInstructionsEnabled: true,
+    toolbarEditorPosition: 'bottom',
   },
   configuration: {
     choicesPosition: {

--- a/packages/drag-in-the-blank/configure/src/main.jsx
+++ b/packages/drag-in-the-blank/configure/src/main.jsx
@@ -142,7 +142,16 @@ export class Main extends React.Component {
     } = configuration || {};
     const { rationaleEnabled, promptEnabled, teacherInstructionsEnabled } =
       model || {};
+    const toolbarOpts = {};
 
+    switch (model.toolbarEditorPosition) {
+      case 'top':
+        toolbarOpts.position = 'top';
+        break;
+      default:
+        toolbarOpts.position = 'bottom';
+        break;
+    }
     return (
       <div className={classes.design}>
         <layout.ConfigLayout
@@ -194,6 +203,7 @@ export class Main extends React.Component {
                   onChange={this.onTeacherInstructionsChanged}
                   imageSupport={imageSupport}
                   nonEmpty={false}
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}
@@ -209,6 +219,7 @@ export class Main extends React.Component {
                   imageSupport={imageSupport}
                   nonEmpty={false}
                   disableUnderline
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}
@@ -234,11 +245,13 @@ export class Main extends React.Component {
                 audio: { disabled: true },
                 video: { disabled: true }
               }}
+              toolbarOpts={toolbarOpts}
             />
             <Choices
               model={model}
               duplicates={model.duplicates}
               onChange={this.onResponsesChanged}
+              toolbarOpts={toolbarOpts}
             />
             {rationaleEnabled && (
               <InputContainer
@@ -250,6 +263,7 @@ export class Main extends React.Component {
                   markup={model.rationale || ''}
                   onChange={this.onRationaleChanged}
                   imageSupport={imageSupport}
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}

--- a/packages/drag-in-the-blank/docs/demo/generate.js
+++ b/packages/drag-in-the-blank/docs/demo/generate.js
@@ -35,5 +35,5 @@ exports.model = (id, element) => ({
   'mode': 'gather',
   'disabled': false,
   'teacherInstructions': null,
-  'toolbarEditorPosition': 'top'
+  'toolbarEditorPosition': 'bottom'
 });

--- a/packages/drag-in-the-blank/docs/demo/generate.js
+++ b/packages/drag-in-the-blank/docs/demo/generate.js
@@ -34,5 +34,6 @@ exports.model = (id, element) => ({
   'feedback': {},
   'mode': 'gather',
   'disabled': false,
-  'teacherInstructions': null
+  'teacherInstructions': null,
+  'toolbarEditorPosition': 'top'
 });

--- a/packages/drag-in-the-blank/docs/pie-schema.json
+++ b/packages/drag-in-the-blank/docs/pie-schema.json
@@ -120,6 +120,16 @@
       "type": "boolean",
       "title": "teacherInstructionsEnabled"
     },
+    "toolbarEditorPosition": {
+      "description": "Indicates the editor's toolbar position which can be 'bottom' or 'top'",
+      "default": ": 'bottom'",
+      "enum": [
+        "bottom",
+        "top"
+      ],
+      "type": "string",
+      "title": "toolbarEditorPosition"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/drag-in-the-blank/docs/pie-schema.json.md
+++ b/packages/drag-in-the-blank/docs/pie-schema.json.md
@@ -85,6 +85,17 @@ Indicates if Student Instructions are enabled
 
 Indicates if Teacher Instructions are enabled
 
+# `toolbarEditorPosition` (string, enum)
+
+Indicates the editor's toolbar position which can be 'bottom' or 'top'
+
+This element must be one of the following enum values:
+
+* `bottom`
+* `top`
+
+Default: `": 'bottom'"`
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/pie-models/src/pie/drag-in-the-blank/index.ts
+++ b/packages/pie-models/src/pie/drag-in-the-blank/index.ts
@@ -83,6 +83,12 @@ export interface DragInTheBlankPie extends PieModel {
 
     /** Indicates if Teacher Instructions are enabled */
     teacherInstructionsEnabled: boolean;
+
+    /**
+     * Indicates the editor's toolbar position which can be 'bottom' or 'top'
+     * @default: 'bottom'
+     */
+    toolbarEditorPosition?: 'bottom' | 'top';
 }
 
 /**


### PR DESCRIPTION
feat(drag-in-the-blank) : added option for setting the toolbar editor position.
<img width="1667" alt="Screenshot 2021-07-12 at 22 39 04" src="https://user-images.githubusercontent.com/26737238/125399979-fabbd200-e3b9-11eb-942f-51072486181f.png">
<img width="1664" alt="Screenshot 2021-07-12 at 22 39 15" src="https://user-images.githubusercontent.com/26737238/125399993-fdb6c280-e3b9-11eb-8cb3-399a23b277f2.png">
<img width="1661" alt="Screenshot 2021-07-12 at 22 39 24" src="https://user-images.githubusercontent.com/26737238/125399996-fe4f5900-e3b9-11eb-817c-b38ba59b606b.png">
<img width="1667" alt="Screenshot 2021-07-12 at 22 39 37" src="https://user-images.githubusercontent.com/26737238/125399999-fee7ef80-e3b9-11eb-98bb-ab38111146c1.png">
<img width="1660" alt="Screenshot 2021-07-12 at 22 39 46" src="https://user-images.githubusercontent.com/26737238/125400001-ff808600-e3b9-11eb-878f-20ea93d82af2.png">
@alextkd 