### PR TITLE
feat(select-text) : added option to set toolbar editor position

### DIFF
--- a/packages/pie-models/src/pie/select-text/index.ts
+++ b/packages/pie-models/src/pie/select-text/index.ts
@@ -79,6 +79,12 @@ export interface SelectTextPie extends PieModel {
 
   /** Indicates if Teacher Instructions are enabled */
   teacherInstructionsEnabled: boolean;
+  
+  /**
+   * Indicates the editor's toolbar position which can be 'bottom' or 'top'
+   * @default: 'bottom'
+   */
+  toolbarEditorPosition?: 'bottom' | 'top';
 }
 
 

--- a/packages/select-text/configure/src/defaultConfiguration.js
+++ b/packages/select-text/configure/src/defaultConfiguration.js
@@ -20,7 +20,8 @@ export default {
     rationaleEnabled: true,
     promptEnabled: true,
     teacherInstructionsEnabled: true,
-    studentInstructionsEnabled: true
+    studentInstructionsEnabled: true,
+    toolbarEditorPosition: 'bottom'
   },
   configuration: {
     selectionCount: {

--- a/packages/select-text/configure/src/design.jsx
+++ b/packages/select-text/configure/src/design.jsx
@@ -160,7 +160,16 @@ export class Design extends React.Component {
     const {
       teacherInstructionsEnabled, promptEnabled, rationaleEnabled, feedbackEnabled
     } = model || {};
+    const toolbarOpts = {};
 
+    switch (model.toolbarEditorPosition) {
+      case 'top':
+        toolbarOpts.position = 'top';
+        break;
+      default:
+        toolbarOpts.position = 'bottom';
+        break;
+    }
     let { tokens: tokensModel } = model;
     tokensModel = tokensModel || [];
 
@@ -212,6 +221,7 @@ export class Design extends React.Component {
                 onChange={this.onTeacherInstructionsChanged}
                 imageSupport={imageSupport}
                 nonEmpty={false}
+                toolbarOpts={toolbarOpts}
               />
             </InputContainer>
           )}
@@ -226,6 +236,7 @@ export class Design extends React.Component {
                 markup={model.prompt}
                 onChange={this.onPromptChanged}
                 imageSupport={imageSupport}
+                toolbarOpts={toolbarOpts}
               />
             </InputContainer>
           )}
@@ -240,6 +251,7 @@ export class Design extends React.Component {
                 markup={model.rationale || ''}
                 onChange={this.onRationaleChanged}
                 imageSupport={imageSupport}
+                toolbarOpts={toolbarOpts}
               />
             </InputContainer>
           )}
@@ -306,6 +318,7 @@ export class Design extends React.Component {
             <FeedbackConfig
               feedback={model.feedback}
               onChange={this.changeFeedback}
+              toolbarOpts={toolbarOpts}
             />
           )}
         </div>

--- a/packages/select-text/docs/demo/generate.js
+++ b/packages/select-text/docs/demo/generate.js
@@ -79,6 +79,7 @@ const base = extras =>
       rationale: 'Rationale goes here.',
       prompt: 'What sentences contain the character 6 in them?',
       promptEnabled: true,
+      toolbarEditorPosition: 'top',
       // text: `<p>Warhol was born in 1928 in Pittsburgh, Pennsylvania. When he was eight years old, he became very sick and had to stay in bed for months. To help him pass the time his mother, who was an artist, taught him how to draw. He took to it like a fish to water. Art became the center of Andy's world. A year later he added picture-taking to his interests when his mother gave him a camera. He also became fascinated with movies.</p><p>Andy studied art in school and learned many ways to make art. He learned how to use different art materials, such as oil paints, metal, clay, and wood. In 1949 he moved to New York City, where he got a job drawing and painting pictures for magazines.</p>`,
       text: `<p>If 'tweren't for sight and sound and smell,<br />
 I'd like the city pretty well,<br />

--- a/packages/select-text/docs/demo/generate.js
+++ b/packages/select-text/docs/demo/generate.js
@@ -79,7 +79,7 @@ const base = extras =>
       rationale: 'Rationale goes here.',
       prompt: 'What sentences contain the character 6 in them?',
       promptEnabled: true,
-      toolbarEditorPosition: 'top',
+      toolbarEditorPosition: 'bottom',
       // text: `<p>Warhol was born in 1928 in Pittsburgh, Pennsylvania. When he was eight years old, he became very sick and had to stay in bed for months. To help him pass the time his mother, who was an artist, taught him how to draw. He took to it like a fish to water. Art became the center of Andy's world. A year later he added picture-taking to his interests when his mother gave him a camera. He also became fascinated with movies.</p><p>Andy studied art in school and learned many ways to make art. He learned how to use different art materials, such as oil paints, metal, clay, and wood. In 1949 he moved to New York City, where he got a job drawing and painting pictures for magazines.</p>`,
       text: `<p>If 'tweren't for sight and sound and smell,<br />
 I'd like the city pretty well,<br />

--- a/packages/select-text/docs/pie-schema.json
+++ b/packages/select-text/docs/pie-schema.json
@@ -289,6 +289,16 @@
       "type": "boolean",
       "title": "teacherInstructionsEnabled"
     },
+    "toolbarEditorPosition": {
+      "description": "Indicates the editor's toolbar position which can be 'bottom' or 'top'",
+      "default": ": 'bottom'",
+      "enum": [
+        "bottom",
+        "top"
+      ],
+      "type": "string",
+      "title": "toolbarEditorPosition"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/select-text/docs/pie-schema.json.md
+++ b/packages/select-text/docs/pie-schema.json.md
@@ -117,6 +117,17 @@ Indicates if Student Instructions are enabled
 
 Indicates if Teacher Instructions are enabled
 
+# `toolbarEditorPosition` (string, enum)
+
+Indicates the editor's toolbar position which can be 'bottom' or 'top'
+
+This element must be one of the following enum values:
+
+* `bottom`
+* `top`
+
+Default: `": 'bottom'"`
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.


### PR DESCRIPTION
<img width="1666" alt="Screenshot 2021-07-14 at 14 14 54" src="https://user-images.githubusercontent.com/26737238/125616357-6c2a9b2c-6daa-4c73-8c14-13331ae7f723.png">
<img width="1665" alt="Screenshot 2021-07-14 at 14 15 02" src="https://user-images.githubusercontent.com/26737238/125616366-d134cb7a-17fd-40c0-a0f3-20eb9b49c1f2.png">
<img width="1675" alt="Screenshot 2021-07-14 at 14 15 09" src="https://user-images.githubusercontent.com/26737238/125616369-211a6222-8bcc-470b-b8eb-6f21baea6d1b.png">
<img width="1656" alt="Screenshot 2021-07-14 at 14 23 08" src="https://user-images.githubusercontent.com/26737238/125616371-1f4759e3-c347-4dc0-ad28-a6f43c6cfe26.png">
@alextkd 