### PR TITLE
fix(number-line): Fix issue with domain and ticks as per SC-28651

### DIFF
--- a/packages/number-line/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/number-line/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -206,7 +206,7 @@ The correct answer should include at least one number line object."
             "fractionLabel": "1/2",
             "fractionTick": "1/8",
             "integerTick": 1,
-            "tickIntervalType": "Fraction",
+            "tickIntervalType": "Decimal",
           }
         }
       />
@@ -225,6 +225,8 @@ The correct answer should include at least one number line object."
     />
   </div>
   <Jss(NumberLine)
+    maxWidth={800}
+    minWidth={200}
     model={
       Object {
         "correctResponse": undefined,
@@ -251,7 +253,7 @@ The correct answer should include at least one number line object."
             "labelStep": "1/2",
             "major": 0.5,
             "minor": 0.125,
-            "tickIntervalType": "Fraction",
+            "tickIntervalType": "Decimal",
             "tickStep": "1/8",
           },
           "title": undefined,
@@ -367,6 +369,8 @@ The correct answer should include at least one number line object."
   </label>
   <Jss(NumberLine)
     answer={Array []}
+    maxWidth={800}
+    minWidth={200}
     model={
       Object {
         "correctResponse": undefined,
@@ -392,7 +396,7 @@ The correct answer should include at least one number line object."
             "labelStep": "1/2",
             "major": 0.5,
             "minor": 0.125,
-            "tickIntervalType": "Fraction",
+            "tickIntervalType": "Decimal",
             "tickStep": "1/8",
           },
           "title": undefined,

--- a/packages/number-line/configure/src/defaults.js
+++ b/packages/number-line/configure/src/defaults.js
@@ -9,7 +9,7 @@ export const model = {
       minor: 0.125,
       major: 0.5,
       labelStep: '1/2',
-      tickIntervalType: 'Fraction',
+      tickIntervalType: 'Decimal',
       tickStep: '1/8',
     },
     arrows: {

--- a/packages/number-line/configure/src/domain.jsx
+++ b/packages/number-line/configure/src/domain.jsx
@@ -23,7 +23,13 @@ export class Domain extends React.Component {
 
   change(key, event, value) {
     const { onChange } = this.props;
-    const update = { ...this.props.domain, [key]: value };
+    let update;
+    //Added condition when min and max is same, then it should not update the value
+    if ((key === 'min' && value === this.props.domain.max) || (key === 'max' && value === this.props.domain.min)) {
+      update = { ...this.props.domain };
+    } else {
+      update = { ...this.props.domain, [key]: value };
+    }
     onChange(sort(update));
   }
 
@@ -34,11 +40,11 @@ export class Domain extends React.Component {
       <div className={classes.displayFlex}>
         <div className={classes.flexRow}>
           <label>Min Value</label>
-          <MiniField value={domain.min} name={DOMAIN_BEGIN} onChange={this.changeMin} />
+          <MiniField min={-100000} max={99999} value={domain.min} name={DOMAIN_BEGIN} onChange={this.changeMin} />
         </div>
         <div className={classes.flexRow}>
           <label>Max Value</label>
-          <MiniField value={domain.max} name={DOMAIN_END} onChange={this.changeMax} />
+          <MiniField min={-99999} max={100000} value={domain.max} name={DOMAIN_END} onChange={this.changeMax} />
         </div>
       </div>
     );

--- a/packages/number-line/configure/src/main.jsx
+++ b/packages/number-line/configure/src/main.jsx
@@ -567,9 +567,9 @@ export class Main extends React.Component {
           {model.widthEnabled && (
             <Size
               size={graph}
-              min={numberLineDimensions ? numberLineDimensions.min : 400}
-              max={numberLineDimensions ? numberLineDimensions.max : 1600}
-              step={numberLineDimensions ? numberLineDimensions.step : 20}
+              min={numberLineDimensions.min}
+              max={numberLineDimensions.max}
+              step={numberLineDimensions.step}
               onChange={this.changeSize}
             />
           )}
@@ -585,8 +585,8 @@ export class Main extends React.Component {
           onAddElement={() => {}}
           onClearElements={() => {}}
           onUndoElement={() => {}}
-          minWidth={numberLineDimensions.min ? numberLineDimensions.min : 400}
-          maxWidth={numberLineDimensions.max ? numberLineDimensions.max : 1600}
+          minWidth={numberLineDimensions.min}
+          maxWidth={numberLineDimensions.max}
           model={trimModel(initialModel)}
         />
 
@@ -654,8 +654,8 @@ export class Main extends React.Component {
               onAddElement={this.addCorrectResponse}
               onClearElements={this.clearCorrectResponse}
               onUndoElement={this.undoCorrectResponse}
-              minWidth={numberLineDimensions.min ? numberLineDimensions.min : 400}
-              maxWidth={numberLineDimensions.max ? numberLineDimensions.max : 1600}
+              minWidth={numberLineDimensions.min}
+              maxWidth={numberLineDimensions.max}
               answer={correctResponse}
               //strip feedback for this model
               model={trimModel(model)}

--- a/packages/number-line/configure/src/main.jsx
+++ b/packages/number-line/configure/src/main.jsx
@@ -30,7 +30,7 @@ const trimModel = (model) => ({
 
 // Object holding information related to tick and label interval values.
 let ticksModel = {
-  tickIntervalType: 'Fraction',
+  tickIntervalType: 'Decimal',
   integerTick: 0,
   fractionTick: '0/1',
   decimalTick: 0,
@@ -278,6 +278,33 @@ export class Main extends React.Component {
     graph.ticks.labelStep = ticksModel.fractionLabel;
   };
 
+  /*
+   * This function updates ticks model from ticks values in graph model.
+   * @param ticks object
+   * */
+  assignGraphToTicksModel = (ticks) => {
+    if (ticks.tickIntervalType) {
+      ticksModel.tickIntervalType = ticks.tickIntervalType;
+    }
+    if (ticks.minor) {
+      ticksModel.decimalTick = ticks.minor;
+      if (ticksModel.tickIntervalType === 'Integer') {
+        ticksModel.integerTick = ticks.minor;
+      } else {
+        ticksModel.integerTick = math.ceil(ticks.minor);
+      }
+      if (ticks.tickStep) {
+        ticksModel.fractionTick = ticks.tickStep;
+      }
+    }
+    if (ticks.major) {
+      ticksModel.decimalLabel = ticks.major;
+      if (ticks.labelStep) {
+        ticksModel.fractionLabel = ticks.labelStep;
+      }
+    }
+  };
+
   getAdjustedHeight = (availableTypes, maxNumberOfPoints) => {
     let onlyPFAvailable = true;
     Object.entries(availableTypes || {}).forEach(([type, value]) => {
@@ -450,6 +477,7 @@ export class Main extends React.Component {
       availableTools = ['PF'],
     } = configuration || {};
     const { errors = {}, graph, spellCheckEnabled, toolbarEditorPosition } = model || {};
+    this.assignGraphToTicksModel(graph.ticks);
     const { dialog, correctAnswerDialog } = this.state;
 
     const { widthError, domainError, maxError, pointsError, correctResponseError } = errors || {};
@@ -539,9 +567,9 @@ export class Main extends React.Component {
           {model.widthEnabled && (
             <Size
               size={graph}
-              min={numberLineDimensions.min}
-              max={numberLineDimensions.max}
-              step={numberLineDimensions.step}
+              min={numberLineDimensions ? numberLineDimensions.min : 400}
+              max={numberLineDimensions ? numberLineDimensions.max : 1600}
+              step={numberLineDimensions ? numberLineDimensions.step : 20}
               onChange={this.changeSize}
             />
           )}
@@ -557,6 +585,8 @@ export class Main extends React.Component {
           onAddElement={() => {}}
           onClearElements={() => {}}
           onUndoElement={() => {}}
+          minWidth={numberLineDimensions.min ? numberLineDimensions.min : 400}
+          maxWidth={numberLineDimensions.max ? numberLineDimensions.max : 1600}
           model={trimModel(initialModel)}
         />
 
@@ -624,6 +654,8 @@ export class Main extends React.Component {
               onAddElement={this.addCorrectResponse}
               onClearElements={this.clearCorrectResponse}
               onUndoElement={this.undoCorrectResponse}
+              minWidth={numberLineDimensions.min ? numberLineDimensions.min : 400}
+              maxWidth={numberLineDimensions.max ? numberLineDimensions.max : 1600}
               answer={correctResponse}
               //strip feedback for this model
               model={trimModel(model)}

--- a/packages/number-line/configure/src/point-config.jsx
+++ b/packages/number-line/configure/src/point-config.jsx
@@ -24,15 +24,12 @@ class PointConfig extends React.Component {
   };
   constructor(props) {
     super(props);
-    this.state = {
-      selection: props.selection,
-    };
   }
 
   toggle(point) {
-    const update = { ...this.state.selection };
+    const update = { ...this.props.selection };
     update[point] = !update[point];
-    this._stateUpdate(update);
+    this._propsUpdate(update);
   }
 
   toggleAll(value) {
@@ -42,17 +39,15 @@ class PointConfig extends React.Component {
       return acc;
     }, {});
 
-    this._stateUpdate(display);
+    this._propsUpdate(display);
   }
 
-  _stateUpdate(selection) {
-    this.setState({ selection }, () => {
-      this.props.onSelectionChange(this.state.selection);
-    });
+  _propsUpdate(selection) {
+    this.props.onSelectionChange(selection);
   }
 
   active(point) {
-    return this.state.selection[point] === true; // ? 'active' : '';
+    return this.props.selection[point] === true; // ? 'active' : '';
   }
 
   render() {

--- a/packages/number-line/configure/src/ticks.jsx
+++ b/packages/number-line/configure/src/ticks.jsx
@@ -14,7 +14,7 @@ export const Ticks = (props) => {
   const {
     classes,
     ticksModel = {
-      tickIntervalType: 'Fraction',
+      tickIntervalType: 'Decimal',
       integerTick: 0,
       fractionTick: '0/1',
       decimalTick: 0,

--- a/packages/number-line/src/number-line/index.jsx
+++ b/packages/number-line/src/number-line/index.jsx
@@ -171,7 +171,7 @@ export class NumberLine extends React.Component {
   }
 
   render() {
-    let { model, classes, onDeleteElements, onMoveElement } = this.props;
+    let { model, classes, onDeleteElements, onMoveElement, minWidth = 400, maxWidth = 1600 } = this.props;
     let { showCorrectAnswer, answers, selectedElements, showMaxPointsWarning, elementType } = this.state;
     let {
       corrected = { correct: [], incorrect: [] },
@@ -187,7 +187,7 @@ export class NumberLine extends React.Component {
     let addElement = this.addElement.bind(this);
     let elementsSelected = !disabled && selectedElements && selectedElements.length > 0;
     const { ticks, domain, arrows, maxNumberOfPoints, height, availableTypes, title, fraction } = graph;
-    const width = this.getSize('width', 400, 1600, 600);
+    const width = this.getSize('width', minWidth, maxWidth, 600);
     const graphProps = {
       disabled,
       domain,


### PR DESCRIPTION
Fixed number line issue as per SC-28651/SC-28674
1. Fix when domain min and max are same screen gets blank
2. Added min and max for number text field.
3. Ticks model not getting set after saving item.
4. Changed default tickintervaltype to decimal to accommodate legacy NL items.
5. AvailableTypes not getting loaded correctly after saving Item