### PR TITLE
feat(passage): implement print PD-1282

### DIFF
--- a/packages/passage/package.json
+++ b/packages/passage/package.json
@@ -14,12 +14,17 @@
     "@pie-lib/render-ui": "^4.12.0",
     "prop-types": "^15.6.1",
     "react": "^16.8.1",
-    "react-dom": "^16.8.1"
+    "react-dom": "^16.8.1",
+    "classnames": "^2.2.5"
   },
   "gitHead": "0e14ff981bcdc8a89a0e58484026496701bfdbc3",
   "scripts": {
     "postpublish": "../../scripts/postpublish"
   },
   "main": "lib/index.js",
-  "module": "src/index.js"
+  "module": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./print": "./src/print.js"
+  }
 }

--- a/packages/passage/src/__tests__/__snapshots__/stimulus-tabs.test.jsx.snap
+++ b/packages/passage/src/__tests__/__snapshots__/stimulus-tabs.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`stimulus tabs snapshot should render component 1`] = `
       "root": "StimulusTabs-root-1",
       "stickyTabs": "StimulusTabs-stickyTabs-3",
       "tab": "StimulusTabs-tab-2",
+      "title": "StimulusTabs-title-4",
     }
   }
   tabs={

--- a/packages/passage/src/print.js
+++ b/packages/passage/src/print.js
@@ -16,7 +16,6 @@ const preparePrintPassage = model =>
     };
   });
 
-
 export default class PassagePrint extends HTMLElement {
   constructor() {
     super();
@@ -40,9 +39,6 @@ export default class PassagePrint extends HTMLElement {
       50,
       { leading: false, trailing: true }
     );
-  }
-  set options(o) {
-    this._options = o;
   }
 
   set model(s) {

--- a/packages/passage/src/print.js
+++ b/packages/passage/src/print.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import debounce from 'lodash/debounce';
+import StimulusTabs from './stimulus-tabs';
+import debug from 'debug';
+
+const log = debug('pie-element:passage:print');
+
+const preparePrintPassage = model =>
+  model.passages.map((passage, index) => {
+    return {
+      id: index,
+      title: passage.title,
+      text: passage.text,
+      disabledTabs: true
+    };
+  });
+
+
+export default class PassagePrint extends HTMLElement {
+  constructor() {
+    super();
+    this._model = null;
+    this._session = [];
+
+    this._rerender = debounce(
+      () => {
+        if (this._model && this._session) {
+          if (this._model.passages && this._model.passages.length > 0) {
+            const printPassage = preparePrintPassage(this._model);
+
+            const element = React.createElement(StimulusTabs, { tabs: printPassage });
+
+            ReactDOM.render(element, this);
+          }
+        } else {
+          log('skip');
+        }
+      },
+      50,
+      { leading: false, trailing: true }
+    );
+  }
+  set options(o) {
+    this._options = o;
+  }
+
+  set model(s) {
+    this._model = s;
+    this._rerender();
+  }
+
+  connectedCallback() {}
+}

--- a/packages/passage/src/print.js
+++ b/packages/passage/src/print.js
@@ -12,7 +12,6 @@ const preparePrintPassage = model =>
       id: index,
       title: passage.title,
       text: passage.text,
-      disabledTabs: true
     };
   });
 
@@ -28,7 +27,7 @@ export default class PassagePrint extends HTMLElement {
           if (this._model.passages && this._model.passages.length > 0) {
             const printPassage = preparePrintPassage(this._model);
 
-            const element = React.createElement(StimulusTabs, { tabs: printPassage });
+            const element = React.createElement(StimulusTabs, { tabs: printPassage, disabledTabs: true });
 
             ReactDOM.render(element, this);
           }

--- a/packages/passage/src/stimulus-tabs.jsx
+++ b/packages/passage/src/stimulus-tabs.jsx
@@ -5,7 +5,7 @@ import Tab from '@material-ui/core/Tab';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import { color, Purpose } from '@pie-lib/render-ui';
-import previewLayout from '@pie-lib/render-ui/lib/preview-layout';
+import classNames from 'classnames';
 
 const styles = (/*theme*/) => ({
   root: {
@@ -21,6 +21,13 @@ const styles = (/*theme*/) => ({
     paddingBottom: '20px',
     position: 'sticky',
     top: 0,
+  },
+  title: {
+    textTransform: 'uppercase',
+    padding: '6px 24px',
+    borderBottom: `2px solid ${color.secondary()}`,
+    width: 'fit-content',
+    marginBottom: '6px'
   }
 });
 
@@ -72,7 +79,26 @@ class StimulusTabs extends React.Component {
     const { activeTab } = this.state;
 
     if (tabs && tabs.length > 1) {
-      return (
+      return tabs[0].disabledTabs ? (
+        <div className="passages">
+          {tabs.map(tab =>
+            <div key={tab.id} className={`passage-${tab.id}`}>
+              <TabContainer multiple >
+                <div
+                  className={classNames(classes.title, 'title')}
+                  dangerouslySetInnerHTML={{ __html: this.parsedText(tab.title) }}
+                />
+                <Purpose purpose="passage-text">
+                  <div
+                    className="text"
+                    key={tab.id}
+                    dangerouslySetInnerHTML={{ __html: this.parsedText(tab.text) }}
+                  />
+                </Purpose>
+              </TabContainer>
+            </div>)}
+        </div>
+      ) : (
         <div className={classes.root}>
           <Tabs
             classes={{
@@ -89,7 +115,7 @@ class StimulusTabs extends React.Component {
                   <Purpose purpose="passage-title">
                     <span
                       dangerouslySetInnerHTML={{ __html: this.parsedText(tab.title) }}
-                    ></span>
+                    />
                   </Purpose>
                 }
                 value={tab.id}
@@ -114,9 +140,9 @@ class StimulusTabs extends React.Component {
 
     } else if (tabs && tabs[0]) {
       return (
-        <div style={{ whiteSpace: 'break-spaces' }} >
+        <div className="passage" style={{ whiteSpace: 'break-spaces' }} >
           <TabContainer>
-            <div dangerouslySetInnerHTML={{ __html: this.parsedText(tabs[0].text) }} />
+            <div className="text" dangerouslySetInnerHTML={{ __html: this.parsedText(tabs[0].text) }} />
           </TabContainer>
         </div>
       );
@@ -131,6 +157,7 @@ StimulusTabs.propTypes = {
       id: PropTypes.number.isRequired,
       title: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired,
+      disabledTabs: PropTypes.bool
     }).isRequired
   ).isRequired,
 };

--- a/packages/passage/src/stimulus-tabs.jsx
+++ b/packages/passage/src/stimulus-tabs.jsx
@@ -75,11 +75,11 @@ class StimulusTabs extends React.Component {
   parsedText = (text) => text.replace(/(<br\/>\n)/g, '<br/>');
 
   render() {
-    const { classes, tabs } = this.props;
+    const { classes, tabs, disabledTabs } = this.props;
     const { activeTab } = this.state;
 
     if (tabs && tabs.length > 1) {
-      return tabs[0].disabledTabs ? (
+      return disabledTabs ? (
         <div className="passages">
           {tabs.map(tab =>
             <div key={tab.id} className={`passage-${tab.id}`}>
@@ -157,9 +157,9 @@ StimulusTabs.propTypes = {
       id: PropTypes.number.isRequired,
       title: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired,
-      disabledTabs: PropTypes.bool
     }).isRequired
   ).isRequired,
+  disabledTabs: PropTypes.bool
 };
 
 export default withStyles(styles)(StimulusTabs);


### PR DESCRIPTION
Rendered tabs in sequence for more than one passage:
<img width="1076" alt="Screen Shot 2021-09-02 at 9 57 38 AM" src="https://user-images.githubusercontent.com/61793308/131802802-14e58134-26b8-4e31-af7b-1eb4cb9c20d8.png">
View with only one passage:
<img width="1061" alt="Screen Shot 2021-09-02 at 9 58 08 AM" src="https://user-images.githubusercontent.com/61793308/131802814-401c1407-6ca3-474e-a70d-0c3d93139e0e.png">
