### PR TITLE
feat(math-inline): if absolute notation is a custom key, it should be…

### DIFF
--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -21,12 +21,24 @@ const DEFAULT_KEYPAD_VARIANT = 6;
 const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 function generateAdditionalKeys(keyData = []) {
-  return keyData.map((key) => ({
-    name: key,
-    latex: key,
-    write: key,
-    label: key,
-  }));
+  return keyData.map((key) => {
+    // if absolute notation is a custom key, we want it to behave like the regular absolute value button
+    if (key === '\\abs{}') {
+      return {
+        name: key,
+        latex: key,
+        symbol: '| |',
+        command: '|'
+      };
+    }
+
+    return {
+      name: key,
+      latex: key,
+      write: key,
+      label: key
+    };
+  });
 }
 
 function getKeyPadWidth(additionalKeys = [], equationEditor) {


### PR DESCRIPTION
…have as the regular button PD-1257
https://illuminate.atlassian.net/browse/PD-1257