### PR TITLE
fix(math-inline): make response area button to fit in response template area

### DIFF
--- a/packages/math-inline/configure/src/general-config-block.jsx
+++ b/packages/math-inline/configure/src/general-config-block.jsx
@@ -52,7 +52,7 @@ const styles = (theme) => ({
     justifyContent: 'center',
     width: '100%',
     minWidth: '500px',
-    maxWidth: '900px',
+    maxWidth: 'inherit',
     height: 'auto',
     minHeight: '130px',
     textAlign: 'left',


### PR DESCRIPTION
![image-20211005-034816](https://user-images.githubusercontent.com/56835388/136010934-1150bb85-4e10-41e9-ae95-50b8b6158d06.png)
