### PR TITLE
feat(math-inline): Implement aria-hidden to exclude MathQuill selectable elements from screen reader accessibility PD-2448

### DIFF
--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -174,22 +174,6 @@ export class Main extends React.Component {
     renderMath(this.root);
   };
 
-  componentDidMount() {
-    this.updateAriaHidden();
-  }
-
-  componentDidUpdate() {
-    this.handleAnswerBlockDomUpdate();
-    this.updateAriaHidden();
-  }
-
-  updateAriaHidden = () => {
-    if (this.root) {
-      const selectableElements = this.root.querySelectorAll('.mq-selectable');
-      (selectableElements || []).forEach((elem) => elem.setAttribute('aria-hidden', 'true'));
-    }
-  };
-
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { config } = this.props.model;
     const { config: nextConfig = {} } = nextProps.model || {};
@@ -254,8 +238,21 @@ export class Main extends React.Component {
 
   componentDidMount() {
     this.handleAnswerBlockDomUpdate();
+    this.updateAriaHidden();
     setTimeout(() => renderMath(this.root), 100);
   }
+
+  componentDidUpdate() {
+    this.handleAnswerBlockDomUpdate();
+    this.updateAriaHidden();
+  }
+
+  updateAriaHidden = () => {
+    if (this.root) {
+      const selectableElements = this.root.querySelectorAll('.mq-selectable');
+      (selectableElements || []).forEach((elem) => elem.setAttribute('aria-hidden', 'true'));
+    }
+  };
 
   onDone = () => {};
 

--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {CorrectAnswerToggle} from '@pie-lib/pie-toolbox/correct-answer-toggle';
+import { CorrectAnswerToggle } from '@pie-lib/pie-toolbox/correct-answer-toggle';
 import { mq, HorizontalKeypad, updateSpans } from '@pie-lib/pie-toolbox/math-input';
 import { Feedback, Collapsible, Readable, hasText, PreviewPrompt } from '@pie-lib/pie-toolbox/render-ui';
 import { renderMath } from '@pie-lib/pie-toolbox/math-rendering';
@@ -174,9 +174,21 @@ export class Main extends React.Component {
     renderMath(this.root);
   };
 
+  componentDidMount() {
+    this.updateAriaHidden();
+  }
+
   componentDidUpdate() {
     this.handleAnswerBlockDomUpdate();
+    this.updateAriaHidden();
   }
+
+  updateAriaHidden = () => {
+    if (this.root) {
+      const selectableElements = this.root.querySelectorAll('.mq-selectable');
+      (selectableElements || []).forEach((elem) => elem.setAttribute('aria-hidden', 'true'));
+    }
+  };
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { config } = this.props.model;
@@ -185,7 +197,12 @@ export class Main extends React.Component {
     // check if the note is the default one for prev language and change to the default one for new language
     // this check is necessary in order to diferanciate between default and authour defined note
     // and only change between languages for default ones
-    if (config.note && config.language && config.language !== nextConfig.language && config.note === translator.t('mathInline.primaryCorrectWithAlternates', { lng: config.language })) {
+    if (
+      config.note &&
+      config.language &&
+      config.language !== nextConfig.language &&
+      config.note === translator.t('mathInline.primaryCorrectWithAlternates', { lng: config.language })
+    ) {
       config.note = translator.t('mathInline.primaryCorrectWithAlternates', { lng: nextConfig.language });
     }
 
@@ -357,7 +374,7 @@ export class Main extends React.Component {
     // Safari Hack: https://stackoverflow.com/a/42764495/5757635
     setTimeout(() => {
       if (ref && IS_SAFARI) {
-        const div = document.querySelector('[role=\'tooltip\']');
+        const div = document.querySelector("[role='tooltip']");
 
         if (div) {
           const el = div.firstChild;
@@ -381,7 +398,7 @@ export class Main extends React.Component {
       animationsDisabled,
       printMode,
       alwaysShowCorrect,
-      language
+      language,
     } = model || {};
 
     if (!config) {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2448

Choosing to add aria-hidden="true" to elements with the class .mq-selectable instead of using display: none is primarily about maintaining functionality and visibility for sighted users while ensuring that these elements are not accessible to screen readers. Here's a brief explanation of the considerations:

In the context of MathQuill or similar math rendering libraries, elements with the class .mq-selectable might be part of the interactive math input experience. They might be necessary for sighted users to interact with or visually parse the mathematical content. Using aria-hidden="true" allows these elements to remain functional and part of the interactive experience for sighted and keyboard-only users, while ensuring they do not create confusion or navigation issues for screen reader users, who will not miss out on essential content or functionality by not accessing these elements.

In summary, the decision to use aria-hidden="true" over display: none is about balancing accessibility needs with maintaining functionality and the visual design. It ensures that the content remains accessible and functional for those who can visually interact with it, without confusing or hindering screen reader users.