### PR TITLE
fix(CTT-174): add safari tooltip fix 

### DIFF
--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -172,6 +172,10 @@ export class Main extends React.Component {
     this.handleAnswerBlockDomUpdate();
   }
 
+  componentWillUnmount() {
+    this.setState({ activeAnswerBlock: '' });
+  }
+
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { config } = this.props.model;
     const { config: nextConfig = {} } = nextProps.model || {};


### PR DESCRIPTION
In classroom-tool context the tooltip is still visible when questions are changed by teacher. 

See this: https://illuminate.atlassian.net/browse/CTT-183