### PR TITLE
feat(multiple-choice): add translations

### DIFF
--- a/packages/multiple-choice/configure/src/defaults.js
+++ b/packages/multiple-choice/configure/src/defaults.js
@@ -111,5 +111,14 @@ export default {
       mmlOutput: false,
       mmlEditing: false,
     },
+    language: {
+      settings: false,
+      label: 'Specify Language',
+      enabled: false,
+    },
+    languageChoices: {
+      label: 'Language Choices',
+      options: [],
+    },
   },
 };

--- a/packages/multiple-choice/configure/src/index.js
+++ b/packages/multiple-choice/configure/src/index.js
@@ -86,7 +86,40 @@ export default class MultipleChoice extends HTMLElement {
     const info = prepareCustomizationObject(c, this._model);
 
     this.onModelChanged(info.model);
-    this._configuration = info.configuration;
+
+    const newConfiguration = {
+      ...sensibleDefaults.configuration,
+      ...info.configuration,
+    };
+    this._configuration = newConfiguration;
+
+    // if language:enabled is true, then the corresponding default item model should include a language value;
+    // if it is false, then the language field should be omitted from the item model.
+    // if a default item model includes a language value (e.g., en_US) and the corresponding authoring view settings have language:settings = true,
+    // then (a) language:enabled should also be true, and (b) that default language value should be represented in languageChoices[] (as a key).
+    if (newConfiguration?.language?.enabled) {
+      if (newConfiguration?.languageChoices?.options?.length) {
+        this._model.language = newConfiguration?.languageChoices.options[0].value;
+      }
+    } else if (newConfiguration.language.settings && this._model.language) {
+      this._configuration.language.enabled = true;
+
+      if (!this._configuration.languageChoices.options || !this._configuration.languageChoices.options.length) {
+        this._configuration.languageChoices.options = [];
+      }
+
+      // check if the language is already included in the languageChoices.options array
+      // and if not, then add it.
+      if (!this._configuration.languageChoices.options.find(option => option.value === this._model.language)) {
+        this._configuration.languageChoices.options.push({
+          value: this._model.language,
+          label: this._model.language,
+        });
+      }
+    } else {
+      delete this._model.language;
+    }
+
     this._render();
   }
 

--- a/packages/multiple-choice/configure/src/main.jsx
+++ b/packages/multiple-choice/configure/src/main.jsx
@@ -127,6 +127,8 @@ const Design = withStyles(styles)((props) => {
     prompt = {},
     withRubric = {},
     mathMlOptions = {},
+    language = {},
+    languageChoices = {},
   } = configuration || {};
   let { maxAnswerChoices } = configuration || {};
   const {
@@ -178,6 +180,8 @@ const Design = withStyles(styles)((props) => {
       model.choicesLayout === 'grid' &&
       nrOfColumnsAvailable.length > 0 &&
       dropdown(gridColumns.label, nrOfColumnsAvailable),
+    'language.enabled': language.settings && toggle(language.label, true),
+    language: language.settings && language.enabled && dropdown(languageChoices.label, languageChoices.options),
   };
 
   const panelProperties = {

--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -87,6 +87,7 @@ export async function model(question, session, env, updateSession) {
     keyMode: normalizedQuestion.choicePrefix,
     choices,
     responseCorrect: env.mode === 'evaluate' ? isResponseCorrect(normalizedQuestion, session) : undefined,
+    language: normalizedQuestion.language,
   };
 
   const { role, mode } = env || {};

--- a/packages/multiple-choice/docs/config-schema.json
+++ b/packages/multiple-choice/docs/config-schema.json
@@ -386,6 +386,66 @@
         }
       }
     },
+    "language": {
+      "title": "ConfigurePropWithEnabled",
+      "type": "object",
+      "properties": {
+        "settings": {
+          "description": "Indicates if the item has to be displayed in the Settings Panel",
+          "type": "boolean",
+          "title": "settings"
+        },
+        "label": {
+          "description": "Indicates the label for the item that has to be displayed in the Settings Panel",
+          "type": "string",
+          "title": "label"
+        },
+        "enabled": {
+          "description": "Indicates the value of the item if it affects config-ui\n(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)",
+          "type": "boolean",
+          "title": "enabled"
+        }
+      }
+    },
+    "languageChoices": {
+      "description": "Language choices configuration\nOnly available if language is enabled",
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "title": "label"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "title": "ConfigureLanguageOptionsProp",
+            "type": "object",
+            "properties": {
+              "value": {
+                "description": "Value of the language option",
+                "type": "string",
+                "title": "value"
+              },
+              "label": {
+                "description": "Label of the language option",
+                "type": "string",
+                "title": "label"
+              }
+            },
+            "required": [
+              "label",
+              "value"
+            ]
+          },
+          "title": "options"
+        }
+      },
+      "required": [
+        "label",
+        "options"
+      ],
+      "title": "languageChoices"
+    },
     "showPrompt": {
       "description": "Determines whether prompt field will be displayed or not",
       "default": true,
@@ -528,6 +588,26 @@
           "title": "mmlEditing"
         }
       }
+    },
+    "ConfigureLanguageOptionsProp": {
+      "title": "ConfigureLanguageOptionsProp",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Value of the language option",
+          "type": "string",
+          "title": "value"
+        },
+        "label": {
+          "description": "Label of the language option",
+          "type": "string",
+          "title": "label"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/packages/multiple-choice/docs/config-schema.json.md
+++ b/packages/multiple-choice/docs/config-schema.json.md
@@ -297,6 +297,46 @@ Indicates if model should have mathML output instead of latex
 
 Indicates if mathML that's already in model should be editable
 
+# `language` (object)
+
+Properties of the `language` object:
+
+## `settings` (boolean)
+
+Indicates if the item has to be displayed in the Settings Panel
+
+## `label` (string)
+
+Indicates the label for the item that has to be displayed in the Settings Panel
+
+## `enabled` (boolean)
+
+Indicates the value of the item if it affects config-ui
+(eg.: if item is a switch and displaying an input on the config-ui depends on the switch value: on/off)
+
+# `languageChoices` (object)
+
+Language choices configuration
+Only available if language is enabled
+
+Properties of the `languageChoices` object:
+
+## `label` (string, required)
+
+## `options` (array, required)
+
+The object is an array with all elements of the type `object`.
+
+The array object has the following properties:
+
+### `value` (string, required)
+
+Value of the language option
+
+### `label` (string, required)
+
+Label of the language option
+
 # `showPrompt` (boolean)
 
 Determines whether prompt field will be displayed or not
@@ -415,3 +455,15 @@ Indicates if model should have mathML output instead of latex
 ### `mmlEditing` (number)
 
 Indicates if mathML that's already in model should be editable
+
+## `ConfigureLanguageOptionsProp` (object)
+
+Properties of the `ConfigureLanguageOptionsProp` object:
+
+### `value` (string, required)
+
+Value of the language option
+
+### `label` (string, required)
+
+Label of the language option

--- a/packages/multiple-choice/docs/pie-schema.json
+++ b/packages/multiple-choice/docs/pie-schema.json
@@ -188,6 +188,11 @@
       "type": "boolean",
       "title": "rubricEnabled"
     },
+    "language": {
+      "description": "Indicates the language of the component\nSupported options: en, es, en_US, en-US, es_ES, es-ES, es_MX, es-MX",
+      "type": "string",
+      "title": "language"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/multiple-choice/docs/pie-schema.json
+++ b/packages/multiple-choice/docs/pie-schema.json
@@ -291,6 +291,26 @@
         }
       }
     },
+    "ConfigureLanguageOptionsProp": {
+      "title": "ConfigureLanguageOptionsProp",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "Value of the language option",
+          "type": "string",
+          "title": "value"
+        },
+        "label": {
+          "description": "Label of the language option",
+          "type": "string",
+          "title": "label"
+        }
+      },
+      "required": [
+        "label",
+        "value"
+      ]
+    },
     "Choice": {
       "title": "Choice",
       "type": "object",

--- a/packages/multiple-choice/docs/pie-schema.json.md
+++ b/packages/multiple-choice/docs/pie-schema.json.md
@@ -237,6 +237,18 @@ Indicates if model should have mathML output instead of latex
 
 Indicates if mathML that's already in model should be editable
 
+## `ConfigureLanguageOptionsProp` (object)
+
+Properties of the `ConfigureLanguageOptionsProp` object:
+
+### `value` (string, required)
+
+Value of the language option
+
+### `label` (string, required)
+
+Label of the language option
+
 ## `Choice` (object)
 
 Properties of the `Choice` object:

--- a/packages/multiple-choice/docs/pie-schema.json.md
+++ b/packages/multiple-choice/docs/pie-schema.json.md
@@ -162,6 +162,11 @@ Indicates if Accessibility Labels are enabled
 
 Indicates if Rubric is enabled
 
+# `language` (string)
+
+Indicates the language of the component
+Supported options: en, es, en_US, en-US, es_ES, es-ES, es_MX, es-MX
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/multiple-choice/package.json
+++ b/packages/multiple-choice/package.json
@@ -11,6 +11,7 @@
     "@pie-lib/correct-answer-toggle": "^2.5.6",
     "@pie-lib/math-rendering": "^3.1.0",
     "@pie-lib/render-ui": "^4.15.4",
+    "@pie-lib/translator": "^2.2.0",
     "classnames": "^2.2.5",
     "debug": "^4.1.1",
     "enzyme-to-json": "^3.3.3",

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -70,6 +70,7 @@ export class MultipleChoice extends React.Component {
     gridColumns: PropTypes.string,
     alwaysShowCorrect: PropTypes.bool,
     animationsDisabled: PropTypes.bool,
+    language: PropTypes.string,
   };
 
   constructor(props) {
@@ -213,6 +214,7 @@ export class MultipleChoice extends React.Component {
       classes,
       alwaysShowCorrect,
       animationsDisabled,
+      language
     } = this.props;
     const { showCorrect } = this.state;
     const isEvaluateMode = mode === 'evaluate';
@@ -259,6 +261,7 @@ export class MultipleChoice extends React.Component {
               show={showCorrectAnswerToggle}
               toggled={showCorrect}
               onToggle={this.onToggle.bind(this)}
+              language={language}
             />
           )}
 

--- a/packages/pie-models/src/pie/multiple-choice/index.ts
+++ b/packages/pie-models/src/pie/multiple-choice/index.ts
@@ -2,7 +2,12 @@ import { Choice } from '../../Choice';
 import { PieModel } from '../../PieModel';
 import { CommonConfigSettings } from '../../CommonConfigSettings';
 import { PromptConfig } from '../../PromptConfig';
-import {ConfigureMathMLProp, ConfigureProp, ConfigurePropWithEnabled} from '../ConfigurationProp';
+import {
+  ConfigureLanguageOptionsProp,
+  ConfigureMathMLProp,
+  ConfigureProp,
+  ConfigurePropWithEnabled
+} from '../ConfigurationProp';
 
 /**
  * NOTE: teacherInstructions, studentInstructions, rationale & scoringType
@@ -232,4 +237,18 @@ export interface MultipleChoiceConfigure extends PromptConfig, CommonConfigSetti
 
   /** Configuration for editable-html */
   mathMlOptions?: ConfigureMathMLProp;
+
+  /**
+   * Language configuration
+   */
+  language?: ConfigurePropWithEnabled;
+
+  /**
+   * Language choices configuration
+   * Only available if language is enabled
+   */
+  languageChoices?: {
+    label: string;
+    options: ConfigureLanguageOptionsProp[];
+  };
 }

--- a/packages/pie-models/src/pie/multiple-choice/index.ts
+++ b/packages/pie-models/src/pie/multiple-choice/index.ts
@@ -88,6 +88,11 @@ export interface MultipleChoicePie extends PieModel {
 
   /** Indicates if Rubric is enabled */
   rubricEnabled: boolean;
+
+  /** Indicates the language of the component
+   * Supported options: en, es, en_US, en-US, es_ES, es-ES, es_MX, es-MX
+   */
+  language?: string;
 }
 
 interface ConfigureMaxImageDimensionsProp {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,7 +2909,7 @@
     react-portal "^4.2.0"
     trigonometry-calculator "^2.0.0"
 
-"@pie-lib/translator@^2.3.0":
+"@pie-lib/translator@^2.2.0", "@pie-lib/translator@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@pie-lib/translator/-/translator-2.3.0.tgz#e0e63fb273443bcdfaf0b187e3982a5e4b9e5543"
   integrity sha512-TtvSvHKuyws367dnxpUZj8gOiHSPJA+CBcEZFnmetNv+EC8Gid00wFyNUJ4/PhEmvIWvS7QN3YqzHlOk4QrYoQ==


### PR DESCRIPTION
apparently multiple-choice was left out during implementing translations, so I added them now. 
The correct answer toggle is the only affected UI label in player