### PR TITLE
feat/PD-1723-C

### DIFF
--- a/packages/charting/configure/src/correct-response.jsx
+++ b/packages/charting/configure/src/correct-response.jsx
@@ -2,13 +2,15 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { Chart } from '@pie-lib/charting';
+import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
 
-const styles = theme => ({
+const styles = (theme) => ({
   container: {
     border: '2px solid #ababab',
     borderRadius: '4px',
     padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 4}px`,
-    background: '#fafafa'
+    background: '#fafafa',
   },
   button: {
     marginTop: theme.spacing.unit * 3,
@@ -16,19 +18,119 @@ const styles = theme => ({
     background: '#eee',
     padding: theme.spacing.unit * 2,
     width: 'fit-content',
-    borderRadius: '4px'
-  }
+    borderRadius: '4px',
+  },
 });
 
+const updateCorrectResponseData = (correctAnswer, data) => {
+  if (!correctAnswer) {
+    return data;
+  }
+
+  let correctResponseDefinition = [];
+
+  data.forEach((category, currentIndex) => {
+    const editable = category.editable;
+    const interactive = category.interactive;
+
+    const label = (editable && correctAnswer[currentIndex]?.label)
+      ? correctAnswer[currentIndex].label
+      : category.label
+
+    const value = (interactive && correctAnswer[currentIndex]?.value)
+      ? correctAnswer[currentIndex].value
+      : category.value
+
+    correctResponseDefinition[currentIndex] = {
+      label: label,
+      value: value,
+      editable: category.editable,
+      interactive: category.interactive,
+    };
+  });
+
+  if (correctResponseDefinition.length < correctAnswer.length) {
+    const missingCategories = correctAnswer.slice(correctResponseDefinition.length, correctAnswer.length)
+
+    return correctResponseDefinition.concat(missingCategories);
+  }
+
+  return correctResponseDefinition;
+};
+
+const insertCategory = (correctAnswer, data) => {
+  const positionToInsert = data.length - 1
+  const categoryToInsert = data[data.length - 1]
+
+  correctAnswer.splice(positionToInsert, 0, categoryToInsert);
+
+  return correctAnswer
+}
+
+const removeCategory = (correctAnswer, data) => {
+  const positionToRemove = data.length - 1
+
+  correctAnswer.splice(positionToRemove, 1);
+
+  return correctAnswer
+}
 export class CorrectResponse extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     model: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    charts: PropTypes.array
+    charts: PropTypes.array,
   };
 
-  changeData = data => {
+  constructor(props) {
+    super(props);
+    this.state = {
+      categories: updateCorrectResponseData(
+        props.model.correctAnswer.data,
+        props.model.data
+      )
+    };
+  }
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const {
+      model: {
+        data: nextData = [],
+        correctAnswer: { data: nextCorrectAnswerData = [] },
+      } = {},
+    } = nextProps;
+    
+    const {
+      model: {
+        data = [],
+      } = {},
+    } = this.props;
+
+    let nextCategories = [];
+
+    if (nextData.length > data.length && nextCorrectAnswerData.length > data.length) {
+      nextCategories= insertCategory( nextCorrectAnswerData, nextData);
+    }
+
+    if (nextData.length < data.length) {
+      nextCategories = removeCategory( nextCorrectAnswerData, nextData);
+   }
+
+   if (!isEqual(nextCorrectAnswerData, this.props.model.correctAnswer.data)){
+    nextCategories =nextCorrectAnswerData;
+  } else if (isEmpty(nextCategories)) {
+    nextCategories = updateCorrectResponseData(
+      nextCorrectAnswerData,
+      nextData
+    );
+  }
+
+    if (!isEqual(nextCategories, data)) {
+      this.setState({ categories: nextCategories });
+    }
+  }
+
+  changeData = (data) => {
     const { model, onChange } = this.props;
     const { correctAnswer } = model || {};
 
@@ -36,32 +138,33 @@ export class CorrectResponse extends React.Component {
       ...model,
       correctAnswer: {
         ...correctAnswer,
-        data
-      }
+        data: data,
+      },
     });
   };
 
   render() {
-    const { classes, model, charts } = this.props;
+    const {  model, charts } = this.props;
+    const { categories } = this.state;
 
     return (
       <div>
         Define Correct Response
-          <div key={`correct-response-graph-${model.correctAnswer.name}`}>
-            <p>{model.correctAnswer.name}</p>
-            <Chart
-              chartType={model.chartType}
-              size={model.graph}
-              domain={model.domain}
-              range={model.range}
-              charts={charts}
-              data={model.correctAnswer.data || []}
-              title={model.title}
-              onDataChange={(data) => this.changeData(data)}
-              addCategoryEnabled={model.addCategoryEnabled}
-              categoryDefaultLabel={model.categoryDefaultLabel}
-            />
-          </div>
+        <div key={`correct-response-graph-${model.correctAnswer.name}`}>
+          <p>{model.correctAnswer.name}</p>
+          <Chart
+            chartType={model.chartType}
+            size={model.graph}
+            domain={model.domain}
+            range={model.range}
+            charts={charts}
+            data={categories}
+            title={model.title}
+            onDataChange={(data) => this.changeData(data)}
+            addCategoryEnabled={model.addCategoryEnabled}
+            categoryDefaultLabel={model.categoryDefaultLabel}
+          />
+        </div>
       </div>
     );
   }

--- a/packages/charting/docs/demo/generate.js
+++ b/packages/charting/docs/demo/generate.js
@@ -8,21 +8,15 @@ exports.model = (id, element) => ({
     data: [
       {
         label: 'A',
-        value: 1,
-        interactive: false,
-        editable: false
+        value: 1
       },
       {
         label: 'B',
-        value: 1,
-        interactive: true,
-        editable: false
+        value: 1
       },
       {
         label: 'C',
-        value: 1,
-        interactive: true,
-        editable: false
+        value: 1
       },
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,10 +2237,10 @@
     debug "^4.1.1"
     lodash "^4.17.11"
 
-"@pie-lib/charting@^4.5.18":
-  version "4.5.18"
-  resolved "https://registry.yarnpkg.com/@pie-lib/charting/-/charting-4.5.18.tgz#e532abc155d732cc6f8adcd22e3e6fdd9fdd0acd"
-  integrity sha512-i+9RgUVxcRO/EXaKmZrcEvSg+4GDAo7h/o5pOnF/y46n9Dh/W1dIAR1ISVNxCDCYDX1/AfN36s4B6RVwCJdgbA==
+"@pie-lib/charting@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@pie-lib/charting/-/charting-5.0.0.tgz#d3563a69b089466a9cf0cbefa2d32b4d3adc66c4"
+  integrity sha512-I+kion3SGjYhnU1fbi9w6IAg2b0IYsWxdHmCeC+w9pjmNbR2d3nGw8EhVsXMqD6F0uUJ36KhDZs3NMQwqTdLvw==
   dependencies:
     "@mapbox/point-geometry" "^0.1.0"
     "@material-ui/core" "^3.8.3"


### PR DESCRIPTION
 Whenever an author adds a Category to “Chart 1”, it should also be added to “Chart 2”, and whenever an author deletes a Category from “Chart 1”, it should also be removed from “Chart 2”. So “Chart 2” should always include all the Categories that are present in “Chart 1”—although in some cases, it may not be readily apparent that a given Category is “the same category” in both places, since its “Chart 2” name could be different.

We don’t support any capacity to move categories around, so if “Chart 1” has Categories 1 to n, “Chart 2” should also have Categories 1 to n, and the correspondences can be established by position. “Chart 2” could also have additional categories, n+1, n+2, etc., if “Student can Add Categories” is set to true. But there should always be an exact 1 to 1 correspondence between the n Categories on “Chart 1” and first n Categories on “Chart 2”.

In other words, If the author deletes the ith Category on “Chart 1”, the ith Category on “Chart 2” should also be deleted. And if the author adds a Category to “Chart 1”, that same Category should be added to “Chart 2”. In the event that “Chart 2” includes Categories that are not on Chart 1, then the new Category should be added before the first of those. Example: Chart 1 has three Categories, which have the names “Cat A”, “Cat B”, and “Cat C”. In “Chart 2”, those categories have been given the new names “Apple”, “Banana”, and “Cherry”. Furthermore, “Chart 2” has two categories that are not present in “Chart 1”, which have been given the names “Lemon” and “Mango”. The author then adds a new Category to “Chart 1” and labels it there as “Cat D”. The same Category should be added to “Chart 2”, where it should be positioned immediately after “Cherry” (which is also immediately before “Lemon”).

In addition: when a Category’s name is changed in “Chart 1”, if that Category’s name is not editable in Chart 2, then the name change should also propagate to “Chart 2”; if that Category’s name is editable in Chart 2, then the “Chart 1” name change should not affect “Chart 2.

Similarly: when a Category’s value is changed in “Chart 1”, if that Category’s value is not changeable in Chart 2, then the change should also appear in “Chart 2”; if that Category’s value is changeable in Chart 2, then the “Chart 1” value change should not affect “Chart 2.

In all cases, the principle is that to whatever extent a particular aspect of the Chart’s design is not manipulatable in “Chart 2”, “Chart 2” must be kept in sync with “Chart 1” in order to produce a valid item. But conversely, to whatever extent a particular aspect of the Chart’s design is manipulatable in “Chart 2”, changes to “Chart 1” should not propagate to “Chart 2”, and vice versa.