### PR TITLE
fix(hotspot): add support for removing --pie-zoom css property PD-360

### DIFF
--- a/packages/hotspot/src/hotspot/index.jsx
+++ b/packages/hotspot/src/hotspot/index.jsx
@@ -33,6 +33,10 @@ class HotspotComponent extends React.Component {
               scale: parseFloat(zoomParsed) / 100,
             })
           }
+        } else if (!zoomParsed && this.state.scale !== 1) {
+          this.setState({
+            scale: 1,
+          });
         }
       });
     });


### PR DESCRIPTION
User will be able to scale back to 1 by removing `--pie-zoom` property. Not reported yet by a tester but it's good to have it.

https://illuminate.atlassian.net/browse/PD-360 