### PR TITLE
feat/math-inline-literal-validation-options

### DIFF
--- a/packages/extended-text-entry/docs/demo/generate.js
+++ b/packages/extended-text-entry/docs/demo/generate.js
@@ -2,7 +2,7 @@ exports.model = (id, element) => ({
   id,
   element,
   customKeys: [
-    "\\square"
+    '\\square'
   ],
   feedback: { type: 'default', default: 'this is default feedback' },
   prompt: 'This is the question prompt',

--- a/packages/math-inline/configure/src/configure.jsx
+++ b/packages/math-inline/configure/src/configure.jsx
@@ -71,7 +71,9 @@ export class Configure extends React.Component {
       studentInstructions = {},
       rationale = {},
       prompt = {},
-      scoringType = {}
+      scoringType = {},
+      ignoreOrder = {},
+      allowTrailingZeros={}
     } = configuration || {};
     log('[render] model', model);
     const { rationaleEnabled, promptEnabled, teacherInstructionsEnabled, feedbackEnabled } = model || {};
@@ -85,6 +87,9 @@ export class Configure extends React.Component {
         toolbarOpts.position = 'bottom';
         break;
     }
+
+    console.log('\n\n', { model, configuration }, '\n\n')
+
     return (
       <div>
         <layout.ConfigLayout
@@ -111,6 +116,10 @@ export class Configure extends React.Component {
                   rationaleEnabled: rationale.settings && toggle(rationale.label),
                   scoringType: scoringType.settings &&
                     radio(scoringType.label, ['auto', 'rubric']),
+                  'ignoreOrder.enabled':
+                    ignoreOrder.settings && toggle(ignoreOrder.label),
+                  'allowTrailingZeros.enabled':
+                    allowTrailingZeros.settings && toggle(allowTrailingZeros.label),
                 },
               }}
             />

--- a/packages/math-inline/configure/src/configure.jsx
+++ b/packages/math-inline/configure/src/configure.jsx
@@ -88,8 +88,6 @@ export class Configure extends React.Component {
         break;
     }
 
-    console.log('\n\n', { model, configuration }, '\n\n')
-
     return (
       <div>
         <layout.ConfigLayout

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -39,6 +39,9 @@ export default {
     teacherInstructionsEnabled: true,
     studentInstructionsEnabled: true,
     toolbarEditorPosition: 'bottom',
+    validationDefault: "literal",
+    ignoreOrderDefault: false,
+    allowTrailingZerosDefault: false,
   },
   configuration: {
     prompt: {
@@ -74,12 +77,14 @@ export default {
       label: 'Allow Partial Scoring',
     },
     ignoreOrder: {
-      controls: true,
-      label: 'Ignore Order'
+      settings: false,
+      label: 'Ignore Order',
+      enabled: true
     },
     allowTrailingZeros: {
-      controls: true,
-      label: 'Allow Trailing Zeros'
+      settings: false,
+      label: 'Allow Trailing Zeros',
+      enabled: true
     },
   },
 };

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -13,21 +13,22 @@ export default {
     feedback: {
       correct: {
         default: 'Correct',
-        type: 'none'
+        type: 'none',
       },
       incorrect: {
         default: 'Incorrect',
-        type: 'none'
+        type: 'none',
       },
       partial: {
         default: 'Nearly',
-        type: 'none'
-      }
+        type: 'none',
+      },
     },
     equationEditor: '3',
     expression: '',
     rationale: 'Rationale goes here.',
-    note: 'The answer shown above is the primary correct answer specified by the author for this item, but other answers may also be recognized as correct.',
+    note:
+      'The answer shown above is the primary correct answer specified by the author for this item, but other answers may also be recognized as correct.',
     prompt: '',
     responses: [],
     customKeys: [],
@@ -42,35 +43,43 @@ export default {
   configuration: {
     prompt: {
       settings: true,
-      label: 'Prompt'
+      label: 'Prompt',
     },
     feedback: {
       settings: true,
-      label: 'Feedback'
+      label: 'Feedback',
     },
     responseType: {
       settings: true,
-      label: 'Response type'
+      label: 'Response type',
     },
     rationale: {
       settings: true,
-      label: 'Rationale'
+      label: 'Rationale',
     },
     scoringType: {
       settings: false,
-      label: 'Scoring Type'
+      label: 'Scoring Type',
     },
     studentInstructions: {
       settings: false,
-      label: 'Student Instructions'
+      label: 'Student Instructions',
     },
     teacherInstructions: {
       settings: true,
-      label: 'Teacher Instructions'
+      label: 'Teacher Instructions',
     },
     partialScoring: {
       settings: false,
-      label: 'Allow Partial Scoring'
-    }
-  }
+      label: 'Allow Partial Scoring',
+    },
+    ignoreOrder: {
+      controls: true,
+      label: 'Ignore Order'
+    },
+    allowTrailingZeros: {
+      controls: true,
+      label: 'Allow Trailing Zeros'
+    },
+  },
 };

--- a/packages/math-inline/configure/src/defaults.js
+++ b/packages/math-inline/configure/src/defaults.js
@@ -79,7 +79,7 @@ export default {
     ignoreOrder: {
       settings: false,
       label: 'Ignore Order',
-      enabled: true
+      enabled: true,
     },
     allowTrailingZeros: {
       settings: false,

--- a/packages/math-inline/configure/src/general-config-block.jsx
+++ b/packages/math-inline/configure/src/general-config-block.jsx
@@ -343,7 +343,6 @@ class GeneralConfigBlock extends React.Component {
     } = model;
     const { rationale: cRationale = {}, prompt: cPrompt = {}, ignoreOrder: cIgnoreOrder = {}, allowTrailingZeros: cAllowTrailingZeros = {} } = configuration || {};
 
-    console.log(configuration, 'configuration')
     const classNames = {
       editor: classes.responseEditor,
       mathToolbar: classes.mathToolbar,

--- a/packages/math-inline/configure/src/general-config-block.jsx
+++ b/packages/math-inline/configure/src/general-config-block.jsx
@@ -341,8 +341,9 @@ class GeneralConfigBlock extends React.Component {
       responseType,
       rationale,
     } = model;
-    const { rationale: cRationale = {}, prompt: cPrompt = {} } = configuration || {};
+    const { rationale: cRationale = {}, prompt: cPrompt = {}, ignoreOrder: cIgnoreOrder = {}, allowTrailingZeros: cAllowTrailingZeros = {} } = configuration || {};
 
+    console.log(configuration, 'configuration')
     const classNames = {
       editor: classes.responseEditor,
       mathToolbar: classes.mathToolbar,
@@ -459,6 +460,8 @@ class GeneralConfigBlock extends React.Component {
             defaultResponse={responseType === ResponseTypes.simple}
             onResponseChange={this.onResponseChange}
             index={idx}
+            cIgnoreOrder={cIgnoreOrder}
+            cAllowTrailingZeros={cAllowTrailingZeros}
           />
         ))}
       </div>

--- a/packages/math-inline/configure/src/index.js
+++ b/packages/math-inline/configure/src/index.js
@@ -18,7 +18,12 @@ export default class MathInlineConfigure extends HTMLElement {
 
     // making sure that validation type is set
     if (!isEmpty(model.responses)) {
-      model.responses = model.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal', allowTrailingZeros: correctResponse.allowTrailingZeros || false, ignoreOrder: correctResponse.ignoreOrder || false }))
+      model.responses = model.responses.map(correctResponse => ({
+        ...correctResponse,
+        validation: correctResponse.validation || defaults.model.validationDefault,
+        allowTrailingZeros: correctResponse.allowTrailingZeros || defaults.model.allowTrailingZerosDefault,
+        ignoreOrder: correctResponse.ignoreOrder || defaults.model.ignoreOrderDefault
+      }))
     }
 
     return { ...defaults.model, ...model }

--- a/packages/math-inline/configure/src/index.js
+++ b/packages/math-inline/configure/src/index.js
@@ -22,7 +22,7 @@ export default class MathInlineConfigure extends HTMLElement {
         ...correctResponse,
         validation: correctResponse.validation || defaults.model.validationDefault,
         allowTrailingZeros: correctResponse.allowTrailingZeros || defaults.model.allowTrailingZerosDefault,
-        ignoreOrder: correctResponse.ignoreOrder || defaults.model.ignoreOrderDefault
+        ignoreOrder: correctResponse.ignoreOrder || defaults.model.ignoreOrderDefault || false
       }))
     }
 

--- a/packages/math-inline/configure/src/index.js
+++ b/packages/math-inline/configure/src/index.js
@@ -18,7 +18,7 @@ export default class MathInlineConfigure extends HTMLElement {
 
     // making sure that validation type is set
     if (!isEmpty(model.responses)) {
-      model.responses = model.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal' }))
+      model.responses = model.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal', allowTrailingZeros: correctResponse.allowTrailingZeros || false, ignoreOrder: correctResponse.ignoreOrder || false }))
     }
 
     return { ...defaults.model, ...model }

--- a/packages/math-inline/configure/src/index.js
+++ b/packages/math-inline/configure/src/index.js
@@ -18,7 +18,7 @@ export default class MathInlineConfigure extends HTMLElement {
 
     // making sure that validation type is set
     if (!isEmpty(model.responses)) {
-      model.responses = model.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || "literal" }))
+      model.responses = model.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal' }))
     }
 
     return { ...defaults.model, ...model }

--- a/packages/math-inline/configure/src/response.jsx
+++ b/packages/math-inline/configure/src/response.jsx
@@ -136,19 +136,17 @@ class Response extends React.Component {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
-
     newResponse.allowTrailingZeros = !response.allowTrailingZeros;
-     onResponseChange(newResponse, index);
-  }
+    onResponseChange(newResponse, index);
+  };
 
-    onIgnoreOrderChange = (event) => {
+  onIgnoreOrderChange = (event) => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
-
     newResponse.ignoreOrder = !response.ignoreOrder;
-     onResponseChange(newResponse, index);
-  }
+    onResponseChange(newResponse, index);
+  };
 
   onAnswerChange = (answer) => {
     const { response, onResponseChange, index } = this.props;
@@ -264,8 +262,8 @@ class Response extends React.Component {
       validation,
       answer,
       alternates,
-      ignoreOrder: ignoreOrder = true,
-      allowTrailingZeros: allowTrailingZeros = true,
+      ignoreOrder,
+      allowTrailingZeros,
     } = response;
     const hasAlternates = Object.keys(alternates || {}).length > 0;
     const classNames = {
@@ -304,32 +302,29 @@ class Response extends React.Component {
           </div>
           {validation === 'literal' && (
             <div className={classes.flexContainer}>
-              {cAllowTrailingZeros.controls &&
-                cAllowTrailingZeros.controls == true && (
-                  <FormControlLabel
-                    label={cAllowTrailingZeros.label}
-                    control={
-                      <Checkbox
-                        checked={allowTrailingZeros}
-                        onChange={this.onAllowTrailingZerosChange}
-                      />
-                    }
-                  />
-                )}
+              {cAllowTrailingZeros.enabled && (
+                <FormControlLabel
+                  label={cAllowTrailingZeros.label}
+                  control={
+                    <Checkbox
+                      checked={allowTrailingZeros}
+                      onChange={this.onAllowTrailingZerosChange}
+                    />
+                  }
+                />
+              )}
 
-              {cIgnoreOrder.controls &&
-                cIgnoreOrder.controls == true && (
-                 <FormControlLabel
-                label={cIgnoreOrder.label}
-                control={
-                  <Checkbox
-                    checked={ignoreOrder}
-                    onChange={this.onIgnoreOrderChange}
-                  />
-                }
-              />
-                )}
-
+              {cIgnoreOrder.enabled && (
+                <FormControlLabel
+                  label={cIgnoreOrder.label}
+                  control={
+                    <Checkbox
+                      checked={ignoreOrder}
+                      onChange={this.onIgnoreOrderChange}
+                    />
+                  }
+                />
+              )}
             </div>
           )}
           <div className={classes.inputContainer}>

--- a/packages/math-inline/configure/src/response.jsx
+++ b/packages/math-inline/configure/src/response.jsx
@@ -137,7 +137,7 @@ class Response extends React.Component {
     const newResponse = { ...response };
 
 
-    newResponse?.allowTrailingZeros = !response.allowTrailingZeros;
+    newResponse.allowTrailingZeros = !response.allowTrailingZeros;
      onResponseChange(newResponse, index);
   }
 
@@ -146,7 +146,7 @@ class Response extends React.Component {
     const newResponse = { ...response };
 
 
-    newResponse?.ignoreOrder = !response.ignoreOrder;
+    newResponse.ignoreOrder = !response.ignoreOrder;
      onResponseChange(newResponse, index);
   }
 
@@ -258,11 +258,6 @@ class Response extends React.Component {
       cAllowTrailingZeros,
       cIgnoreOrder,
     } = this.props;
-    console.log(this.props, 'this props');
-
-    console.log(cAllowTrailingZeros, ' cAllowTrailingZeros');
-
-    console.log(cIgnoreOrder, 'cIgnoreOrder');
 
     const { showKeypad } = this.state;
     const {

--- a/packages/math-inline/configure/src/response.jsx
+++ b/packages/math-inline/configure/src/response.jsx
@@ -16,33 +16,33 @@ import { withStyles } from '@material-ui/core/styles';
 // TODO once we support individual response correctness, we need to remove this constant
 const INDIVIDUAL_RESPONSE_CORRECTNESS_SUPPORTED = false;
 
-const styles = theme => ({
+const styles = (theme) => ({
   responseContainer: {
     marginTop: theme.spacing.unit * 2,
     width: '100%',
     border: '1px solid darkgray',
     display: 'flex',
     flexDirection: 'column',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
   },
   cardContent: {
-    paddingBottom: `${theme.spacing.unit}px !important`
+    paddingBottom: `${theme.spacing.unit}px !important`,
   },
   title: {
     fontWeight: 700,
     fontSize: '1.2rem',
-    flex: 3
+    flex: 3,
   },
   selectContainer: {
-    flex: 2
+    flex: 2,
   },
   inputContainer: {
-    marginTop: theme.spacing.unit
+    marginTop: theme.spacing.unit,
   },
   titleBar: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
   },
   responseEditor: {
     display: 'flex',
@@ -52,34 +52,34 @@ const styles = theme => ({
     minWidth: '500px',
     maxWidth: '900px',
     height: 'auto',
-    minHeight: '40px'
+    minHeight: '40px',
   },
   mathToolbar: {
-    width: '100%'
+    width: '100%',
   },
   configPanel: {
     display: 'flex',
     justifyContent: 'space-between',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   alternateButton: {
-    border: '1px solid lightgrey'
+    border: '1px solid lightgrey',
   },
   removeAlternateButton: {
     marginLeft: theme.spacing.unit * 2,
     border: '1px solid lightgrey',
     color: 'gray',
-    fontSize: '0.8rem'
+    fontSize: '0.8rem',
   },
   checkboxContainer: {
     marginTop: theme.spacing.unit * 2,
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center'
+    alignItems: 'center',
   },
   configLabel: {
-    marginRight: 'auto'
-  }
+    marginRight: 'auto',
+  },
 });
 
 class Response extends React.Component {
@@ -89,12 +89,14 @@ class Response extends React.Component {
     mode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     index: PropTypes.number,
     onResponseChange: PropTypes.func.isRequired,
-    response: PropTypes.object.isRequired
+    response: PropTypes.object.isRequired,
+    cIgnoreOrder: PropTypes.object.isRequired,
+    cAllowTrailingZeros: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
     defaultResponse: false,
-    mode: 'miscellaneous'
+    mode: 'miscellaneous',
   };
 
   constructor(props) {
@@ -107,12 +109,12 @@ class Response extends React.Component {
       alternateIdCounter: alternatesLength + 1,
       showKeypad: {
         openCount: 0,
-        main: false
-      }
+        main: false,
+      },
     };
   }
 
-  onChange = name => evt => {
+  onChange = (name) => (evt) => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
@@ -121,7 +123,7 @@ class Response extends React.Component {
     onResponseChange(newResponse, index);
   };
 
-  onConfigChanged = name => evt => {
+  onConfigChanged = (name) => (evt) => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
@@ -130,7 +132,7 @@ class Response extends React.Component {
     onResponseChange(newResponse, index);
   };
 
-  onAnswerChange = answer => {
+  onAnswerChange = (answer) => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
@@ -139,7 +141,7 @@ class Response extends React.Component {
     onResponseChange(newResponse, index);
   };
 
-  onAlternateAnswerChange = alternateId => answer => {
+  onAlternateAnswerChange = (alternateId) => (answer) => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
@@ -162,11 +164,11 @@ class Response extends React.Component {
     onResponseChange(newResponse, index);
 
     this.setState({
-      alternateIdCounter: alternateIdCounter + 1
+      alternateIdCounter: alternateIdCounter + 1,
     });
   };
 
-  onRemoveAlternate = alternateId => () => {
+  onRemoveAlternate = (alternateId) => () => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
 
@@ -174,75 +176,91 @@ class Response extends React.Component {
 
     onResponseChange(newResponse, index);
 
-    this.setState(state => ({
+    this.setState((state) => ({
       showKeypad: {
         ...state.showKeypad,
         openCount: !state.showKeypad[alternateId]
           ? state.showKeypad.openCount
-          : state.showKeypad.openCount - 1
-      }
+          : state.showKeypad.openCount - 1,
+      },
     }));
   };
 
   onDone = () => {
-    this.setState(state => ({
+    this.setState((state) => ({
       showKeypad: {
         ...state.showKeypad,
         openCount: state.showKeypad.openCount - 1,
-        main: false
-      }
+        main: false,
+      },
     }));
   };
 
   onFocus = () => {
-    this.setState(state => ({
+    this.setState((state) => ({
       showKeypad: {
         ...state.showKeypad,
         openCount: !state.showKeypad.main
           ? state.showKeypad.openCount + 1
           : state.showKeypad.openCount,
-        main: true
-      }
+        main: true,
+      },
     }));
   };
 
-  onAlternateFocus = alternateId => () => {
-    this.setState(state => ({
+  onAlternateFocus = (alternateId) => () => {
+    this.setState((state) => ({
       showKeypad: {
         ...state.showKeypad,
         openCount: !state.showKeypad[alternateId]
           ? state.showKeypad.openCount + 1
           : state.showKeypad.openCount,
-        [alternateId]: true
-      }
+        [alternateId]: true,
+      },
     }));
   };
 
-  onAlternateDone = alternateId => () => {
-    this.setState(state => ({
+  onAlternateDone = (alternateId) => () => {
+    this.setState((state) => ({
       showKeypad: {
         ...state.showKeypad,
         openCount: state.showKeypad.openCount - 1,
-        [alternateId]: false
-      }
+        [alternateId]: false,
+      },
     }));
   };
 
   render() {
-    const { classes, mode, defaultResponse, index, response } = this.props;
+    const {
+      classes,
+      mode,
+      defaultResponse,
+      index,
+      response,
+      cAllowTrailingZeros,
+      cIgnoreOrder,
+    } = this.props;
+    console.log(this.props, 'this props');
+
+    console.log(cAllowTrailingZeros, ' cAllowTrailingZeros');
+
+    console.log(cIgnoreOrder, 'cIgnoreOrder');
+
     const { showKeypad } = this.state;
     const {
       validation,
       answer,
       alternates,
+      ignoreOrder: ignoreOrder = true,
+      allowTrailingZeros: allowTrailingZeros = true,
     } = response;
     const hasAlternates = Object.keys(alternates || {}).length > 0;
     const classNames = {
       editor: classes.responseEditor,
-      mathToolbar: classes.mathToolbar
+      mathToolbar: classes.mathToolbar,
     };
     const styles = {
-      minHeight: `${showKeypad.openCount > 0 ? 430 : 230}px`
+      minHeight: `${showKeypad.openCount > 0 ? 430 : 230}px`,
     };
 
     return (
@@ -264,13 +282,43 @@ class Response extends React.Component {
               <Select
                 className={classes.select}
                 onChange={this.onChange('validation')}
-                value={validation || "literal"}
+                value={validation || 'literal'}
               >
                 <MenuItem value="literal">Literal Validation</MenuItem>
                 <MenuItem value="symbolic">Symbolic Validation</MenuItem>
               </Select>
             </InputContainer>
           </div>
+          {validation === 'literal' && (
+            <div className={classes.flexContainer}>
+              {cAllowTrailingZeros.controls &&
+                cAllowTrailingZeros.controls == true && (
+                  <FormControlLabel
+                    label={cAllowTrailingZeros.label}
+                    control={
+                      <Checkbox
+                        checked={allowTrailingZeros}
+                        onChange={this.onAllowTrailingZerosChange}
+                      />
+                    }
+                  />
+                )}
+
+              {cIgnoreOrder.controls &&
+                cIgnoreOrder.controls == true && (
+                 <FormControlLabel
+                label={cIgnoreOrder.label}
+                control={
+                  <Checkbox
+                    checked={ignoreOrder}
+                    onChange={this.onIgnoreOrder}
+                  />
+                }
+              />
+                )}
+
+            </div>
+          )}
           <div className={classes.inputContainer}>
             <InputLabel>Correct Answer</InputLabel>
             <MathToolbar
@@ -321,8 +369,7 @@ class Response extends React.Component {
               >
                 ADD ALTERNATE
               </Button>
-              <div className={classes.checkboxContainer}>
-              </div>
+              <div className={classes.checkboxContainer}></div>
             </div>
           )}
         </CardContent>

--- a/packages/math-inline/configure/src/response.jsx
+++ b/packages/math-inline/configure/src/response.jsx
@@ -132,6 +132,24 @@ class Response extends React.Component {
     onResponseChange(newResponse, index);
   };
 
+  onAllowTrailingZerosChange = (event) => {
+    const { response, onResponseChange, index } = this.props;
+    const newResponse = { ...response };
+
+
+    newResponse?.allowTrailingZeros = !response.allowTrailingZeros;
+     onResponseChange(newResponse, index);
+  }
+
+    onIgnoreOrderChange = (event) => {
+    const { response, onResponseChange, index } = this.props;
+    const newResponse = { ...response };
+
+
+    newResponse?.ignoreOrder = !response.ignoreOrder;
+     onResponseChange(newResponse, index);
+  }
+
   onAnswerChange = (answer) => {
     const { response, onResponseChange, index } = this.props;
     const newResponse = { ...response };
@@ -311,7 +329,7 @@ class Response extends React.Component {
                 control={
                   <Checkbox
                     checked={ignoreOrder}
-                    onChange={this.onIgnoreOrder}
+                    onChange={this.onIgnoreOrderChange}
                   />
                 }
               />

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -123,9 +123,9 @@ export const normalize = (question) => {
   // making sure that validation type is set
   if (!isEmpty(question.responses)) {
     question.responses = question.responses.map(correctResponse => ({
-      ...correctResponse, validation: correctResponse.validation || defaults.model.validationDefault,
-      allowTrailingZeros: correctResponse.allowTrailingZeros || defaults.model.allowTrailingZerosDefault,
-      ignoreOrder: correctResponse.ignoreOrder || defaults.model.ignoreOrderDefault
+      ...correctResponse, validation: correctResponse.validation || question.validationDefault,
+      allowTrailingZeros: correctResponse.allowTrailingZeros || question.allowTrailingZerosDefault,
+      ignoreOrder: correctResponse.ignoreOrder || question.ignoreOrderDefault
     }))
   }
 

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -50,7 +50,7 @@ function getIsAnswerCorrect(correctResponseItem, answerItem) {
   correctResponseItem.forEach(correctResponse => {
 
     let opts = {
-      mode: correctResponse.validation || 'literal'
+      mode: correctResponse.validation || defaults.validationDefault
     }
 
     if (opts.mode == 'literal') {
@@ -122,7 +122,11 @@ export const normalize = (question) => {
 
   // making sure that validation type is set
   if (!isEmpty(question.responses)) {
-    question.responses = question.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal', allowTrailingZeros: correctResponse.allowTrailingZeros || false, ignoreOrder: correctResponse.ignoreOrder || false }))
+    question.responses = question.responses.map(correctResponse => ({
+      ...correctResponse, validation: correctResponse.validation || defaults.model.validationDefault,
+      allowTrailingZeros: correctResponse.allowTrailingZeros || defaults.model.allowTrailingZerosDefault,
+      ignoreOrder: correctResponse.ignoreOrder || defaults.model.ignoreOrderDefault
+    }))
   }
 
   return {

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -50,10 +50,10 @@ function getIsAnswerCorrect(correctResponseItem, answerItem) {
   correctResponseItem.forEach(correctResponse => {
 
     let opts = {
-      mode: correctResponse.validation || "literal"
+      mode: correctResponse.validation || 'literal'
     }
 
-    if (opts.mode == "literal") {
+    if (opts.mode == 'literal') {
       opts.literal = {
         allowTrailingZeros: correctResponse.allowTrailingZeros || false,
         ignoreOrder: correctResponse.ignoreOrder || false,
@@ -122,7 +122,7 @@ export const normalize = (question) => {
 
   // making sure that validation type is set
   if (!isEmpty(question.responses)) {
-    question.responses = question.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || "literal" }))
+    question.responses = question.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal' }))
   }
 
   return {

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -122,7 +122,7 @@ export const normalize = (question) => {
 
   // making sure that validation type is set
   if (!isEmpty(question.responses)) {
-    question.responses = question.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal' }))
+    question.responses = question.responses.map(correctResponse => ({ ...correctResponse, validation: correctResponse.validation || 'literal', allowTrailingZeros: correctResponse.allowTrailingZeros || false, ignoreOrder: correctResponse.ignoreOrder || false }))
   }
 
   return {

--- a/packages/math-inline/docs/config-schema.json
+++ b/packages/math-inline/docs/config-schema.json
@@ -115,6 +115,48 @@
         }
       }
     },
+    "ignoreOrder": {
+      "title": "ConfigurePropWithEnabled",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        },
+        "enabled": {
+          "description": "Indicates the value of the item if it affects config-ui\n(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)",
+          "type": "boolean",
+          "title": "enabled"
+        }
+      }
+    },
+    "allowTrailingZeros": {
+      "title": "ConfigurePropWithEnabled",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        },
+        "enabled": {
+          "description": "Indicates the value of the item if it affects config-ui\n(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)",
+          "type": "boolean",
+          "title": "enabled"
+        }
+      }
+    },
     "showPrompt": {
       "description": "Determines whether prompt field will be displayed or not",
       "default": true,
@@ -148,6 +190,27 @@
           "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
           "type": "string",
           "title": "label"
+        }
+      }
+    },
+    "ConfigurePropWithEnabled": {
+      "title": "ConfigurePropWithEnabled",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        },
+        "enabled": {
+          "description": "Indicates the value of the item if it affects config-ui\n(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)",
+          "type": "boolean",
+          "title": "enabled"
         }
       }
     }

--- a/packages/math-inline/docs/config-schema.json.md
+++ b/packages/math-inline/docs/config-schema.json.md
@@ -86,6 +86,40 @@ Indicates if the item has to be displayed in the Settings Panel
 
 Indicates the label for the item that has to be displayed in the Settings Panel
 
+# `ignoreOrder` (object)
+
+Properties of the `ignoreOrder` object:
+
+## `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+## `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+## `enabled` (boolean)
+
+Indicates the value of the item if it affects config-ui
+(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)
+
+# `allowTrailingZeros` (object)
+
+Properties of the `allowTrailingZeros` object:
+
+## `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+## `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+## `enabled` (boolean)
+
+Indicates the value of the item if it affects config-ui
+(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)
+
 # `showPrompt` (boolean)
 
 Determines whether prompt field will be displayed or not
@@ -121,3 +155,20 @@ Indicates if the item has to be displayed in the Settings Panel
 ### `label` (string)
 
 Indicates the label for the item that has to be displayed in the Settings Panel
+
+## `ConfigurePropWithEnabled` (object)
+
+Properties of the `ConfigurePropWithEnabled` object:
+
+### `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+### `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+### `enabled` (boolean)
+
+Indicates the value of the item if it affects config-ui
+(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)

--- a/packages/math-inline/docs/pie-schema.json
+++ b/packages/math-inline/docs/pie-schema.json
@@ -372,17 +372,17 @@
       "type": "boolean",
       "title": "partialScoring"
     },
-    "ignoreOrder": {
-      "description": "Indicates if ignoreOrder option is shown on Design Screen",
+    "ignoreOrderDefault": {
+      "description": "Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct",
       "default": "is false",
       "type": "boolean",
-      "title": "ignoreOrder"
+      "title": "ignoreOrderDefault"
     },
-    "allowTrailingZeros": {
-      "description": "Indicates if allowTrailingZeros option is shown on Design Screen",
+    "allowTrailingZerosDefault": {
+      "description": "Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct",
       "default": "is false",
       "type": "boolean",
-      "title": "allowTrailingZeros"
+      "title": "allowTrailingZerosDefault"
     },
     "rationale": {
       "description": "Indicates the value for rationale",
@@ -463,12 +463,12 @@
     }
   },
   "required": [
-    "allowTrailingZeros",
+    "allowTrailingZerosDefault",
     "element",
     "expression",
     "feedbackEnabled",
     "id",
-    "ignoreOrder",
+    "ignoreOrderDefault",
     "rationaleEnabled",
     "responses",
     "studentInstructionsEnabled",
@@ -488,6 +488,27 @@
           "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
           "type": "string",
           "title": "label"
+        }
+      }
+    },
+    "ConfigurePropWithEnabled": {
+      "title": "ConfigurePropWithEnabled",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        },
+        "enabled": {
+          "description": "Indicates the value of the item if it affects config-ui\n(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)",
+          "type": "boolean",
+          "title": "enabled"
         }
       }
     },

--- a/packages/math-inline/docs/pie-schema.json
+++ b/packages/math-inline/docs/pie-schema.json
@@ -233,6 +233,18 @@
             "type": "string",
             "title": "validation"
           },
+          "ignoreOrder": {
+            "description": "Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct",
+            "default": "is false",
+            "type": "boolean",
+            "title": "ignoreOrder"
+          },
+          "allowTrailingZeros": {
+            "description": "Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct",
+            "default": "is false",
+            "type": "boolean",
+            "title": "allowTrailingZeros"
+          },
           "answer": {
             "description": "The answer for the question",
             "type": "string",
@@ -268,9 +280,11 @@
           }
         },
         "required": [
+          "allowTrailingZeros",
           "alternates",
           "answer",
           "id",
+          "ignoreOrder",
           "validation"
         ]
       },
@@ -297,6 +311,18 @@
           ],
           "type": "string",
           "title": "validation"
+        },
+        "ignoreOrder": {
+          "description": "Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct",
+          "default": "is false",
+          "type": "boolean",
+          "title": "ignoreOrder"
+        },
+        "allowTrailingZeros": {
+          "description": "Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct",
+          "default": "is false",
+          "type": "boolean",
+          "title": "allowTrailingZeros"
         },
         "answer": {
           "description": "The answer for the question",
@@ -333,9 +359,11 @@
         }
       },
       "required": [
+        "allowTrailingZeros",
         "alternates",
         "answer",
         "id",
+        "ignoreOrder",
         "validation"
       ]
     },
@@ -343,6 +371,18 @@
       "description": "Indicates if partial scoring is allowed.\nThis property is not used yet.",
       "type": "boolean",
       "title": "partialScoring"
+    },
+    "ignoreOrder": {
+      "description": "Indicates if ignoreOrder option is shown on Design Screen",
+      "default": "is false",
+      "type": "boolean",
+      "title": "ignoreOrder"
+    },
+    "allowTrailingZeros": {
+      "description": "Indicates if allowTrailingZeros option is shown on Design Screen",
+      "default": "is false",
+      "type": "boolean",
+      "title": "allowTrailingZeros"
     },
     "rationale": {
       "description": "Indicates the value for rationale",
@@ -423,10 +463,12 @@
     }
   },
   "required": [
+    "allowTrailingZeros",
     "element",
     "expression",
     "feedbackEnabled",
     "id",
+    "ignoreOrder",
     "rationaleEnabled",
     "responses",
     "studentInstructionsEnabled",
@@ -683,6 +725,18 @@
           "type": "string",
           "title": "validation"
         },
+        "ignoreOrder": {
+          "description": "Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct",
+          "default": "is false",
+          "type": "boolean",
+          "title": "ignoreOrder"
+        },
+        "allowTrailingZeros": {
+          "description": "Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct",
+          "default": "is false",
+          "type": "boolean",
+          "title": "allowTrailingZeros"
+        },
         "answer": {
           "description": "The answer for the question",
           "type": "string",
@@ -718,9 +772,11 @@
         }
       },
       "required": [
+        "allowTrailingZeros",
         "alternates",
         "answer",
         "id",
+        "ignoreOrder",
         "validation"
       ]
     },

--- a/packages/math-inline/docs/pie-schema.json.md
+++ b/packages/math-inline/docs/pie-schema.json.md
@@ -149,15 +149,15 @@ an object with some alternatives for the correct answers
 Indicates if partial scoring is allowed.
 This property is not used yet.
 
-# `ignoreOrder` (boolean, required)
+# `ignoreOrderDefault` (boolean, required)
 
-Indicates if ignoreOrder option is shown on Design Screen
+Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct
 
 Default: `"is false"`
 
-# `allowTrailingZeros` (boolean, required)
+# `allowTrailingZerosDefault` (boolean, required)
 
-Indicates if allowTrailingZeros option is shown on Design Screen
+Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct
 
 Default: `"is false"`
 
@@ -244,6 +244,23 @@ Indicates if the item has to be displayed in the Settings Panel
 ### `label` (string)
 
 Indicates the label for the item that has to be displayed in the Settings Panel
+
+## `ConfigurePropWithEnabled` (object)
+
+Properties of the `ConfigurePropWithEnabled` object:
+
+### `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+### `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+### `enabled` (boolean)
+
+Indicates the value of the item if it affects config-ui
+(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)
 
 ## `ComplexFeedbackType` (object)
 

--- a/packages/math-inline/docs/pie-schema.json.md
+++ b/packages/math-inline/docs/pie-schema.json.md
@@ -83,6 +83,18 @@ This element must be one of the following enum values:
 
 Default: `"is literal"`
 
+## `ignoreOrder` (boolean, required)
+
+Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct
+
+Default: `"is false"`
+
+## `allowTrailingZeros` (boolean, required)
+
+Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct
+
+Default: `"is false"`
+
 ## `answer` (string, required)
 
 The answer for the question
@@ -111,6 +123,18 @@ This element must be one of the following enum values:
 
 Default: `"is literal"`
 
+## `ignoreOrder` (boolean, required)
+
+Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct
+
+Default: `"is false"`
+
+## `allowTrailingZeros` (boolean, required)
+
+Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct
+
+Default: `"is false"`
+
 ## `answer` (string, required)
 
 The answer for the question
@@ -124,6 +148,18 @@ an object with some alternatives for the correct answers
 
 Indicates if partial scoring is allowed.
 This property is not used yet.
+
+# `ignoreOrder` (boolean, required)
+
+Indicates if ignoreOrder option is shown on Design Screen
+
+Default: `"is false"`
+
+# `allowTrailingZeros` (boolean, required)
+
+Indicates if allowTrailingZeros option is shown on Design Screen
+
+Default: `"is false"`
 
 # `rationale` (string)
 
@@ -276,6 +312,18 @@ This element must be one of the following enum values:
 * `symbolic`
 
 Default: `"is literal"`
+
+### `ignoreOrder` (boolean, required)
+
+Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct
+
+Default: `"is false"`
+
+### `allowTrailingZeros` (boolean, required)
+
+Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct
+
+Default: `"is false"`
 
 ### `answer` (string, required)
 

--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -335,7 +335,7 @@ export class Main extends React.Component {
     // Safari Hack: https://stackoverflow.com/a/42764495/5757635
     setTimeout(() => {
       if (ref && IS_SAFARI) {
-        const div = document.querySelector("[role='tooltip']");
+        const div = document.querySelector('[role=\'tooltip\']');
         if (div) {
           const el = div.firstChild;
           el.setAttribute('tabindex', '-1');

--- a/packages/number-line/configure/src/main.jsx
+++ b/packages/number-line/configure/src/main.jsx
@@ -100,7 +100,7 @@ export class Main extends React.Component {
     const height = this.getAdjustedHeight(availableTypes, maxNumberOfPoints);
 
     this.graphChange({ height });
-  };
+  }
 
   graphChange = o => {
     const { onChange } = this.props;

--- a/packages/pie-models/src/pie/math-inline/index.ts
+++ b/packages/pie-models/src/pie/math-inline/index.ts
@@ -2,7 +2,7 @@ import { PieModel } from '../../PieModel';
 import { PromptConfig } from '../../PromptConfig';
 import { CommonConfigSettings } from '../../CommonConfigSettings';
 import { ComplexFeedbackType } from '../../Feedback';
-import { ConfigureProp } from '../ConfigurationProp';
+import { ConfigureProp, ConfigurePropWithEnabled } from '../ConfigurationProp';
 
 interface Alternate {
   /** The id for the alternative response */
@@ -107,15 +107,16 @@ export interface MathInlinePie extends PieModel {
   partialScoring?: boolean;
 
   /**
-   * Indicates if ignoreOrder option is shown on Design Screen
+   * Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct
    * @default is false
    */
-  ignoreOrder: boolean;
+  ignoreOrderDefault: boolean;
+
   /**
-   * Indicates if allowTrailingZeros option is shown on Design Screen
+   * Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct
    * @default is false
    */
-  allowTrailingZeros: boolean;
+  allowTrailingZerosDefault: boolean;
 
   /** Indicates the value for rationale */
   rationale?: string;
@@ -195,4 +196,14 @@ export interface MathInlineConfigure
    * Teacher Instructions configuration
    */
   teacherInstructions?: ConfigureProp;
+
+  /**
+   * Ignore Order configuration
+   */
+  ignoreOrder?: ConfigurePropWithEnabled;
+
+  /**
+   * Allow Trailing Zeros configuration
+   */
+  allowTrailingZeros?: ConfigurePropWithEnabled;
 }

--- a/packages/pie-models/src/pie/math-inline/index.ts
+++ b/packages/pie-models/src/pie/math-inline/index.ts
@@ -26,6 +26,18 @@ interface MathInlineResponse {
    */
   validation: 'literal' | 'symbolic';
 
+  /**
+   * Indicates if the order of expression elements in literal validation can be ignore - whilst the expression is still mathematically correct
+   * @default is false
+   */
+  ignoreOrder: boolean;
+
+  /**
+   * Indicates the allowance of trailing zeros in expressions - whilst the expression is still mathematically correct
+   * @default is false
+   */
+  allowTrailingZeros: boolean;
+
   /** The answer for the question */
   answer: string;
 
@@ -93,6 +105,17 @@ export interface MathInlinePie extends PieModel {
    * This property is not used yet.
    */
   partialScoring?: boolean;
+
+  /**
+   * Indicates if ignoreOrder option is shown on Design Screen
+   * @default is false
+   */
+  ignoreOrder: boolean;
+  /**
+   * Indicates if allowTrailingZeros option is shown on Design Screen
+   * @default is false
+   */
+  allowTrailingZeros: boolean;
 
   /** Indicates the value for rationale */
   rationale?: string;


### PR DESCRIPTION
My task was: 
![image](https://user-images.githubusercontent.com/56835388/130398485-361d34f5-6585-485a-8a3b-69dd10bad394.png)

In order to be consistent in configuration I use `enabled` not `controls`.

Please see documentation here: 
/Users/carla/Documents/Work/pie-framework/pie-elements/packages/pie-models/src/pie/math-inline/index.ts

Resulted behaviour is the following:

Example 1. validation literal `ignoreOrder: { enabled :true} && allowTrailingZeros: {enabled: true}`
![image](https://user-images.githubusercontent.com/56835388/130400161-e16ab3fc-20f5-4fac-9a76-4fcb220e0c10.png)

Example 2. validation literal `ignoreOrder: { enabled :false} && allowTrailingZeros: {enabled: true}` && onDefault model we have ignoreOrder:true and allowTrailingZeros: true 

Design result will be this: 
![image](https://user-images.githubusercontent.com/56835388/130400746-62adbaea-16b4-4c5b-8c7a-d9361d09d98f.png)
 Validation will consider ignoreOrder option true, without possibility to change it from UI
