### PR TITLE
fix(number-line): initial view should render correctly in pits

### DIFF
--- a/packages/number-line/src/index.js
+++ b/packages/number-line/src/index.js
@@ -131,6 +131,10 @@ export default class NumberLine extends HTMLElement {
   _render() {
     try {
       if (this._model && this._session) {
+        if (!this._session.answer) {
+          this._applyInitialElements();
+        }
+
         let answer = (this._session.answer || []).map(toGraphFormat);
         let model = cloneDeep(this._model);
         model.correctResponse =

--- a/packages/number-line/src/number-line/index.jsx
+++ b/packages/number-line/src/number-line/index.jsx
@@ -110,7 +110,7 @@ export class NumberLine extends React.Component {
       const { answers } = this.state;
 
       const contains = answers.some((element) => {
-        return JSON.stringify(element) === JSON.stringify(elementData);
+        return isEqual(element, elementData);
       });
 
       if (!contains) {


### PR DESCRIPTION
- apply initial elements if session is undefined, so that initial view will work in pits
- fix: initial view - it should not be possible to plot the same point or other object multiple times