### PR TITLE
fix(multi-trait-rubric): fix windows scrollbar showing for no reason …

### DIFF
--- a/packages/multi-trait-rubric/src/scale.jsx
+++ b/packages/multi-trait-rubric/src/scale.jsx
@@ -13,7 +13,7 @@ const styles = (theme) => ({
   },
   tableWrapper: {
     width: '100%',
-    overflow: 'scroll'
+    overflow: 'auto'
   },
   table: {
     borderSpacing: 0,


### PR DESCRIPTION
…PD-2749

For windows: Setting it to auto will display the scrollbar if its needed only, while scroll suggests there should always be a scrollbar.
https://illuminate.atlassian.net/browse/PD-2749 