### PR TITLE
feat(charting): Update default behavior of charting authoring UI properties. Update docs accordingly. PD-3216

### DIFF
--- a/packages/charting/configure/src/__tests__/__snapshots__/configure.test.js.snap
+++ b/packages/charting/configure/src/__tests__/__snapshots__/configure.test.js.snap
@@ -19,8 +19,8 @@ exports[`ChartingConfig renders snapshot 1`] = `
       </WithStyles(Typography)>
       <Chart
         addCategoryEnabled={true}
-        changeEditableEnabled={true}
-        changeInteractiveEnabled={true}
+        changeEditableEnabled={false}
+        changeInteractiveEnabled={false}
         chartType="lineCross"
         data={Array []}
         defineChart={true}
@@ -44,12 +44,6 @@ exports[`ChartingConfig renders snapshot 1`] = `
         }
         title=""
       />
-      <div>
-        <WithStyles(Checkbox)
-          checked={true}
-          onChange={[Function]}
-        />
-      </div>
       <Component
         open={false}
       />
@@ -216,9 +210,9 @@ exports[`Configure renders snapshot 1`] = `
       model={
         Object {
           "addCategoryEnabled": true,
-          "changeAddCategoryEnabled": true,
-          "changeEditableEnabled": true,
-          "changeInteractiveEnabled": true,
+          "changeAddCategoryEnabled": false,
+          "changeEditableEnabled": false,
+          "changeInteractiveEnabled": false,
           "chartType": "lineCross",
           "correctAnswer": Object {},
           "data": Array [],
@@ -380,9 +374,9 @@ exports[`Configure renders snapshot 1`] = `
     model={
       Object {
         "addCategoryEnabled": true,
-        "changeAddCategoryEnabled": true,
-        "changeEditableEnabled": true,
-        "changeInteractiveEnabled": true,
+        "changeAddCategoryEnabled": false,
+        "changeEditableEnabled": false,
+        "changeInteractiveEnabled": false,
         "chartType": "lineCross",
         "correctAnswer": Object {},
         "data": Array [],
@@ -482,9 +476,9 @@ exports[`Configure renders snapshot 1`] = `
     model={
       Object {
         "addCategoryEnabled": true,
-        "changeAddCategoryEnabled": true,
-        "changeEditableEnabled": true,
-        "changeInteractiveEnabled": true,
+        "changeAddCategoryEnabled": false,
+        "changeEditableEnabled": false,
+        "changeInteractiveEnabled": false,
         "chartType": "lineCross",
         "correctAnswer": Object {},
         "data": Array [],
@@ -556,9 +550,9 @@ exports[`Configure renders snapshot 1`] = `
     model={
       Object {
         "addCategoryEnabled": true,
-        "changeAddCategoryEnabled": true,
-        "changeEditableEnabled": true,
-        "changeInteractiveEnabled": true,
+        "changeAddCategoryEnabled": false,
+        "changeEditableEnabled": false,
+        "changeInteractiveEnabled": false,
         "chartType": "lineCross",
         "correctAnswer": Object {},
         "data": Array [],

--- a/packages/charting/configure/src/defaults.js
+++ b/packages/charting/configure/src/defaults.js
@@ -36,9 +36,9 @@ export default {
     teacherInstructionsEnabled: true,
     studentInstructionsEnabled: true,
     studentNewCategoryDefaultLabel: 'New Category',
-    changeInteractiveEnabled: true,
-    changeEditableEnabled: true,
-    changeAddCategoryEnabled: true,
+    changeInteractiveEnabled: false,
+    changeEditableEnabled: false,
+    changeAddCategoryEnabled: false,
   },
   configuration: {
     spellCheck: {

--- a/packages/charting/docs/demo/generate.js
+++ b/packages/charting/docs/demo/generate.js
@@ -2,6 +2,9 @@ exports.model = (id, element) => ({
   id,
   element,
   addCategoryEnabled: true,
+  changeInteractiveEnabled: true,
+  changeEditableEnabled: true,
+  changeAddCategoryEnabled: true,
   chartType: 'bar',
   correctAnswer: {
     data: [

--- a/packages/charting/docs/pie-schema.json
+++ b/packages/charting/docs/pie-schema.json
@@ -504,17 +504,17 @@
       "title": "rubricEnabled"
     },
     "changeInteractiveEnabled": {
-      "description": "Indicates if teacher can enable/disable data[]:interactive",
+      "description": "Indicates if teacher can enable/disable data[]:interactive. Default value is false",
       "type": "boolean",
       "title": "changeInteractiveEnabled"
     },
     "changeEditableEnabled": {
-      "description": "Indicates if teacher can enable/disable data[]:editable",
+      "description": "Indicates if teacher can enable/disable data[]:editable. Default value is false",
       "type": "boolean",
       "title": "changeEditableEnabled"
     },
     "changeAddCategoryEnabled": {
-      "description": "Indicates if teacher can enable/disable addCategoryEnabled",
+      "description": "Indicates if teacher can enable/disable addCategoryEnabled. Default value is false",
       "type": "boolean",
       "title": "changeAddCategoryEnabled"
     },

--- a/packages/charting/docs/pie-schema.json.md
+++ b/packages/charting/docs/pie-schema.json.md
@@ -168,15 +168,15 @@ Indicates if Rubric is enabled
 
 # `changeInteractiveEnabled` (boolean, required)
 
-Indicates if teacher can enable/disable data[]:interactive
+Indicates if teacher can enable/disable data[]:interactive. Default value is false
 
 # `changeEditableEnabled` (boolean, required)
 
-Indicates if teacher can enable/disable data[]:editable
+Indicates if teacher can enable/disable data[]:editable. Default value is false
 
 # `changeAddCategoryEnabled` (boolean, required)
 
-Indicates if teacher can enable/disable addCategoryEnabled
+Indicates if teacher can enable/disable addCategoryEnabled. Default value is false
 
 # `studentNewCategoryDefaultLabel` (string, required)
 

--- a/packages/pie-models/src/pie/charting/index.ts
+++ b/packages/pie-models/src/pie/charting/index.ts
@@ -162,13 +162,13 @@ export interface ChartingPie extends PieModel {
   /** Indicates if Rubric is enabled */
   rubricEnabled: boolean;
 
-  /** Indicates if teacher can enable/disable data[]:interactive */
+  /** Indicates if teacher can enable/disable data[]:interactive. Default value is false */
   changeInteractiveEnabled: boolean;
 
-  /** Indicates if teacher can enable/disable data[]:editable */
+  /** Indicates if teacher can enable/disable data[]:editable. Default value is false */
   changeEditableEnabled: boolean;
 
-  /** Indicates if teacher can enable/disable addCategoryEnabled */
+  /** Indicates if teacher can enable/disable addCategoryEnabled. Default value is false */
   changeAddCategoryEnabled: boolean;
 
   /**


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3216

Update default behavior of charting authoring UI properties

- Set default values for `changeInteractiveEnabled`, `changeEditableEnabled`, and `changeAddCategoryEnabled` to false.
- Ensures consistent authoring UI behavior when these properties are not explicitly set.
- Update docs accordingly.
