### PR TITLE
fix/PD-1677: MC Horizontal Layout Tweaks

### DIFF
--- a/packages/multiple-choice/src/choice-input.jsx
+++ b/packages/multiple-choice/src/choice-input.jsx
@@ -9,6 +9,8 @@ import FeedbackTick from './feedback-tick';
 import Radio from '@material-ui/core/Radio';
 import classNames from 'classnames';
 
+const CLASS_NAME = 'multiple-choice-component';
+
 const styleSheet = () => ({
   row: {
     display: 'flex',
@@ -24,6 +26,11 @@ const styleSheet = () => ({
       color: color.text(),
     },
   },
+  horizontalLayout: {
+    [`& .${CLASS_NAME}`]: {
+      paddingRight: '8px',
+    }
+  }
 });
 
 const formStyleSheet = {
@@ -38,8 +45,6 @@ export const StyledFormControlLabel = withStyles(formStyleSheet, {
 })((props) => (
   <FormControlLabel {...props} classes={{ label: props.classes.label }} />
 ));
-
-const CLASS_NAME = 'multiple-choice-component';
 
 const colorStyle = (varName, fallback) => ({
   [`&.${CLASS_NAME}`]: {
@@ -152,6 +157,7 @@ export class ChoiceInput extends React.Component {
     className: PropTypes.string,
     hideTick: PropTypes.bool,
     isEvaluateMode: PropTypes.bool,
+    choicesLayout: PropTypes.oneOf(['vertical', 'grid', 'horizontal']),
   };
 
   static defaultProps = {
@@ -188,16 +194,21 @@ export class ChoiceInput extends React.Component {
       accessibility,
       hideTick,
       isEvaluateMode,
+      choicesLayout
     } = this.props;
 
     const Tag = choiceMode === 'checkbox' ? StyledCheckbox : StyledRadio;
     const classSuffix = choiceMode === 'checkbox' ? 'checkbox' : 'radio-button';
 
+    const holderClassNames = classNames(classes.checkboxHolder, {
+      [classes.horizontalLayout]: choicesLayout === 'horizontal',
+    });
+
     return (
       <div className={classNames(className, 'corespring-' + classSuffix, 'choice-input')}>
         <div className={classes.row}>
           {(!hideTick && isEvaluateMode) && <FeedbackTick correctness={correctness} />}
-          <div className={classNames(classes.checkboxHolder, 'checkbox-holder')}>
+          <div className={classNames(holderClassNames, 'checkbox-holder')}>
             <StyledFormControlLabel
               disabled={disabled}
               label={displayKey ? displayKey + '. ' : ''}

--- a/packages/multiple-choice/src/choice.jsx
+++ b/packages/multiple-choice/src/choice.jsx
@@ -50,6 +50,7 @@ export class Choice extends React.Component {
     const names = classNames(classes.choice, {
       [classes.noBorder]:
         index === choicesLength - 1 || choicesLayout !== 'vertical',
+      [classes.horizontalLayout]: choicesLayout === 'horizontal',
     });
 
     return (
@@ -86,4 +87,13 @@ export default withStyles({
   noBorder: {
     borderBottom: 'none',
   },
+  horizontalLayout: {
+    paddingRight: '20px',
+    '& label': {
+      marginRight: '8px',
+      // '& span:first-child': {
+      //   paddingRight: 0
+      // }
+    },
+  }
 })(Choice);


### PR DESCRIPTION
## [PD-1677](https://illuminate.atlassian.net/browse/PD-1677)

- labels (letters/numbers) are closer to the controls (radio/checkbox)
- answer choices are closer to their labels
- added whitespace to the end of each choice

<img width="514" alt="Screen Shot 2022-05-12 at 4 43 30 PM" src="https://user-images.githubusercontent.com/613099/168164755-154ecf3c-cdd6-4aba-9dce-ab7c522f1f3b.png">

<img width="515" alt="Screen Shot 2022-05-12 at 4 44 08 PM" src="https://user-images.githubusercontent.com/613099/168164756-c92e5307-72c7-4edf-aee1-01175a9a5f1a.png">
