### PR TITLE
feat(math-inline): added option to set toolbar editor position

### DIFF
--- a/packages/math-inline/configure/src/__tests__/__snapshots__/configure.test.js.snap
+++ b/packages/math-inline/configure/src/__tests__/__snapshots__/configure.test.js.snap
@@ -218,6 +218,11 @@ exports[`Configure renders correctly with snapshot 1`] = `
           }
           onChange={[Function]}
           promptEnabled={true}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
         <FeedbackConfig
           feedback={
@@ -237,6 +242,11 @@ exports[`Configure renders correctly with snapshot 1`] = `
             }
           }
           onChange={[Function]}
+          toolbarOpts={
+            Object {
+              "position": "bottom",
+            }
+          }
         />
       </div>
     </div>

--- a/packages/math-inline/configure/src/configure.jsx
+++ b/packages/math-inline/configure/src/configure.jsx
@@ -75,7 +75,16 @@ export class Configure extends React.Component {
     } = configuration || {};
     log('[render] model', model);
     const { rationaleEnabled, promptEnabled, teacherInstructionsEnabled, feedbackEnabled } = model || {};
+    const toolbarOpts = {};
 
+    switch (model.toolbarEditorPosition) {
+      case 'top':
+        toolbarOpts.position = 'top';
+        break;
+      default:
+        toolbarOpts.position = 'bottom';
+        break;
+    }
     return (
       <div>
         <layout.ConfigLayout
@@ -117,6 +126,7 @@ export class Configure extends React.Component {
                     onChange={this.changeTeacherInstructions}
                     imageSupport={imageSupport}
                     nonEmpty={false}
+                    toolbarOpts={toolbarOpts}
                   />
                 </InputContainer>
               )}
@@ -128,12 +138,14 @@ export class Configure extends React.Component {
                 onChange={this.onChange}
                 rationaleEnabled={rationaleEnabled}
                 promptEnabled={promptEnabled}
+                toolbarOpts={toolbarOpts}
               />
               {
                 feedbackEnabled && (
                   <FeedbackConfig
                     feedback={model.feedback}
                     onChange={this.onFeedbackChange}
+                    toolbarOpts={toolbarOpts}
                   />
                 )
               }

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -35,7 +35,8 @@ export default {
     promptEnabled: true,
     rationaleEnabled: true,
     teacherInstructionsEnabled: true,
-    studentInstructionsEnabled: true
+    studentInstructionsEnabled: true,
+    toolbarEditorPosition: "bottom",
   },
   configuration: {
     prompt: {

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -36,7 +36,7 @@ export default {
     rationaleEnabled: true,
     teacherInstructionsEnabled: true,
     studentInstructionsEnabled: true,
-    toolbarEditorPosition: "bottom",
+    toolbarEditorPosition: 'bottom',
   },
   configuration: {
     prompt: {

--- a/packages/math-inline/configure/src/general-config-block.jsx
+++ b/packages/math-inline/configure/src/general-config-block.jsx
@@ -142,6 +142,7 @@ class GeneralConfigBlock extends React.Component {
     onChange: PropTypes.func.isRequired,
     promptEnabled: PropTypes.bool,
     rationaleEnabled: PropTypes.bool,
+    toolbarOpts: PropTypes.object
   };
 
   constructor(props) {
@@ -328,6 +329,7 @@ class GeneralConfigBlock extends React.Component {
       configuration,
       promptEnabled,
       rationaleEnabled,
+      toolbarOpts
     } = this.props;
     const { showKeypad } = this.state;
     const {
@@ -365,6 +367,7 @@ class GeneralConfigBlock extends React.Component {
               onChange={this.onChange('prompt')}
               imageSupport={imageSupport}
               nonEmpty={false}
+              toolbarOpts={toolbarOpts}
             />
           </InputContainer>
         )}
@@ -384,6 +387,7 @@ class GeneralConfigBlock extends React.Component {
               onChange={this.onChange('rationale')}
               imageSupport={imageSupport}
               nonEmpty={false}
+              toolbarOpts={toolbarOpts}
             />
           </InputContainer>
         )}

--- a/packages/math-inline/docs/demo/generate.js
+++ b/packages/math-inline/docs/demo/generate.js
@@ -17,6 +17,7 @@ const initialModel = {
 
 const E262456 = {
   'equationEditor': 3,
+  'toolbarEditorPosition': "top",
   'prompt': '<p><strong>B.</strong> Find the value of the expression that you wrote in part A to find how much money the band members made.</p>\n\n<p>Use the on-screen keyboard to type your answer in the box below.</p>\n',
   'expression': '${{response}}',
   'responses': [

--- a/packages/math-inline/docs/demo/generate.js
+++ b/packages/math-inline/docs/demo/generate.js
@@ -17,7 +17,7 @@ const initialModel = {
 
 const E262456 = {
   'equationEditor': 3,
-  'toolbarEditorPosition': 'top',
+  'toolbarEditorPosition': 'bottom',
   'prompt': '<p><strong>B.</strong> Find the value of the expression that you wrote in part A to find how much money the band members made.</p>\n\n<p>Use the on-screen keyboard to type your answer in the box below.</p>\n',
   'expression': '${{response}}',
   'responses': [

--- a/packages/math-inline/docs/demo/generate.js
+++ b/packages/math-inline/docs/demo/generate.js
@@ -17,7 +17,7 @@ const initialModel = {
 
 const E262456 = {
   'equationEditor': 3,
-  'toolbarEditorPosition': "top",
+  'toolbarEditorPosition': 'top',
   'prompt': '<p><strong>B.</strong> Find the value of the expression that you wrote in part A to find how much money the band members made.</p>\n\n<p>Use the on-screen keyboard to type your answer in the box below.</p>\n',
   'expression': '${{response}}',
   'responses': [

--- a/packages/math-inline/docs/pie-schema.json
+++ b/packages/math-inline/docs/pie-schema.json
@@ -396,6 +396,16 @@
       "type": "boolean",
       "title": "teacherInstructionsEnabled"
     },
+    "toolbarEditorPosition": {
+      "description": "Indicates the editor's toolbar position which can be 'bottom' or 'top'",
+      "default": ": 'bottom'",
+      "enum": [
+        "bottom",
+        "top"
+      ],
+      "type": "string",
+      "title": "toolbarEditorPosition"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/math-inline/docs/pie-schema.json.md
+++ b/packages/math-inline/docs/pie-schema.json.md
@@ -168,6 +168,17 @@ Indicates if Student Instructions are enabled
 
 Indicates if Teacher Instructions are enabled
 
+# `toolbarEditorPosition` (string, enum)
+
+Indicates the editor's toolbar position which can be 'bottom' or 'top'
+
+This element must be one of the following enum values:
+
+* `bottom`
+* `top`
+
+Default: `": 'bottom'"`
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/pie-models/src/pie/math-inline/index.ts
+++ b/packages/pie-models/src/pie/math-inline/index.ts
@@ -113,6 +113,12 @@ export interface MathInlinePie extends PieModel {
 
     /** Indicates if Teacher Instructions are enabled */
     teacherInstructionsEnabled: boolean;
+
+    /**
+     * Indicates the editor's toolbar position which can be 'bottom' or 'top'
+     * @default: 'bottom'
+     */
+    toolbarEditorPosition?: 'bottom' | 'top';
 }
 
 


### PR DESCRIPTION
<img width="1671" alt="Screenshot 2021-07-13 at 14 57 18" src="https://user-images.githubusercontent.com/26737238/125451712-a301efed-ef4d-462c-9fd6-23c77b260b85.png">
<img width="1670" alt="Screenshot 2021-07-13 at 14 57 26" src="https://user-images.githubusercontent.com/26737238/125451725-72299319-c644-4ff0-835d-3056710e9e6d.png">
<img width="1677" alt="Screenshot 2021-07-13 at 14 57 34" src="https://user-images.githubusercontent.com/26737238/125451728-b0232841-7e76-4490-a155-050f8dd4a74d.png">
<img width="1661" alt="Screenshot 2021-07-13 at 14 58 01" src="https://user-images.githubusercontent.com/26737238/125451730-4f602c2d-75cb-4adb-8407-bfb09486e16f.png">
@alextkd 