### PR TITLE
fix(explicit-constructed-response): Maximum Length field should alway…

### DIFF
--- a/packages/explicit-constructed-response/configure/src/alternateSection.jsx
+++ b/packages/explicit-constructed-response/configure/src/alternateSection.jsx
@@ -11,6 +11,7 @@ import Select from '@material-ui/core/Select';
 import TextField from '@material-ui/core/TextField';
 import { withStyles } from '@material-ui/core/styles';
 import max from 'lodash/max';
+import { getAdjustedLength } from './markupUtils';
 
 const styles = () => ({
   altChoices: {
@@ -178,7 +179,7 @@ export class AlternateSection extends React.Component {
     });
 
     if (newLength > maxLength || newLength + 10 <= maxLength) {
-      lengthChanged(newLength);
+      lengthChanged(getAdjustedLength(newLength));
     }
   };
 

--- a/packages/explicit-constructed-response/configure/src/main.jsx
+++ b/packages/explicit-constructed-response/configure/src/main.jsx
@@ -164,18 +164,28 @@ export class Main extends React.Component {
 
   onChangeResponse = (index, newVal) => {
     const { model, onModelChanged} = this.props;
-    const { choices, maxLengthPerChoice } = model;
+    const { choices } = model;
+    let { maxLengthPerChoice } = model;
     const newValLength = (newVal || '').length;
 
     if (!choices[index]) {
-      choices[index] = [{ label: '', value: '0' }];
-      maxLengthPerChoice.splice(index, 0, newValLength);
-    }
+      choices[index] = [{ label: newVal || '', value: '0' }];
 
-    choices[index][0].label = newVal || '';
+      // add default values for missing choices up to the new index position
+      const nbOfMissingChoices = index > maxLengthPerChoice.length ? index - maxLengthPerChoice.length : 0;
 
-    if (maxLengthPerChoice && newVal && maxLengthPerChoice[index] < newValLength) {
-      maxLengthPerChoice[index] = newValLength;
+      maxLengthPerChoice = [ ...maxLengthPerChoice, ...Array(nbOfMissingChoices).fill(1) ];
+
+      maxLengthPerChoice.splice(index, 0, getAdjustedLength(newValLength));
+    } else {
+      choices[index][0].label = newVal || '';
+
+      if (
+        maxLengthPerChoice
+        && (maxLengthPerChoice[index] < newValLength || maxLengthPerChoice[index] > newValLength + 10)
+      ) {
+        maxLengthPerChoice[index] = getAdjustedLength(newValLength);
+      }
     }
 
     onModelChanged({


### PR DESCRIPTION
…s appear when Maximum Length Per Choice is set to true PD-1591
https://illuminate.atlassian.net/browse/PD-1591