### PR TITLE
fix(image-cloze-association): Moved the evaluate symbol to fit in the available content PD-1244

### DIFF
--- a/packages/image-cloze-association/src/possible-response.jsx
+++ b/packages/image-cloze-association/src/possible-response.jsx
@@ -27,9 +27,10 @@ export class PossibleResponse extends React.Component {
     const { classes, connectDragSource, containerStyle, data } = this.props;
     const additionalClass = this.getClassname();
     const evaluationStyle = {
-      alignSelf: 'center',
       fontSize: 14,
-      paddingRight: 2
+      position: 'absolute',
+      bottom: '3px',
+      right: '3px'
     };
 
     return connectDragSource(
@@ -62,6 +63,7 @@ PossibleResponse.defaultProps = {
 
 const styles = () => ({
   base: {
+    position: 'relative',
     backgroundColor: color.background(),
     border: `1px solid ${color.primary()}`,
     display: 'flex',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-1244