### PR TITLE
fix/PD-1770: Number line design treatment of rays in Evaluate

### DIFF
--- a/packages/number-line/src/number-line/graph/elements/ray.jsx
+++ b/packages/number-line/src/number-line/graph/elements/ray.jsx
@@ -35,12 +35,15 @@ const style = {
   correct: rayColor(colors.correct),
   incorrect: rayColor(colors.incorrect),
   arrowCorrect: {
+    fill: colors.correct,
     '--arrow-color': colors.correct
   },
   arrowIncorrect: {
+    fill: colors.incorrect,
     '--arrow-color': colors.incorrect
   },
   arrowSelected: {
+    fill: colors.selected,
     '--arrow-color': colors.selected
   }
 };


### PR DESCRIPTION
## [PD-1770](https://illuminate.atlassian.net/browse/PD-1770)

Correct and incorrect arrow colors should now match the ray color.

<img width="554" alt="Screen Shot 2022-05-18 at 5 07 11 PM" src="https://user-images.githubusercontent.com/613099/169156459-769d5f27-f57d-4fc8-9d86-1855c362b4fe.png">

<img width="555" alt="Screen Shot 2022-05-18 at 5 07 39 PM" src="https://user-images.githubusercontent.com/613099/169156462-300e2bba-fc67-4df2-be00-ca7e464eef6e.png">
