### PR TITLE
feat(explicit-constructed-response) : toolbar editor position

### DIFF
--- a/packages/explicit-constructed-response/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/explicit-constructed-response/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -85,6 +85,7 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
             "slateMarkup": "<p>The <span data-type=\\"explicit_constructed_response\\" data-index=\\"0\\" data-value=\\"cow\\"></span> jumped <span data-type=\\"explicit_constructed_response\\" data-index=\\"1\\" data-value=\\"over\\"></span> the <span data-type=\\"explicit_constructed_response\\" data-index=\\"2\\" data-value=\\"moon\\"></span></p>",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": true,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChangeConfiguration={[Function]}
@@ -100,6 +101,11 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
           markup=""
           nonEmpty={false}
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </InputContainer>
       <InputContainer
@@ -110,6 +116,11 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
           markup="Complete the sentence"
           nonEmpty={false}
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </InputContainer>
       <WithStyles(Typography)>
@@ -187,6 +198,7 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
             "slateMarkup": "<p>The <span data-type=\\"explicit_constructed_response\\" data-index=\\"0\\" data-value=\\"cow\\"></span> jumped <span data-type=\\"explicit_constructed_response\\" data-index=\\"1\\" data-value=\\"over\\"></span> the <span data-type=\\"explicit_constructed_response\\" data-index=\\"2\\" data-value=\\"moon\\"></span></p>",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": true,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChange={[Function]}
@@ -197,6 +209,11 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
         <EditableHtml
           markup=""
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </InputContainer>
     </div>
@@ -289,6 +306,7 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
             "slateMarkup": "<p>The <span data-type=\\"explicit_constructed_response\\" data-index=\\"0\\" data-value=\\"cow\\"></span> jumped <span data-type=\\"explicit_constructed_response\\" data-index=\\"1\\" data-value=\\"over\\"></span> the <span data-type=\\"explicit_constructed_response\\" data-index=\\"2\\" data-value=\\"moon\\"></span></p>",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": false,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChangeConfiguration={[Function]}
@@ -372,6 +390,7 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
             "slateMarkup": "<p>The <span data-type=\\"explicit_constructed_response\\" data-index=\\"0\\" data-value=\\"cow\\"></span> jumped <span data-type=\\"explicit_constructed_response\\" data-index=\\"1\\" data-value=\\"over\\"></span> the <span data-type=\\"explicit_constructed_response\\" data-index=\\"2\\" data-value=\\"moon\\"></span></p>",
             "studentInstructionsEnabled": true,
             "teacherInstructionsEnabled": false,
+            "toolbarEditorPosition": "bottom",
           }
         }
         onChange={[Function]}

--- a/packages/explicit-constructed-response/configure/src/defaults.js
+++ b/packages/explicit-constructed-response/configure/src/defaults.js
@@ -5,6 +5,7 @@ export default {
     prompt: 'Use the inputs to complete the sentence',
     shuffle: true,
     markup: '<p>The {{0}} jumped {{1}} the {{2}}</p>',
+    toolbarEditorPosition: 'bottom',
     choices: {
       0: [
         {

--- a/packages/explicit-constructed-response/configure/src/main.jsx
+++ b/packages/explicit-constructed-response/configure/src/main.jsx
@@ -198,7 +198,16 @@ export class Main extends React.Component {
     } = configuration || {};
     const { teacherInstructionsEnabled, promptEnabled, rationaleEnabled } =
       model || {};
+    const toolbarOpts = {};
 
+    switch (model.toolbarEditorPosition) {
+      case 'top':
+        toolbarOpts.position = 'top';
+        break;
+      default:
+        toolbarOpts.position = 'bottom';
+        break;
+    }
     return (
       <div className={classes.design}>
         <layout.ConfigLayout
@@ -239,6 +248,7 @@ export class Main extends React.Component {
                   onChange={this.onTeacherInstructionsChanged}
                   imageSupport={imageSupport}
                   nonEmpty={false}
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}
@@ -254,6 +264,7 @@ export class Main extends React.Component {
                   imageSupport={imageSupport}
                   nonEmpty={false}
                   disableUnderline
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}
@@ -314,6 +325,7 @@ export class Main extends React.Component {
                   markup={model.rationale || ''}
                   onChange={this.onRationaleChanged}
                   imageSupport={imageSupport}
+                  toolbarOpts={toolbarOpts}
                 />
               </InputContainer>
             )}

--- a/packages/explicit-constructed-response/docs/demo/generate.js
+++ b/packages/explicit-constructed-response/docs/demo/generate.js
@@ -15,5 +15,5 @@ exports.model = (id, element) => ({
   prompt: 'Complete the sentence',
   note: 'The answer shown above is the most common correct answer for this item. One or more additional correct answers are also defined, and will also be recognized as correct.',
   promptEnabled: true,
-  toolbarEditorPosition: 'top'
+  toolbarEditorPosition: 'bottom'
 });

--- a/packages/explicit-constructed-response/docs/demo/generate.js
+++ b/packages/explicit-constructed-response/docs/demo/generate.js
@@ -14,5 +14,6 @@ exports.model = (id, element) => ({
   },
   prompt: 'Complete the sentence',
   note: 'The answer shown above is the most common correct answer for this item. One or more additional correct answers are also defined, and will also be recognized as correct.',
-  promptEnabled: true
+  promptEnabled: true,
+  toolbarEditorPosition: 'top'
 });

--- a/packages/explicit-constructed-response/docs/pie-schema.json
+++ b/packages/explicit-constructed-response/docs/pie-schema.json
@@ -98,6 +98,16 @@
       "type": "string",
       "title": "note"
     },
+    "toolbarEditorPosition": {
+      "description": "Indicates the editor's toolbar position which can be 'bottom' or 'top'",
+      "default": ": 'bottom'",
+      "enum": [
+        "bottom",
+        "top"
+      ],
+      "type": "string",
+      "title": "toolbarEditorPosition"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/explicit-constructed-response/docs/pie-schema.json.md
+++ b/packages/explicit-constructed-response/docs/pie-schema.json.md
@@ -60,6 +60,17 @@ Indicates if Teacher Instructions are enabled
 
 Indicates the note for the answer
 
+# `toolbarEditorPosition` (string, enum)
+
+Indicates the editor's toolbar position which can be 'bottom' or 'top'
+
+This element must be one of the following enum values:
+
+* `bottom`
+* `top`
+
+Default: `": 'bottom'"`
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/pie-models/src/pie/explicit-constructed-response/index.ts
+++ b/packages/pie-models/src/pie/explicit-constructed-response/index.ts
@@ -66,6 +66,12 @@ export interface ExplicitConstructedResponsePie extends PieModel {
 
     /** Indicates the note for the answer */
     note?: string;
+    
+    /**
+     * Indicates the editor's toolbar position which can be 'bottom' or 'top'
+     * @default: 'bottom'
+     */
+    toolbarEditorPosition?: 'bottom' | 'top';
 }
 
 /**


### PR DESCRIPTION
feat(explicit-constructed-response) : added option to set toolbar editor position
<img width="1670" alt="Screenshot 2021-07-13 at 09 13 49" src="https://user-images.githubusercontent.com/26737238/125400667-d9a7b100-e3ba-11eb-966a-59a9dece2aac.png">
<img width="1667" alt="Screenshot 2021-07-13 at 09 14 00" src="https://user-images.githubusercontent.com/26737238/125400677-dca2a180-e3ba-11eb-9593-33f20e923398.png">
<img width="1666" alt="Screenshot 2021-07-13 at 09 14 08" src="https://user-images.githubusercontent.com/26737238/125400682-dd3b3800-e3ba-11eb-9fd7-34d555657047.png">
<img width="1658" alt="Screenshot 2021-07-13 at 09 14 25" src="https://user-images.githubusercontent.com/26737238/125400684-ddd3ce80-e3ba-11eb-8cd7-c8840484108d.png">
<img width="1668" alt="Screenshot 2021-07-13 at 09 13 38" src="https://user-images.githubusercontent.com/26737238/125400687-ddd3ce80-e3ba-11eb-9da5-1ed8dfad6b49.png">
@alextkd 