### PR TITLE
feat(math-inline): Add aria-describedby and screen-reader-only instructions to textarea in MER response areas PD-2482

### DIFF
--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -264,18 +264,39 @@ export class Main extends React.Component {
     }
 
     updateAria = () => {
+        const {classes} = this.props;
+        
         if (this.root) {
             // Update aria-hidden for .mq-selectable elements
             const selectableElements = this.root.querySelectorAll('.mq-selectable');
             selectableElements.forEach(elem => elem.setAttribute('aria-hidden', 'true'));
-
-            // Update aria-label for textarea elements
+    
+            // Update aria-label for textarea elements and add aria-describedby
             const textareaElements = this.root.querySelectorAll('textarea');
             textareaElements.forEach(elem => {
-                elem.setAttribute('aria-label', 'Enter answer using math editor buttons or keyboard.');
+                elem.setAttribute('aria-label', 'Enter answer.');
+    
+                // Find the parent element that contains the textarea
+                const parent = elem.closest('.mq-textarea');
+    
+                if (parent) {
+                    // Create or find the instructions element within the parent
+                    let instructionsElement = parent.querySelector('#instructions');
+    
+                    if (!instructionsElement) {
+                        instructionsElement = document.createElement('span');
+                        instructionsElement.id = 'instructions';
+                        instructionsElement.className = classes.srOnly
+                        instructionsElement.textContent = 'This field automatically displays a math keypad. Both keypad and keyboard input are accepted, and keyboard entry accepts LaTeX markup.';
+                        parent.insertBefore(instructionsElement, elem);
+                    }
+    
+                    elem.setAttribute('aria-describedby', 'instructions');
+                }
             });
         }
     };
+    
 
   onDone = () => {};
 

--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CorrectAnswerToggle } from '@pie-lib/pie-toolbox/correct-answer-toggle';
-import { mq, HorizontalKeypad, updateSpans } from '@pie-lib/pie-toolbox/math-input';
-import { Feedback, Collapsible, Readable, hasText, PreviewPrompt } from '@pie-lib/pie-toolbox/render-ui';
-import { renderMath } from '@pie-lib/pie-toolbox/math-rendering-accessible';
-import { withStyles } from '@material-ui/core/styles';
+import {CorrectAnswerToggle} from '@pie-lib/pie-toolbox/correct-answer-toggle';
+import {mq, HorizontalKeypad, updateSpans} from '@pie-lib/pie-toolbox/math-input';
+import {Feedback, Collapsible, Readable, hasText, PreviewPrompt} from '@pie-lib/pie-toolbox/render-ui';
+import {renderMath} from '@pie-lib/pie-toolbox/math-rendering-accessible';
+import {withStyles} from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
-import { ResponseTypes } from './utils';
+import {ResponseTypes} from './utils';
 import isEqual from 'lodash/isEqual';
 import cx from 'classnames';
 import SimpleQuestionBlock from './simple-question-block';
 import MathQuill from '@pie-framework/mathquill';
-import { color } from '@pie-lib/pie-toolbox/render-ui';
+import {color} from '@pie-lib/pie-toolbox/render-ui';
 import isEmpty from 'lodash/isEmpty';
 import Translator from '@pie-lib/pie-toolbox/translator';
-const { translator } = Translator;
+const {translator} = Translator;
 let registered = false;
 
 const NEWLINE_LATEX = /\\newline/g;
@@ -30,889 +30,889 @@ const DEFAULT_KEYPAD_VARIANT = 6;
 const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 function generateAdditionalKeys(keyData = []) {
-  return keyData.map((key) => ({
-    name: key,
-    latex: key,
-    write: key,
-    label: key,
-  }));
+    return keyData.map((key) => ({
+        name: key,
+        latex: key,
+        write: key,
+        label: key,
+    }));
 }
 
 function getKeyPadWidth(additionalKeys = [], equationEditor) {
-  return Math.floor(additionalKeys.length / 5) * 30 + (equationEditor === 'miscellaneous' ? 600 : 500);
+    return Math.floor(additionalKeys.length / 5) * 30 + (equationEditor === 'miscellaneous' ? 600 : 500);
 }
 
 function prepareForStatic(model, state) {
-  const { config, disabled } = model || {};
-  const { expression, responses, printMode, alwaysShowCorrect } = config || {};
+    const {config, disabled} = model || {};
+    const {expression, responses, printMode, alwaysShowCorrect} = config || {};
 
-  if (config && expression) {
-    const modelExpression = expression;
+    if (config && expression) {
+        const modelExpression = expression;
 
-    if (state.showCorrect) {
-      return responses && responses.length && responses[0].answer;
+        if (state.showCorrect) {
+            return responses && responses.length && responses[0].answer;
+        }
+
+        let answerBlocks = 1; // assume one at least
+        // build out local state model using responses declared in expression
+
+        return (modelExpression || '')
+            .replace(REGEX, function () {
+                const answer = state.session.answers[`r${answerBlocks}`];
+
+                if (printMode && !alwaysShowCorrect) {
+                    const blankSpace = '\\ \\ '.repeat(30) + '\\newline ';
+
+                    return `\\MathQuillMathField[r${answerBlocks++}]{${blankSpace.repeat(3)}}`;
+                }
+
+                if (disabled) {
+                    return `\\embed{answerBlock}[r${answerBlocks++}]`;
+                }
+
+                return `\\MathQuillMathField[r${answerBlocks++}]{${(answer && answer.value) || ''}}`;
+            })
+            .replace(NEWLINE_LATEX, '\\embed{newLine}[]');
     }
-
-    let answerBlocks = 1; // assume one at least
-    // build out local state model using responses declared in expression
-
-    return (modelExpression || '')
-      .replace(REGEX, function () {
-        const answer = state.session.answers[`r${answerBlocks}`];
-
-        if (printMode && !alwaysShowCorrect) {
-          const blankSpace = '\\ \\ '.repeat(30) + '\\newline ';
-
-          return `\\MathQuillMathField[r${answerBlocks++}]{${blankSpace.repeat(3)}}`;
-        }
-
-        if (disabled) {
-          return `\\embed{answerBlock}[r${answerBlocks++}]`;
-        }
-
-        return `\\MathQuillMathField[r${answerBlocks++}]{${(answer && answer.value) || ''}}`;
-      })
-      .replace(NEWLINE_LATEX, '\\embed{newLine}[]');
-  }
 }
 
 export class Main extends React.Component {
-  static propTypes = {
-    classes: PropTypes.object,
-    session: PropTypes.object.isRequired,
-    onSessionChange: PropTypes.func,
-    model: PropTypes.object.isRequired,
-  };
+    static propTypes = {
+        classes: PropTypes.object,
+        session: PropTypes.object.isRequired,
+        onSessionChange: PropTypes.func,
+        model: PropTypes.object.isRequired,
+    };
 
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    const answers = {};
+        const answers = {};
 
-    if (props.model.config && props.model.config.expression) {
-      let answerBlocks = 1; // assume one at least
-      // build out local state model using responses declared in expression
+        if (props.model.config && props.model.config.expression) {
+            let answerBlocks = 1; // assume one at least
+            // build out local state model using responses declared in expression
 
-      (props.model.config.expression || '').replace(REGEX, () => {
-        answers[`r${answerBlocks}`] = {
-          value:
-            (props.session &&
-              props.session.answers &&
-              props.session.answers[`r${answerBlocks}`] &&
-              props.session.answers[`r${answerBlocks}`].value) ||
-            '',
+            (props.model.config.expression || '').replace(REGEX, () => {
+                answers[`r${answerBlocks}`] = {
+                    value:
+                        (props.session &&
+                            props.session.answers &&
+                            props.session.answers[`r${answerBlocks}`] &&
+                            props.session.answers[`r${answerBlocks}`].value) ||
+                        '',
+                };
+
+                answerBlocks += 1;
+            });
+        }
+
+        this.state = {
+            session: {...props.session, answers},
+            activeAnswerBlock: '',
+            showCorrect: this.props.model.config.alwaysShowCorrect || false,
         };
-
-        answerBlocks += 1;
-      });
     }
 
-    this.state = {
-      session: { ...props.session, answers },
-      activeAnswerBlock: '',
-      showCorrect: this.props.model.config.alwaysShowCorrect || false,
-    };
-  }
+    UNSAFE_componentWillMount() {
+        const {classes} = this.props;
 
-  UNSAFE_componentWillMount() {
-    const { classes } = this.props;
+        if (typeof window !== 'undefined') {
+            let MQ = MathQuill.getInterface(2);
 
-    if (typeof window !== 'undefined') {
-      let MQ = MathQuill.getInterface(2);
-
-      if (!registered) {
-        MQ.registerEmbed('answerBlock', (data) => {
-          return {
-            htmlString: `<div class="${classes.blockContainer}">
+            if (!registered) {
+                MQ.registerEmbed('answerBlock', (data) => {
+                    return {
+                        htmlString: `<div class="${classes.blockContainer}">
                 <div class="${classes.blockResponse}" id="${data}Index">R</div>
                 <div class="${classes.blockMath}">
                   <span id="${data}"></span>
                 </div>
               </div>`,
-            text: () => 'text',
-            latex: () => `\\embed{answerBlock}[${data}]`,
-          };
-        });
+                        text: () => 'text',
+                        latex: () => `\\embed{answerBlock}[${data}]`,
+                    };
+                });
 
-        registered = true;
-      }
-    }
-  }
-
-  handleAnswerBlockDomUpdate = () => {
-    const { model, classes } = this.props;
-    const { session, showCorrect } = this.state;
-    const answers = session.answers;
-
-    if (this.root && model.disabled && !showCorrect) {
-      Object.keys(answers).forEach((answerId) => {
-        const el = this.root.querySelector(`#${answerId}`);
-        const indexEl = this.root.querySelector(`#${answerId}Index`);
-        // const correct = model.correctness && model.correctness.correct;
-
-        if (el) {
-          let MQ = MathQuill.getInterface(2);
-          const answer = answers[answerId];
-
-          el.textContent = (answer && answer.value) || '';
-
-          if (!model.view) {
-            // for now, we're not going to be showing individual response correctness
-            // TODO re-attach the classes once we are
-            // el.parentElement.parentElement.classList.add(
-            //   correct ? classes.correct : classes.incorrect
-            // );
-          } else {
-            el.parentElement.parentElement.classList.remove(classes.correct);
-            el.parentElement.parentElement.classList.remove(classes.incorrect);
-          }
-
-          MQ.StaticMath(el);
-
-          // For now, we're not going to be indexing response blocks
-          // TODO go back to indexing once we support individual response correctness
-          // indexEl.textContent = `R${idx + 1}`;
-          indexEl.textContent = 'R';
+                registered = true;
+            }
         }
-      });
     }
 
-    renderMath(this.root);
-  };
+    handleAnswerBlockDomUpdate = () => {
+        const {model, classes} = this.props;
+        const {session, showCorrect} = this.state;
+        const answers = session.answers;
 
-  countResponseOccurrences(expression) {
-    const pattern = /\{\{response\}\}/g;
-    const matches = expression.match(pattern);
+        if (this.root && model.disabled && !showCorrect) {
+            Object.keys(answers).forEach((answerId) => {
+                const el = this.root.querySelector(`#${answerId}`);
+                const indexEl = this.root.querySelector(`#${answerId}Index`);
+                // const correct = model.correctness && model.correctness.correct;
 
-    return matches ? matches.length : 0;
-  }
+                if (el) {
+                    let MQ = MathQuill.getInterface(2);
+                    const answer = answers[answerId];
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const { config } = this.props.model;
-    const { config: nextConfig = {} } = nextProps.model || {};
-    // check if the note is the default one for prev language and change to the default one for new language
-    // this check is necessary in order to diferanciate between default and authour defined note
-    // and only change between languages for default ones
-    if (
-      config.note &&
-      config.language &&
-      config.language !== nextConfig.language &&
-      config.note === translator.t('mathInline.primaryCorrectWithAlternates', { lng: config.language })
-    ) {
-      config.note = translator.t('mathInline.primaryCorrectWithAlternates', { lng: nextConfig.language });
-    }
+                    el.textContent = (answer && answer.value) || '';
 
-    if ((config.env && config.env.mode !== 'evaluate') || (nextConfig.env && nextConfig.env.mode !== 'evaluate')) {
-      this.setState({ ...this.state.session, showCorrect: false });
-    }
+                    if (!model.view) {
+                        // for now, we're not going to be showing individual response correctness
+                        // TODO re-attach the classes once we are
+                        // el.parentElement.parentElement.classList.add(
+                        //   correct ? classes.correct : classes.incorrect
+                        // );
+                    } else {
+                        el.parentElement.parentElement.classList.remove(classes.correct);
+                        el.parentElement.parentElement.classList.remove(classes.incorrect);
+                    }
 
-    if (nextConfig.alwaysShowCorrect) {
-      this.setState({ showCorrect: true });
-    }
+                    MQ.StaticMath(el);
 
-    if (this.countResponseOccurrences(config.expression) < this.countResponseOccurrences(nextConfig.expression)) {
-      setTimeout(() => this.updateAria(), 100);
-    }
-
-    if (
-      (config && config.responses && config.responses.length !== nextConfig.responses.length) ||
-      (!config && nextConfig && nextConfig.responses) ||
-      (config && nextConfig && config.expression !== nextConfig.expression)
-    ) {
-      const newAnswers = {};
-      const answers = this.state.session.answers;
-
-      let answerBlocks = 1; // assume one at least
-
-      // build out local state model using responses declared in expression
-      (nextConfig.expression || '').replace(REGEX, () => {
-        newAnswers[`r${answerBlocks}`] = {
-          value: (answers && answers[`r${answerBlocks}`] && answers[`r${answerBlocks}`].value) || '',
-        };
-        answerBlocks++;
-      });
-
-      this.setState(
-        (state) => ({
-          session: {
-            ...state.session,
-            completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
-            answers: newAnswers,
-          },
-        }),
-        this.handleAnswerBlockDomUpdate,
-      );
-    }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    const sameModel = isEqual(this.props.model, nextProps.model);
-    const sameState = isEqual(this.state, nextState);
-
-    return !sameModel || !sameState;
-  }
-
-  componentDidMount() {
-    this.handleAnswerBlockDomUpdate();
-    this.updateAria();
-    setTimeout(() => renderMath(this.root), 100);
-  }
-
-  componentDidUpdate() {
-    this.handleAnswerBlockDomUpdate();
-  }
-
-  updateAria = () => {
-    const { classes } = this.props;
-
-    if (this.root) {
-      // Update aria-hidden for .mq-selectable elements
-      const selectableElements = this.root.querySelectorAll('.mq-selectable');
-      selectableElements.forEach((elem) => elem.setAttribute('aria-hidden', 'true'));
-
-      // Update aria-label for textarea elements and add aria-describedby
-      const textareaElements = this.root.querySelectorAll('textarea');
-      textareaElements.forEach((elem, index) => {
-        elem.setAttribute('aria-label', 'Enter answer.');
-
-        // Create a unique id for each instructions element
-        const instructionsId = `instructions-${index}`;
-
-        // Find the parent element that contains the textarea
-        const parent = elem.closest('.mq-textarea');
-
-        if (parent) {
-          // Create or find the instructions element within the parent
-          let instructionsElement = parent.querySelector(`#${instructionsId}`);
-
-          if (!instructionsElement) {
-            instructionsElement = document.createElement('span');
-            instructionsElement.id = instructionsId;
-            instructionsElement.className = classes.srOnly;
-            instructionsElement.textContent =
-              'This field automatically displays a math keypad. Both keypad and keyboard input are accepted, and keyboard entry accepts LaTeX markup.';
-            parent.insertBefore(instructionsElement, elem);
-          }
-
-          elem.setAttribute('aria-describedby', instructionsId);
+                    // For now, we're not going to be indexing response blocks
+                    // TODO go back to indexing once we support individual response correctness
+                    // indexEl.textContent = `R${idx + 1}`;
+                    indexEl.textContent = 'R';
+                }
+            });
         }
-      });
-    }
-  };
 
+        renderMath(this.root);
+    };
+
+    countResponseOccurrences(expression) {
+        const pattern = /\{\{response\}\}/g;
+        const matches = expression.match(pattern);
+
+        return matches ? matches.length : 0;
+    }
+
+
+    UNSAFE_componentWillReceiveProps(nextProps) {
+        const {config} = this.props.model;
+        const {config: nextConfig = {}} = nextProps.model || {};
+        // check if the note is the default one for prev language and change to the default one for new language
+        // this check is necessary in order to diferanciate between default and authour defined note
+        // and only change between languages for default ones
+        if (
+            config.note &&
+            config.language &&
+            config.language !== nextConfig.language &&
+            config.note === translator.t('mathInline.primaryCorrectWithAlternates', {lng: config.language})
+        ) {
+            config.note = translator.t('mathInline.primaryCorrectWithAlternates', {lng: nextConfig.language});
+        }
+
+        if ((config.env && config.env.mode !== 'evaluate') || (nextConfig.env && nextConfig.env.mode !== 'evaluate')) {
+            this.setState({...this.state.session, showCorrect: false});
+        }
+
+        if (nextConfig.alwaysShowCorrect) {
+            this.setState({showCorrect: true});
+        }
+
+        if (this.countResponseOccurrences(config.expression) < this.countResponseOccurrences(nextConfig.expression)) {
+            setTimeout(() => this.updateAria(), 100);
+        }
+
+        if (
+            (config && config.responses && config.responses.length !== nextConfig.responses.length) ||
+            (!config && nextConfig && nextConfig.responses) ||
+            (config && nextConfig && config.expression !== nextConfig.expression)
+        ) {
+            const newAnswers = {};
+            const answers = this.state.session.answers;
+
+            let answerBlocks = 1; // assume one at least
+
+            // build out local state model using responses declared in expression
+            (nextConfig.expression || '').replace(REGEX, () => {
+                newAnswers[`r${answerBlocks}`] = {
+                    value: (answers && answers[`r${answerBlocks}`] && answers[`r${answerBlocks}`].value) || '',
+                };
+                answerBlocks++;
+            });
+
+            this.setState(
+                (state) => ({
+                    session: {
+                        ...state.session,
+                        completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
+                        answers: newAnswers,
+                    },
+                }),
+                this.handleAnswerBlockDomUpdate,
+            );
+        }
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        const sameModel = isEqual(this.props.model, nextProps.model);
+        const sameState = isEqual(this.state, nextState);
+
+        return !sameModel || !sameState;
+    }
+
+    componentDidMount() {
+        this.handleAnswerBlockDomUpdate();
+        this.updateAria();
+        setTimeout(() => renderMath(this.root), 100);
+    }
+
+    componentDidUpdate() {
+        this.handleAnswerBlockDomUpdate();
+    }
+
+    updateAria = () => {
+        const {classes} = this.props;
+    
+        if (this.root) {
+            // Update aria-hidden for .mq-selectable elements
+            const selectableElements = this.root.querySelectorAll('.mq-selectable');
+            selectableElements.forEach(elem => elem.setAttribute('aria-hidden', 'true'));
+    
+            // Update aria-label for textarea elements and add aria-describedby
+            const textareaElements = this.root.querySelectorAll('textarea');
+            textareaElements.forEach((elem, index) => {
+                elem.setAttribute('aria-label', 'Enter answer.');
+    
+                // Create a unique id for each instructions element
+                const instructionsId = `instructions-${index}`;
+    
+                // Find the parent element that contains the textarea
+                const parent = elem.closest('.mq-textarea');
+    
+                if (parent) {
+                    // Create or find the instructions element within the parent
+                    let instructionsElement = parent.querySelector(`#${instructionsId}`);
+    
+                    if (!instructionsElement) {
+                        instructionsElement = document.createElement('span');
+                        instructionsElement.id = instructionsId;
+                        instructionsElement.className = classes.srOnly;
+                        instructionsElement.textContent = 'This field automatically displays a math keypad. Both keypad and keyboard input are accepted, and keyboard entry accepts LaTeX markup.';
+                        parent.insertBefore(instructionsElement, elem);
+                    }
+    
+                    elem.setAttribute('aria-describedby', instructionsId);
+                }
+            });
+        }
+    };
+    
   onDone = () => {};
 
-  onSimpleResponseChange = (response) => {
-    this.setState((state) => ({ session: { ...state.session, response } }), this.callOnSessionChange);
-  };
+    onSimpleResponseChange = (response) => {
+        this.setState((state) => ({session: {...state.session, response}}), this.callOnSessionChange);
+    };
 
-  onSubFieldFocus = (id) => {
-    this.setState({ activeAnswerBlock: id });
-  };
+    onSubFieldFocus = (id) => {
+        this.setState({activeAnswerBlock: id});
+    };
 
-  toNodeData = (data) => {
-    if (!data) {
-      return;
-    }
+    toNodeData = (data) => {
+        if (!data) {
+            return;
+        }
 
-    const { type, value } = data;
+        const {type, value} = data;
 
-    if (type === 'command' || type === 'cursor') {
-      return data;
-    } else if (type === 'answer') {
-      return { type: 'answer', ...data };
-    } else if (value === 'clear') {
-      return { type: 'clear' };
-    } else {
-      return { type: 'write', value };
-    }
-  };
+        if (type === 'command' || type === 'cursor') {
+            return data;
+        } else if (type === 'answer') {
+            return {type: 'answer', ...data};
+        } else if (value === 'clear') {
+            return {type: 'clear'};
+        } else {
+            return {type: 'write', value};
+        }
+    };
 
-  setInput = (input) => {
-    this.input = input;
-  };
+    setInput = (input) => {
+        this.input = input;
+    };
 
-  onClick = (data) => {
-    const c = this.toNodeData(data);
+    onClick = (data) => {
+        const c = this.toNodeData(data);
 
-    if (c.type === 'clear') {
-      this.input.clear();
-    } else if (c.type === 'command') {
-      if (Array.isArray(c.value)) {
-        c.value.forEach((vv) => {
-          this.input.cmd(vv);
-        });
-      } else {
-        this.input.cmd(c.value);
-      }
-    } else if (c.type === 'cursor') {
-      this.input.keystroke(c.value);
-    } else {
-      this.input.write(c.value);
-    }
+        if (c.type === 'clear') {
+            this.input.clear();
+        } else if (c.type === 'command') {
+            if (Array.isArray(c.value)) {
+                c.value.forEach((vv) => {
+                    this.input.cmd(vv);
+                });
+            } else {
+                this.input.cmd(c.value);
+            }
+        } else if (c.type === 'cursor') {
+            this.input.keystroke(c.value);
+        } else {
+            this.input.write(c.value);
+        }
 
-    this.input.focus();
-  };
+        this.input.focus();
+    };
 
-  callOnSessionChange = () => {
-    const { onSessionChange } = this.props;
+    callOnSessionChange = () => {
+        const {onSessionChange} = this.props;
 
-    if (onSessionChange) {
-      onSessionChange(this.state.session);
-    }
-  };
+        if (onSessionChange) {
+            onSessionChange(this.state.session);
+        }
+    };
 
-  toggleShowCorrect = (show) => {
-    this.setState({ showCorrect: show }, this.handleAnswerBlockDomUpdate);
-  };
+    toggleShowCorrect = (show) => {
+        this.setState({showCorrect: show}, this.handleAnswerBlockDomUpdate);
+    };
 
-  subFieldChanged = (name, subfieldValue) => {
-    updateSpans();
+    subFieldChanged = (name, subfieldValue) => {
+        updateSpans();
 
-    if (name) {
-      this.setState(
-        (state) => ({
-          session: {
-            ...state.session,
-            completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
-            answers: {
-              ...state.session.answers,
-              [name]: { value: subfieldValue },
-            },
-          },
-        }),
-        this.callOnSessionChange,
-      );
-    }
-  };
+        if (name) {
+            this.setState(
+                (state) => ({
+                    session: {
+                        ...state.session,
+                        completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
+                        answers: {
+                            ...state.session.answers,
+                            [name]: {value: subfieldValue},
+                        },
+                    },
+                }),
+                this.callOnSessionChange,
+            );
+        }
+    };
 
-  getFieldName = (changeField, fields) => {
-    const { answers } = this.state.session;
+    getFieldName = (changeField, fields) => {
+        const {answers} = this.state.session;
 
-    if (Object.keys(answers || {}).length) {
-      const keys = Object.keys(answers);
+        if (Object.keys(answers || {}).length) {
+            const keys = Object.keys(answers);
 
-      return keys.find((k) => {
-        const tf = fields[k];
+            return keys.find((k) => {
+                const tf = fields[k];
 
-        return tf && tf.id == changeField.id;
-      });
-    }
-  };
+                return tf && tf.id == changeField.id;
+            });
+        }
+    };
 
-  onBlur = (e) => {
-    const { relatedTarget, currentTarget } = e || {};
+    onBlur = (e) => {
+        const {relatedTarget, currentTarget} = e || {};
 
-    function getParentWithRoleTooltip(element, depth = 0) {
-      // only run this max 16 times
-      if (!element || depth >= 16) return null;
+        function getParentWithRoleTooltip(element, depth = 0) {
+            // only run this max 16 times
+            if (!element || depth >= 16) return null;
 
-      const parent = element.offsetParent;
+            const parent = element.offsetParent;
 
-      if (!parent) return null;
+            if (!parent) return null;
 
-      if (parent.getAttribute('role') === 'tooltip') {
-        return parent;
-      }
+            if (parent.getAttribute('role') === 'tooltip') {
+                return parent;
+            }
 
-      return getParentWithRoleTooltip(parent, depth + 1);
-    }
+            return getParentWithRoleTooltip(parent, depth + 1);
+        }
 
-    function getDeepChildDataKeypad(element, depth = 0) {
-      // only run this max 4 times
-      if (!element || depth >= 4) return null;
+        function getDeepChildDataKeypad(element, depth = 0) {
+            // only run this max 4 times
+            if (!element || depth >= 4) return null;
 
-      const child = element?.children?.[0];
+            const child = element?.children?.[0];
 
-      if (!child) return null;
+            if (!child) return null;
 
-      if (child.attributes && child.attributes['data-keypad']) {
-        return child;
-      }
+            if (child.attributes && child.attributes['data-keypad']) {
+                return child;
+            }
 
-      return getDeepChildDataKeypad(child, depth + 1);
-    }
+            return getDeepChildDataKeypad(child, depth + 1);
+        }
 
-    const parentWithTooltipRole = getParentWithRoleTooltip(relatedTarget);
-    const childWithDataKeypad = parentWithTooltipRole ? getDeepChildDataKeypad(parentWithTooltipRole) : null;
+        const parentWithTooltipRole = getParentWithRoleTooltip(relatedTarget);
+        const childWithDataKeypad = parentWithTooltipRole ? getDeepChildDataKeypad(parentWithTooltipRole) : null;
 
-    if (!relatedTarget || !currentTarget || !childWithDataKeypad?.attributes['data-keypad']) {
-      this.setState({ activeAnswerBlock: '' });
-    }
-    // else {
-    //     // Just for debugging purpose:
-    //     console.log('\n\nNew childWithDataKeypad', childWithDataKeypad);
-    //
-    //     if (IS_SAFARI) {
-    //         // (IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.children[0]?.attributes?.['data-keypad'])
-    //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]?.children[0]);
-    //     } else {
-    //         // (!IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.attributes?.['data-keypad']) ||
-    //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]);
-    //     }
-    // }
-  };
+        if (!relatedTarget || !currentTarget || !childWithDataKeypad?.attributes['data-keypad']) {
+            this.setState({activeAnswerBlock: ''});
+        }
+        // else {
+        //     // Just for debugging purpose:
+        //     console.log('\n\nNew childWithDataKeypad', childWithDataKeypad);
+        //
+        //     if (IS_SAFARI) {
+        //         // (IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.children[0]?.attributes?.['data-keypad'])
+        //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]?.children[0]);
+        //     } else {
+        //         // (!IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.attributes?.['data-keypad']) ||
+        //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]);
+        //     }
+        // }
+    };
 
-  setTooltipRef(ref) {
-    // Safari Hack: https://stackoverflow.com/a/42764495/5757635
-    setTimeout(() => {
-      if (ref && IS_SAFARI) {
+    setTooltipRef(ref) {
+        // Safari Hack: https://stackoverflow.com/a/42764495/5757635
+        setTimeout(() => {
+            if (ref && IS_SAFARI) {
         const div = document.querySelector("[role='tooltip']");
 
-        if (div) {
-          const el = div.firstChild;
-          el.setAttribute('tabindex', '-1');
+                if (div) {
+                    const el = div.firstChild;
+                    el.setAttribute('tabindex', '-1');
+                }
+            }
+        }, 1);
+    }
+
+    render() {
+        const {model, classes} = this.props;
+        const {activeAnswerBlock, showCorrect, session} = this.state;
+        const {
+            config,
+            correctness,
+            disabled,
+            view,
+            teacherInstructions,
+            rationale,
+            feedback,
+            animationsDisabled,
+            printMode,
+            alwaysShowCorrect,
+            language,
+        } = model || {};
+
+        if (!config) {
+            return null;
         }
-      }
-    }, 1);
-  }
 
-  render() {
-    const { model, classes } = this.props;
-    const { activeAnswerBlock, showCorrect, session } = this.state;
-    const {
-      config,
-      correctness,
-      disabled,
-      view,
-      teacherInstructions,
-      rationale,
-      feedback,
-      animationsDisabled,
-      printMode,
-      alwaysShowCorrect,
-      language,
-    } = model || {};
+        const {
+            showNote,
+            note,
+            prompt,
+            responses,
+            responseType,
+            equationEditor,
+            customKeys,
+            env: {mode, role} = {},
+        } = config || {};
+        const displayNote = (showCorrect || (mode === 'view' && role === 'instructor')) && showNote && note;
+        const emptyResponse = isEmpty(responses);
+        const showCorrectAnswerToggle = !emptyResponse && correctness && correctness.correctness !== 'correct';
+        const tooltipModeEnabled = disabled && correctness;
+        const additionalKeys = generateAdditionalKeys(customKeys);
+        const correct = correctness && correctness.correct;
+        const staticLatex = prepareForStatic(model, this.state) || '';
+        const viewMode = disabled && !correctness;
+        const studentPrintMode = printMode && !alwaysShowCorrect;
 
-    if (!config) {
-      return null;
-    }
-
-    const {
-      showNote,
-      note,
-      prompt,
-      responses,
-      responseType,
-      equationEditor,
-      customKeys,
-      env: { mode, role } = {},
-    } = config || {};
-    const displayNote = (showCorrect || (mode === 'view' && role === 'instructor')) && showNote && note;
-    const emptyResponse = isEmpty(responses);
-    const showCorrectAnswerToggle = !emptyResponse && correctness && correctness.correctness !== 'correct';
-    const tooltipModeEnabled = disabled && correctness;
-    const additionalKeys = generateAdditionalKeys(customKeys);
-    const correct = correctness && correctness.correct;
-    const staticLatex = prepareForStatic(model, this.state) || '';
-    const viewMode = disabled && !correctness;
-    const studentPrintMode = printMode && !alwaysShowCorrect;
-
-    const printView = (
-      <div className={classes.printContainer}>
-        <mq.Static
-          className={classes.static}
-          ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
-          latex={staticLatex}
-          onSubFieldChange={this.subFieldChanged}
-          getFieldName={this.getFieldName}
-          setInput={this.setInput}
-          onSubFieldFocus={this.onSubFieldFocus}
-          onBlur={this.onBlur}
-        />
-      </div>
-    );
-
-    const midContent = (
-      <div className={classes.main}>
-        {mode === 'gather' && <h2 className={classes.srOnly}>Math Equation Response Question</h2>}
-
-        {viewMode &&
-          teacherInstructions &&
-          hasText(teacherInstructions) &&
-          (!animationsDisabled ? (
-            <Collapsible
-              className={classes.collapsible}
-              labels={{ hidden: 'Show Teacher Instructions', visible: 'Hide Teacher Instructions' }}
-            >
-              <div dangerouslySetInnerHTML={{ __html: teacherInstructions }} />
-            </Collapsible>
-          ) : (
-            <div dangerouslySetInnerHTML={{ __html: teacherInstructions }} />
-          ))}
-
-        {prompt && (
-          <div className={classes.promptContainer}>
-            <PreviewPrompt prompt={prompt} />
-          </div>
-        )}
-
-        {studentPrintMode ? (
-          printView
-        ) : (
-          <Readable false>
-            <div className={classes.inputAndKeypadContainer} tabIndex={0}>
-              {responseType === ResponseTypes.simple && (
-                <SimpleQuestionBlock
-                  onSimpleResponseChange={this.onSimpleResponseChange}
-                  showCorrect={showCorrect}
-                  emptyResponse={emptyResponse}
-                  model={model}
-                  session={session}
+        const printView = (
+            <div className={classes.printContainer}>
+                <mq.Static
+                    className={classes.static}
+                    ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
+                    latex={staticLatex}
+                    onSubFieldChange={this.subFieldChanged}
+                    getFieldName={this.getFieldName}
+                    setInput={this.setInput}
+                    onSubFieldFocus={this.onSubFieldFocus}
+                    onBlur={this.onBlur}
                 />
-              )}
-
-              {responseType === ResponseTypes.advanced && (
-                <div
-                  className={cx(classes.expression, {
-                    [classes.incorrect]: !emptyResponse && !correct && !showCorrect,
-                    [classes.correct]: !emptyResponse && (correct || showCorrect),
-                    [classes.showCorrectness]: !emptyResponse && disabled && correctness && !view,
-                    [classes.correctAnswerShown]: showCorrect,
-                    [classes.printCorrect]: printMode && alwaysShowCorrect,
-                  })}
-                >
-                  <Tooltip
-                    ref={(ref) => this.setTooltipRef(ref)}
-                    enterTouchDelay={0}
-                    interactive
-                    open={!!activeAnswerBlock}
-                    classes={{
-                      tooltip: classes.keypadTooltip,
-                      popper: classes.keypadTooltipPopper,
-                    }}
-                    title={Object.keys(session.answers).map(
-                      (answerId) =>
-                        (answerId === activeAnswerBlock && !(showCorrect || disabled) && (
-                          <div
-                            data-keypad={true}
-                            key={answerId}
-                            className={classes.responseContainer}
-                            style={{
-                              // marginTop: this.mqStatic && this.mqStatic.input.offsetHeight - 20,
-                              width: getKeyPadWidth(additionalKeys, equationEditor),
-                            }}
-                          >
-                            <HorizontalKeypad
-                              additionalKeys={additionalKeys}
-                              mode={equationEditor || DEFAULT_KEYPAD_VARIANT}
-                              onClick={this.onClick}
-                            />
-                          </div>
-                        )) ||
-                        null,
-                    )}
-                  >
-                    <mq.Static
-                      className={classes.static}
-                      ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
-                      latex={staticLatex}
-                      onSubFieldChange={this.subFieldChanged}
-                      getFieldName={this.getFieldName}
-                      setInput={this.setInput}
-                      onSubFieldFocus={this.onSubFieldFocus}
-                      onBlur={this.onBlur}
-                    />
-                  </Tooltip>
-                </div>
-              )}
             </div>
-          </Readable>
-        )}
+        );
 
-        {viewMode && displayNote && (
-          <div className={classes.note} dangerouslySetInnerHTML={{ __html: `<strong>Note:</strong> ${note}` }} />
-        )}
+        const midContent = (
+            <div className={classes.main}>
+                {mode === 'gather' && <h2 className={classes.srOnly}>Math Equation Response Question</h2>}
 
-        {viewMode &&
-          rationale &&
-          hasText(rationale) &&
-          (!animationsDisabled ? (
-            <Collapsible labels={{ hidden: 'Show Rationale', visible: 'Hide Rationale' }}>
-              <div dangerouslySetInnerHTML={{ __html: rationale }} />
-            </Collapsible>
-          ) : (
-            <div dangerouslySetInnerHTML={{ __html: rationale }} />
-          ))}
-      </div>
-    );
+                {viewMode &&
+                    teacherInstructions &&
+                    hasText(teacherInstructions) &&
+                    (!animationsDisabled ? (
+                        <Collapsible
+                            className={classes.collapsible}
+                            labels={{hidden: 'Show Teacher Instructions', visible: 'Hide Teacher Instructions'}}
+                        >
+                            <div dangerouslySetInnerHTML={{__html: teacherInstructions}}/>
+                        </Collapsible>
+                    ) : (
+                        <div dangerouslySetInnerHTML={{__html: teacherInstructions}}/>
+                    ))}
 
-    if (
-      tooltipModeEnabled &&
-      (showCorrectAnswerToggle ||
-        (teacherInstructions && hasText(teacherInstructions)) ||
-        (rationale && hasText(rationale)) ||
-        feedback)
-    ) {
-      return (
-        <Tooltip
-          interactive
-          enterTouchDelay={0}
-          classes={{
-            tooltip: classes.tooltip,
-            popper: classes.tooltipPopper,
-          }}
-          title={
-            <div>
-              <div className={classes.main}>
-                {showCorrectAnswerToggle && (
-                  <CorrectAnswerToggle
-                    language={language}
-                    className={classes.toggle}
-                    show
-                    toggled={showCorrect}
-                    onToggle={this.toggleShowCorrect}
-                  />
+                {prompt && (
+                    <div className={classes.promptContainer}>
+                        <PreviewPrompt prompt={prompt}/>
+                    </div>
                 )}
-              </div>
 
-              {teacherInstructions && hasText(teacherInstructions) && (
-                <Collapsible
-                  className={classes.collapsible}
-                  key="collapsible-teacher-instructions"
-                  labels={{
-                    hidden: 'Show Teacher Instructions',
-                    visible: 'Hide Teacher Instructions',
-                  }}
-                >
-                  <PreviewPrompt prompt={teacherInstructions} />
-                </Collapsible>
-              )}
-              {displayNote && hasText(note) && (
-                <Collapsible
-                  className={classes.collapsible}
-                  key="collapsible-note"
-                  labels={{
-                    hidden: translator.t('common:showNote', { lng: language }),
-                    visible: translator.t('common:hideNote', { lng: language }),
-                  }}
-                >
-                  <PreviewPrompt prompt={note} />
-                </Collapsible>
-              )}
+                {studentPrintMode ? (
+                    printView
+                ) : (
+                    <Readable false>
+                        <div className={classes.inputAndKeypadContainer} tabIndex={0}>
+                            {responseType === ResponseTypes.simple && (
+                                <SimpleQuestionBlock
+                                    onSimpleResponseChange={this.onSimpleResponseChange}
+                                    showCorrect={showCorrect}
+                                    emptyResponse={emptyResponse}
+                                    model={model}
+                                    session={session}
+                                />
+                            )}
 
-              {rationale && hasText(rationale) && (
-                <Collapsible
-                  className={classes.collapsible}
-                  key="collapsible-rationale"
-                  labels={{
-                    hidden: 'Show Rationale',
-                    visible: 'Hide Rationale',
-                  }}
-                >
-                  <PreviewPrompt prompt={rationale} />
-                </Collapsible>
-              )}
+                            {responseType === ResponseTypes.advanced && (
+                                <div
+                                    className={cx(classes.expression, {
+                                        [classes.incorrect]: !emptyResponse && !correct && !showCorrect,
+                                        [classes.correct]: !emptyResponse && (correct || showCorrect),
+                                        [classes.showCorrectness]: !emptyResponse && disabled && correctness && !view,
+                                        [classes.correctAnswerShown]: showCorrect,
+                                        [classes.printCorrect]: printMode && alwaysShowCorrect,
+                                    })}
+                                >
+                                    <Tooltip
+                                        ref={(ref) => this.setTooltipRef(ref)}
+                                        enterTouchDelay={0}
+                                        interactive
+                                        open={!!activeAnswerBlock}
+                                        classes={{
+                                            tooltip: classes.keypadTooltip,
+                                            popper: classes.keypadTooltipPopper,
+                                        }}
+                                        title={Object.keys(session.answers).map(
+                                            (answerId) =>
+                                                (answerId === activeAnswerBlock && !(showCorrect || disabled) && (
+                                                    <div
+                                                        data-keypad={true}
+                                                        key={answerId}
+                                                        className={classes.responseContainer}
+                                                        style={{
+                                                            // marginTop: this.mqStatic && this.mqStatic.input.offsetHeight - 20,
+                                                            width: getKeyPadWidth(additionalKeys, equationEditor),
+                                                        }}
+                                                    >
+                                                        <HorizontalKeypad
+                                                            additionalKeys={additionalKeys}
+                                                            mode={equationEditor || DEFAULT_KEYPAD_VARIANT}
+                                                            onClick={this.onClick}
+                                                        />
+                                                    </div>
+                                                )) ||
+                                                null,
+                                        )}
+                                    >
+                                        <mq.Static
+                                            className={classes.static}
+                                            ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
+                                            latex={staticLatex}
+                                            onSubFieldChange={this.subFieldChanged}
+                                            getFieldName={this.getFieldName}
+                                            setInput={this.setInput}
+                                            onSubFieldFocus={this.onSubFieldFocus}
+                                            onBlur={this.onBlur}
+                                        />
+                                    </Tooltip>
+                                </div>
+                            )}
+                        </div>
+                    </Readable>
+                )}
 
-              {feedback && <Feedback correctness={correctness.correctness} feedback={feedback} />}
+                {viewMode && displayNote && (
+                    <div className={classes.note} dangerouslySetInnerHTML={{__html: `<strong>Note:</strong> ${note}`}}/>
+                )}
+
+                {viewMode &&
+                    rationale &&
+                    hasText(rationale) &&
+                    (!animationsDisabled ? (
+                        <Collapsible labels={{hidden: 'Show Rationale', visible: 'Hide Rationale'}}>
+                            <div dangerouslySetInnerHTML={{__html: rationale}}/>
+                        </Collapsible>
+                    ) : (
+                        <div dangerouslySetInnerHTML={{__html: rationale}}/>
+                    ))}
             </div>
-          }
-        >
-          <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
-            {midContent}
-          </div>
-        </Tooltip>
-      );
-    }
+        );
 
-    return (
-      <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
-        {midContent}
-      </div>
-    );
-  }
+        if (
+            tooltipModeEnabled &&
+            (showCorrectAnswerToggle ||
+                (teacherInstructions && hasText(teacherInstructions)) ||
+                (rationale && hasText(rationale)) ||
+                feedback)
+        ) {
+            return (
+                <Tooltip
+                    interactive
+                    enterTouchDelay={0}
+                    classes={{
+                        tooltip: classes.tooltip,
+                        popper: classes.tooltipPopper,
+                    }}
+                    title={
+                        <div>
+                            <div className={classes.main}>
+                                {showCorrectAnswerToggle && (
+                                    <CorrectAnswerToggle
+                                        language={language}
+                                        className={classes.toggle}
+                                        show
+                                        toggled={showCorrect}
+                                        onToggle={this.toggleShowCorrect}
+                                    />
+                                )}
+                            </div>
+
+                            {teacherInstructions && hasText(teacherInstructions) && (
+                                <Collapsible
+                                    className={classes.collapsible}
+                                    key="collapsible-teacher-instructions"
+                                    labels={{
+                                        hidden: 'Show Teacher Instructions',
+                                        visible: 'Hide Teacher Instructions',
+                                    }}
+                                >
+                                    <PreviewPrompt prompt={teacherInstructions}/>
+                                </Collapsible>
+                            )}
+                            {displayNote && hasText(note) && (
+                                <Collapsible
+                                    className={classes.collapsible}
+                                    key="collapsible-note"
+                                    labels={{
+                                        hidden: translator.t('common:showNote', {lng: language}),
+                                        visible: translator.t('common:hideNote', {lng: language}),
+                                    }}
+                                >
+                                    <PreviewPrompt prompt={note}/>
+                                </Collapsible>
+                            )}
+
+                            {rationale && hasText(rationale) && (
+                                <Collapsible
+                                    className={classes.collapsible}
+                                    key="collapsible-rationale"
+                                    labels={{
+                                        hidden: 'Show Rationale',
+                                        visible: 'Hide Rationale',
+                                    }}
+                                >
+                                    <PreviewPrompt prompt={rationale}/>
+                                </Collapsible>
+                            )}
+
+                            {feedback && <Feedback correctness={correctness.correctness} feedback={feedback}/>}
+                        </div>
+                    }
+                >
+                    <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
+                        {midContent}
+                    </div>
+                </Tooltip>
+            );
+        }
+
+        return (
+            <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
+                {midContent}
+            </div>
+        );
+    }
 }
 
 const styles = (theme) => ({
-  mainContainer: {
-    color: color.text(),
-    backgroundColor: color.background(),
-    display: 'inline-block',
-  },
-  tooltip: {
-    background: `${color.primaryLight()} !important`,
-    color: color.text(),
-    padding: theme.spacing.unit * 2,
-    border: `1px solid ${color.secondary()}`,
-    fontSize: '16px',
-    '& :not(.MathJax) > table tr': {
-      '&:nth-child(2n)': {
-        backgroundColor: 'unset !important',
-      },
+    mainContainer: {
+        color: color.text(),
+        backgroundColor: color.background(),
+        display: 'inline-block',
     },
-  },
-  tooltipPopper: {
-    opacity: 1,
-  },
-  keypadTooltip: {
-    fontSize: 'initial',
-    background: 'transparent',
-    width: '600px',
-    marginTop: 0,
-    paddingTop: 0,
-  },
-  keypadTooltipPopper: {
-    background: 'transparent',
-    width: '650px',
-    opacity: 1,
-  },
-  promptContainer: {
-    marginBottom: theme.spacing.unit * 2,
-  },
-  main: {
-    width: '100%',
-    position: 'relative',
-    backgroundColor: color.background(),
-    color: color.text(),
-  },
-  title: {
-    fontSize: '1.1rem',
-    display: 'block',
-    marginTop: theme.spacing.unit * 2,
-    marginBottom: theme.spacing.unit,
-  },
-  note: {
-    paddingBottom: theme.spacing.unit * 2,
-  },
-  collapsible: {
-    marginBottom: theme.spacing.unit * 2,
-  },
-  responseContainer: {
-    zIndex: 10,
-    // position: 'absolute',
-    // right: 0,
-    minWidth: '400px',
-    marginTop: theme.spacing.unit * 2,
-  },
-  expression: {
-    maxWidth: 'fit-content',
-    '& > .mq-math-mode': {
-      '& > .mq-root-block': {
-        '& > .mq-editable-field': {
-          minWidth: '10px',
-          margin: (theme.spacing.unit * 2) / 3,
-          padding: theme.spacing.unit / 4,
+    tooltip: {
+        background: `${color.primaryLight()} !important`,
+        color: color.text(),
+        padding: theme.spacing.unit * 2,
+        border: `1px solid ${color.secondary()}`,
+        fontSize: '16px',
+        '& :not(.MathJax) > table tr': {
+            '&:nth-child(2n)': {
+                backgroundColor: 'unset !important',
+            },
         },
-      },
-      '& sup': {
-        top: 0,
-      },
     },
-  },
-  static: {
-    '& > .mq-root-block': {
-      '& > .mq-editable-field': {
-        borderColor: color.text(),
-      },
+    tooltipPopper: {
+        opacity: 1,
     },
-  },
-  inputAndKeypadContainer: {
-    position: 'relative',
-    '& .mq-overarrow-inner': {
-      border: 'none !important',
-      padding: '0 !important',
+    keypadTooltip: {
+        fontSize: 'initial',
+        background: 'transparent',
+        width: '600px',
+        marginTop: 0,
+        paddingTop: 0,
     },
-    '& .mq-overarrow-inner-right': {
-      display: 'none !important',
+    keypadTooltipPopper: {
+        background: 'transparent',
+        width: '650px',
+        opacity: 1,
     },
-    '& .mq-overarrow-inner-left': {
-      display: 'none !important',
+    promptContainer: {
+        marginBottom: theme.spacing.unit * 2,
     },
-    '& .mq-overarrow.mq-arrow-both': {
-      minWidth: '1.23em',
-      '& *': {
-        lineHeight: '1 !important',
-      },
-      '&:before': {
-        top: '-0.4em',
-        left: '-1px',
-      },
-      '&:after': {
-        top: '-2.4em',
-        right: '-1px',
-      },
-      '&.mq-empty:after': {
-        top: '-0.45em',
-      },
+    main: {
+        width: '100%',
+        position: 'relative',
+        backgroundColor: color.background(),
+        color: color.text(),
     },
-    '& .mq-overarrow.mq-arrow-right': {
-      '&:before': {
-        top: '-0.4em',
-        right: '-1px',
-      },
+    title: {
+        fontSize: '1.1rem',
+        display: 'block',
+        marginTop: theme.spacing.unit * 2,
+        marginBottom: theme.spacing.unit,
     },
-    '& .mq-longdiv-inner': {
-      borderTop: '1px solid !important',
-      paddingTop: '1.5px !important',
+    note: {
+        paddingBottom: theme.spacing.unit * 2,
     },
-    '& .mq-parallelogram': {
-      lineHeight: 0.85,
+    collapsible: {
+        marginBottom: theme.spacing.unit * 2,
     },
-  },
-  showCorrectness: {
-    border: '2px solid',
-  },
-  correctAnswerShown: {
-    padding: theme.spacing.unit,
-    letterSpacing: '0.5px',
-  },
-  printCorrect: {
-    border: `2px solid ${color.correct()} !important`,
-  },
-  correct: {
-    borderColor: `${color.correct()} !important`,
-  },
-  incorrect: {
-    borderColor: `${color.incorrect()} !important`,
-  },
-  blockContainer: {
-    margin: `${theme.spacing.unit}px !important`,
-    display: 'inline-flex',
-    border: '2px solid grey !important',
-  },
-  blockResponse: {
-    flex: 2,
-    color: 'grey',
-    background: theme.palette.grey['A100'],
-    fontSize: '0.8rem !important',
-    padding: `${theme.spacing.unit / 2}px !important`,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRight: `2px solid ${color.disabled()} !important`,
-  },
-  toggle: {
-    color: color.text(),
-    marginBottom: theme.spacing.unit * 2,
-  },
-  blockMath: {
-    color: color.text(),
-    backgroundColor: color.background(),
-    padding: `${theme.spacing.unit / 2}px !important`,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flex: 8,
-    '& > .mq-math-mode': {
-      '& > .mq-hasCursor': {
-        '& > .mq-cursor': {
-          display: 'none',
+    responseContainer: {
+        zIndex: 10,
+        // position: 'absolute',
+        // right: 0,
+        minWidth: '400px',
+        marginTop: theme.spacing.unit * 2,
+    },
+    expression: {
+        maxWidth: 'fit-content',
+        '& > .mq-math-mode': {
+            '& > .mq-root-block': {
+                '& > .mq-editable-field': {
+                    minWidth: '10px',
+                    margin: (theme.spacing.unit * 2) / 3,
+                    padding: theme.spacing.unit / 4,
+                },
+            },
+            '& sup': {
+                top: 0,
+            },
         },
-      },
     },
-  },
-  printContainer: {
-    marginBottom: theme.spacing.unit,
-    pointerEvents: 'none',
-  },
-  srOnly: {
-    position: 'absolute',
-    left: '-10000px',
-    top: 'auto',
-    width: '1px',
-    height: '1px',
-    overflow: 'hidden',
-  },
+    static: {
+        '& > .mq-root-block': {
+            '& > .mq-editable-field': {
+                borderColor: color.text(),
+            },
+        },
+    },
+    inputAndKeypadContainer: {
+        position: 'relative',
+        '& .mq-overarrow-inner': {
+            border: 'none !important',
+            padding: '0 !important',
+        },
+        '& .mq-overarrow-inner-right': {
+            display: 'none !important',
+        },
+        '& .mq-overarrow-inner-left': {
+            display: 'none !important',
+        },
+        '& .mq-overarrow.mq-arrow-both': {
+            minWidth: '1.23em',
+            '& *': {
+                lineHeight: '1 !important',
+            },
+            '&:before': {
+                top: '-0.4em',
+                left: '-1px',
+            },
+            '&:after': {
+                top: '-2.4em',
+                right: '-1px',
+            },
+            '&.mq-empty:after': {
+                top: '-0.45em',
+            },
+        },
+        '& .mq-overarrow.mq-arrow-right': {
+            '&:before': {
+                top: '-0.4em',
+                right: '-1px',
+            },
+        },
+        '& .mq-longdiv-inner': {
+            borderTop: '1px solid !important',
+            paddingTop: '1.5px !important',
+        },
+        '& .mq-parallelogram': {
+            lineHeight: 0.85,
+        },
+    },
+    showCorrectness: {
+        border: '2px solid',
+    },
+    correctAnswerShown: {
+        padding: theme.spacing.unit,
+        letterSpacing: '0.5px',
+    },
+    printCorrect: {
+        border: `2px solid ${color.correct()} !important`,
+    },
+    correct: {
+        borderColor: `${color.correct()} !important`,
+    },
+    incorrect: {
+        borderColor: `${color.incorrect()} !important`,
+    },
+    blockContainer: {
+        margin: `${theme.spacing.unit}px !important`,
+        display: 'inline-flex',
+        border: '2px solid grey !important',
+    },
+    blockResponse: {
+        flex: 2,
+        color: 'grey',
+        background: theme.palette.grey['A100'],
+        fontSize: '0.8rem !important',
+        padding: `${theme.spacing.unit / 2}px !important`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRight: `2px solid ${color.disabled()} !important`,
+    },
+    toggle: {
+        color: color.text(),
+        marginBottom: theme.spacing.unit * 2,
+    },
+    blockMath: {
+        color: color.text(),
+        backgroundColor: color.background(),
+        padding: `${theme.spacing.unit / 2}px !important`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flex: 8,
+        '& > .mq-math-mode': {
+            '& > .mq-hasCursor': {
+                '& > .mq-cursor': {
+                    display: 'none',
+                },
+            },
+        },
+    },
+    printContainer: {
+        marginBottom: theme.spacing.unit,
+        pointerEvents: 'none',
+    },
+    srOnly: {
+        position: 'absolute',
+        left: '-10000px',
+        top: 'auto',
+        width: '1px',
+        height: '1px',
+        overflow: 'hidden',
+    },
 });
 
 export default withStyles(styles)(Main);

--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {CorrectAnswerToggle} from '@pie-lib/pie-toolbox/correct-answer-toggle';
-import {mq, HorizontalKeypad, updateSpans} from '@pie-lib/pie-toolbox/math-input';
-import {Feedback, Collapsible, Readable, hasText, PreviewPrompt} from '@pie-lib/pie-toolbox/render-ui';
-import {renderMath} from '@pie-lib/pie-toolbox/math-rendering-accessible';
-import {withStyles} from '@material-ui/core/styles';
+import { CorrectAnswerToggle } from '@pie-lib/pie-toolbox/correct-answer-toggle';
+import { mq, HorizontalKeypad, updateSpans } from '@pie-lib/pie-toolbox/math-input';
+import { Feedback, Collapsible, Readable, hasText, PreviewPrompt } from '@pie-lib/pie-toolbox/render-ui';
+import { renderMath } from '@pie-lib/pie-toolbox/math-rendering-accessible';
+import { withStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
-import {ResponseTypes} from './utils';
+import { ResponseTypes } from './utils';
 import isEqual from 'lodash/isEqual';
 import cx from 'classnames';
 import SimpleQuestionBlock from './simple-question-block';
 import MathQuill from '@pie-framework/mathquill';
-import {color} from '@pie-lib/pie-toolbox/render-ui';
+import { color } from '@pie-lib/pie-toolbox/render-ui';
 import isEmpty from 'lodash/isEmpty';
 import Translator from '@pie-lib/pie-toolbox/translator';
-const {translator} = Translator;
+const { translator } = Translator;
 let registered = false;
 
 const NEWLINE_LATEX = /\\newline/g;
@@ -30,887 +30,889 @@ const DEFAULT_KEYPAD_VARIANT = 6;
 const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 function generateAdditionalKeys(keyData = []) {
-    return keyData.map((key) => ({
-        name: key,
-        latex: key,
-        write: key,
-        label: key,
-    }));
+  return keyData.map((key) => ({
+    name: key,
+    latex: key,
+    write: key,
+    label: key,
+  }));
 }
 
 function getKeyPadWidth(additionalKeys = [], equationEditor) {
-    return Math.floor(additionalKeys.length / 5) * 30 + (equationEditor === 'miscellaneous' ? 600 : 500);
+  return Math.floor(additionalKeys.length / 5) * 30 + (equationEditor === 'miscellaneous' ? 600 : 500);
 }
 
 function prepareForStatic(model, state) {
-    const {config, disabled} = model || {};
-    const {expression, responses, printMode, alwaysShowCorrect} = config || {};
+  const { config, disabled } = model || {};
+  const { expression, responses, printMode, alwaysShowCorrect } = config || {};
 
-    if (config && expression) {
-        const modelExpression = expression;
+  if (config && expression) {
+    const modelExpression = expression;
 
-        if (state.showCorrect) {
-            return responses && responses.length && responses[0].answer;
+    if (state.showCorrect) {
+      return responses && responses.length && responses[0].answer;
+    }
+
+    let answerBlocks = 1; // assume one at least
+    // build out local state model using responses declared in expression
+
+    return (modelExpression || '')
+      .replace(REGEX, function () {
+        const answer = state.session.answers[`r${answerBlocks}`];
+
+        if (printMode && !alwaysShowCorrect) {
+          const blankSpace = '\\ \\ '.repeat(30) + '\\newline ';
+
+          return `\\MathQuillMathField[r${answerBlocks++}]{${blankSpace.repeat(3)}}`;
         }
 
-        let answerBlocks = 1; // assume one at least
-        // build out local state model using responses declared in expression
+        if (disabled) {
+          return `\\embed{answerBlock}[r${answerBlocks++}]`;
+        }
 
-        return (modelExpression || '')
-            .replace(REGEX, function () {
-                const answer = state.session.answers[`r${answerBlocks}`];
-
-                if (printMode && !alwaysShowCorrect) {
-                    const blankSpace = '\\ \\ '.repeat(30) + '\\newline ';
-
-                    return `\\MathQuillMathField[r${answerBlocks++}]{${blankSpace.repeat(3)}}`;
-                }
-
-                if (disabled) {
-                    return `\\embed{answerBlock}[r${answerBlocks++}]`;
-                }
-
-                return `\\MathQuillMathField[r${answerBlocks++}]{${(answer && answer.value) || ''}}`;
-            })
-            .replace(NEWLINE_LATEX, '\\embed{newLine}[]');
-    }
+        return `\\MathQuillMathField[r${answerBlocks++}]{${(answer && answer.value) || ''}}`;
+      })
+      .replace(NEWLINE_LATEX, '\\embed{newLine}[]');
+  }
 }
 
 export class Main extends React.Component {
-    static propTypes = {
-        classes: PropTypes.object,
-        session: PropTypes.object.isRequired,
-        onSessionChange: PropTypes.func,
-        model: PropTypes.object.isRequired,
-    };
+  static propTypes = {
+    classes: PropTypes.object,
+    session: PropTypes.object.isRequired,
+    onSessionChange: PropTypes.func,
+    model: PropTypes.object.isRequired,
+  };
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const answers = {};
+    const answers = {};
 
-        if (props.model.config && props.model.config.expression) {
-            let answerBlocks = 1; // assume one at least
-            // build out local state model using responses declared in expression
+    if (props.model.config && props.model.config.expression) {
+      let answerBlocks = 1; // assume one at least
+      // build out local state model using responses declared in expression
 
-            (props.model.config.expression || '').replace(REGEX, () => {
-                answers[`r${answerBlocks}`] = {
-                    value:
-                        (props.session &&
-                            props.session.answers &&
-                            props.session.answers[`r${answerBlocks}`] &&
-                            props.session.answers[`r${answerBlocks}`].value) ||
-                        '',
-                };
-
-                answerBlocks += 1;
-            });
-        }
-
-        this.state = {
-            session: {...props.session, answers},
-            activeAnswerBlock: '',
-            showCorrect: this.props.model.config.alwaysShowCorrect || false,
+      (props.model.config.expression || '').replace(REGEX, () => {
+        answers[`r${answerBlocks}`] = {
+          value:
+            (props.session &&
+              props.session.answers &&
+              props.session.answers[`r${answerBlocks}`] &&
+              props.session.answers[`r${answerBlocks}`].value) ||
+            '',
         };
+
+        answerBlocks += 1;
+      });
     }
 
-    UNSAFE_componentWillMount() {
-        const {classes} = this.props;
+    this.state = {
+      session: { ...props.session, answers },
+      activeAnswerBlock: '',
+      showCorrect: this.props.model.config.alwaysShowCorrect || false,
+    };
+  }
 
-        if (typeof window !== 'undefined') {
-            let MQ = MathQuill.getInterface(2);
+  UNSAFE_componentWillMount() {
+    const { classes } = this.props;
 
-            if (!registered) {
-                MQ.registerEmbed('answerBlock', (data) => {
-                    return {
-                        htmlString: `<div class="${classes.blockContainer}">
+    if (typeof window !== 'undefined') {
+      let MQ = MathQuill.getInterface(2);
+
+      if (!registered) {
+        MQ.registerEmbed('answerBlock', (data) => {
+          return {
+            htmlString: `<div class="${classes.blockContainer}">
                 <div class="${classes.blockResponse}" id="${data}Index">R</div>
                 <div class="${classes.blockMath}">
                   <span id="${data}"></span>
                 </div>
               </div>`,
-                        text: () => 'text',
-                        latex: () => `\\embed{answerBlock}[${data}]`,
-                    };
-                });
+            text: () => 'text',
+            latex: () => `\\embed{answerBlock}[${data}]`,
+          };
+        });
 
-                registered = true;
-            }
+        registered = true;
+      }
+    }
+  }
+
+  handleAnswerBlockDomUpdate = () => {
+    const { model, classes } = this.props;
+    const { session, showCorrect } = this.state;
+    const answers = session.answers;
+
+    if (this.root && model.disabled && !showCorrect) {
+      Object.keys(answers).forEach((answerId) => {
+        const el = this.root.querySelector(`#${answerId}`);
+        const indexEl = this.root.querySelector(`#${answerId}Index`);
+        // const correct = model.correctness && model.correctness.correct;
+
+        if (el) {
+          let MQ = MathQuill.getInterface(2);
+          const answer = answers[answerId];
+
+          el.textContent = (answer && answer.value) || '';
+
+          if (!model.view) {
+            // for now, we're not going to be showing individual response correctness
+            // TODO re-attach the classes once we are
+            // el.parentElement.parentElement.classList.add(
+            //   correct ? classes.correct : classes.incorrect
+            // );
+          } else {
+            el.parentElement.parentElement.classList.remove(classes.correct);
+            el.parentElement.parentElement.classList.remove(classes.incorrect);
+          }
+
+          MQ.StaticMath(el);
+
+          // For now, we're not going to be indexing response blocks
+          // TODO go back to indexing once we support individual response correctness
+          // indexEl.textContent = `R${idx + 1}`;
+          indexEl.textContent = 'R';
         }
+      });
     }
 
-    handleAnswerBlockDomUpdate = () => {
-        const {model, classes} = this.props;
-        const {session, showCorrect} = this.state;
-        const answers = session.answers;
+    renderMath(this.root);
+  };
 
-        if (this.root && model.disabled && !showCorrect) {
-            Object.keys(answers).forEach((answerId) => {
-                const el = this.root.querySelector(`#${answerId}`);
-                const indexEl = this.root.querySelector(`#${answerId}Index`);
-                // const correct = model.correctness && model.correctness.correct;
+  countResponseOccurrences(expression) {
+    const pattern = /\{\{response\}\}/g;
+    const matches = expression.match(pattern);
 
-                if (el) {
-                    let MQ = MathQuill.getInterface(2);
-                    const answer = answers[answerId];
+    return matches ? matches.length : 0;
+  }
 
-                    el.textContent = (answer && answer.value) || '';
-
-                    if (!model.view) {
-                        // for now, we're not going to be showing individual response correctness
-                        // TODO re-attach the classes once we are
-                        // el.parentElement.parentElement.classList.add(
-                        //   correct ? classes.correct : classes.incorrect
-                        // );
-                    } else {
-                        el.parentElement.parentElement.classList.remove(classes.correct);
-                        el.parentElement.parentElement.classList.remove(classes.incorrect);
-                    }
-
-                    MQ.StaticMath(el);
-
-                    // For now, we're not going to be indexing response blocks
-                    // TODO go back to indexing once we support individual response correctness
-                    // indexEl.textContent = `R${idx + 1}`;
-                    indexEl.textContent = 'R';
-                }
-            });
-        }
-
-        renderMath(this.root);
-    };
-
-    countResponseOccurrences(expression) {
-        const pattern = /\{\{response\}\}/g;
-        const matches = expression.match(pattern);
-
-        return matches ? matches.length : 0;
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { config } = this.props.model;
+    const { config: nextConfig = {} } = nextProps.model || {};
+    // check if the note is the default one for prev language and change to the default one for new language
+    // this check is necessary in order to diferanciate between default and authour defined note
+    // and only change between languages for default ones
+    if (
+      config.note &&
+      config.language &&
+      config.language !== nextConfig.language &&
+      config.note === translator.t('mathInline.primaryCorrectWithAlternates', { lng: config.language })
+    ) {
+      config.note = translator.t('mathInline.primaryCorrectWithAlternates', { lng: nextConfig.language });
     }
 
-
-    UNSAFE_componentWillReceiveProps(nextProps) {
-        const {config} = this.props.model;
-        const {config: nextConfig = {}} = nextProps.model || {};
-        // check if the note is the default one for prev language and change to the default one for new language
-        // this check is necessary in order to diferanciate between default and authour defined note
-        // and only change between languages for default ones
-        if (
-            config.note &&
-            config.language &&
-            config.language !== nextConfig.language &&
-            config.note === translator.t('mathInline.primaryCorrectWithAlternates', {lng: config.language})
-        ) {
-            config.note = translator.t('mathInline.primaryCorrectWithAlternates', {lng: nextConfig.language});
-        }
-
-        if ((config.env && config.env.mode !== 'evaluate') || (nextConfig.env && nextConfig.env.mode !== 'evaluate')) {
-            this.setState({...this.state.session, showCorrect: false});
-        }
-
-        if (nextConfig.alwaysShowCorrect) {
-            this.setState({showCorrect: true});
-        }
-
-        if (this.countResponseOccurrences(config.expression) < this.countResponseOccurrences(nextConfig.expression)) {
-            setTimeout(() => this.updateAria(), 100);
-        }
-
-        if (
-            (config && config.responses && config.responses.length !== nextConfig.responses.length) ||
-            (!config && nextConfig && nextConfig.responses) ||
-            (config && nextConfig && config.expression !== nextConfig.expression)
-        ) {
-            const newAnswers = {};
-            const answers = this.state.session.answers;
-
-            let answerBlocks = 1; // assume one at least
-
-            // build out local state model using responses declared in expression
-            (nextConfig.expression || '').replace(REGEX, () => {
-                newAnswers[`r${answerBlocks}`] = {
-                    value: (answers && answers[`r${answerBlocks}`] && answers[`r${answerBlocks}`].value) || '',
-                };
-                answerBlocks++;
-            });
-
-            this.setState(
-                (state) => ({
-                    session: {
-                        ...state.session,
-                        completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
-                        answers: newAnswers,
-                    },
-                }),
-                this.handleAnswerBlockDomUpdate,
-            );
-        }
+    if ((config.env && config.env.mode !== 'evaluate') || (nextConfig.env && nextConfig.env.mode !== 'evaluate')) {
+      this.setState({ ...this.state.session, showCorrect: false });
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        const sameModel = isEqual(this.props.model, nextProps.model);
-        const sameState = isEqual(this.state, nextState);
-
-        return !sameModel || !sameState;
+    if (nextConfig.alwaysShowCorrect) {
+      this.setState({ showCorrect: true });
     }
 
-    componentDidMount() {
-        this.handleAnswerBlockDomUpdate();
-        this.updateAria();
-        setTimeout(() => renderMath(this.root), 100);
+    if (this.countResponseOccurrences(config.expression) < this.countResponseOccurrences(nextConfig.expression)) {
+      setTimeout(() => this.updateAria(), 100);
     }
 
-    componentDidUpdate() {
-        this.handleAnswerBlockDomUpdate();
-    }
+    if (
+      (config && config.responses && config.responses.length !== nextConfig.responses.length) ||
+      (!config && nextConfig && nextConfig.responses) ||
+      (config && nextConfig && config.expression !== nextConfig.expression)
+    ) {
+      const newAnswers = {};
+      const answers = this.state.session.answers;
 
-    updateAria = () => {
-        const {classes} = this.props;
-        
-        if (this.root) {
-            // Update aria-hidden for .mq-selectable elements
-            const selectableElements = this.root.querySelectorAll('.mq-selectable');
-            selectableElements.forEach(elem => elem.setAttribute('aria-hidden', 'true'));
-    
-            // Update aria-label for textarea elements and add aria-describedby
-            const textareaElements = this.root.querySelectorAll('textarea');
-            textareaElements.forEach(elem => {
-                elem.setAttribute('aria-label', 'Enter answer.');
-    
-                // Find the parent element that contains the textarea
-                const parent = elem.closest('.mq-textarea');
-    
-                if (parent) {
-                    // Create or find the instructions element within the parent
-                    let instructionsElement = parent.querySelector('#instructions');
-    
-                    if (!instructionsElement) {
-                        instructionsElement = document.createElement('span');
-                        instructionsElement.id = 'instructions';
-                        instructionsElement.className = classes.srOnly
-                        instructionsElement.textContent = 'This field automatically displays a math keypad. Both keypad and keyboard input are accepted, and keyboard entry accepts LaTeX markup.';
-                        parent.insertBefore(instructionsElement, elem);
-                    }
-    
-                    elem.setAttribute('aria-describedby', 'instructions');
-                }
-            });
+      let answerBlocks = 1; // assume one at least
+
+      // build out local state model using responses declared in expression
+      (nextConfig.expression || '').replace(REGEX, () => {
+        newAnswers[`r${answerBlocks}`] = {
+          value: (answers && answers[`r${answerBlocks}`] && answers[`r${answerBlocks}`].value) || '',
+        };
+        answerBlocks++;
+      });
+
+      this.setState(
+        (state) => ({
+          session: {
+            ...state.session,
+            completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
+            answers: newAnswers,
+          },
+        }),
+        this.handleAnswerBlockDomUpdate,
+      );
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    const sameModel = isEqual(this.props.model, nextProps.model);
+    const sameState = isEqual(this.state, nextState);
+
+    return !sameModel || !sameState;
+  }
+
+  componentDidMount() {
+    this.handleAnswerBlockDomUpdate();
+    this.updateAria();
+    setTimeout(() => renderMath(this.root), 100);
+  }
+
+  componentDidUpdate() {
+    this.handleAnswerBlockDomUpdate();
+  }
+
+  updateAria = () => {
+    const { classes } = this.props;
+
+    if (this.root) {
+      // Update aria-hidden for .mq-selectable elements
+      const selectableElements = this.root.querySelectorAll('.mq-selectable');
+      selectableElements.forEach((elem) => elem.setAttribute('aria-hidden', 'true'));
+
+      // Update aria-label for textarea elements and add aria-describedby
+      const textareaElements = this.root.querySelectorAll('textarea');
+      textareaElements.forEach((elem, index) => {
+        elem.setAttribute('aria-label', 'Enter answer.');
+
+        // Create a unique id for each instructions element
+        const instructionsId = `instructions-${index}`;
+
+        // Find the parent element that contains the textarea
+        const parent = elem.closest('.mq-textarea');
+
+        if (parent) {
+          // Create or find the instructions element within the parent
+          let instructionsElement = parent.querySelector(`#${instructionsId}`);
+
+          if (!instructionsElement) {
+            instructionsElement = document.createElement('span');
+            instructionsElement.id = instructionsId;
+            instructionsElement.className = classes.srOnly;
+            instructionsElement.textContent =
+              'This field automatically displays a math keypad. Both keypad and keyboard input are accepted, and keyboard entry accepts LaTeX markup.';
+            parent.insertBefore(instructionsElement, elem);
+          }
+
+          elem.setAttribute('aria-describedby', instructionsId);
         }
-    };
-    
+      });
+    }
+  };
 
   onDone = () => {};
 
-    onSimpleResponseChange = (response) => {
-        this.setState((state) => ({session: {...state.session, response}}), this.callOnSessionChange);
-    };
+  onSimpleResponseChange = (response) => {
+    this.setState((state) => ({ session: { ...state.session, response } }), this.callOnSessionChange);
+  };
 
-    onSubFieldFocus = (id) => {
-        this.setState({activeAnswerBlock: id});
-    };
+  onSubFieldFocus = (id) => {
+    this.setState({ activeAnswerBlock: id });
+  };
 
-    toNodeData = (data) => {
-        if (!data) {
-            return;
-        }
+  toNodeData = (data) => {
+    if (!data) {
+      return;
+    }
 
-        const {type, value} = data;
+    const { type, value } = data;
 
-        if (type === 'command' || type === 'cursor') {
-            return data;
-        } else if (type === 'answer') {
-            return {type: 'answer', ...data};
-        } else if (value === 'clear') {
-            return {type: 'clear'};
-        } else {
-            return {type: 'write', value};
-        }
-    };
+    if (type === 'command' || type === 'cursor') {
+      return data;
+    } else if (type === 'answer') {
+      return { type: 'answer', ...data };
+    } else if (value === 'clear') {
+      return { type: 'clear' };
+    } else {
+      return { type: 'write', value };
+    }
+  };
 
-    setInput = (input) => {
-        this.input = input;
-    };
+  setInput = (input) => {
+    this.input = input;
+  };
 
-    onClick = (data) => {
-        const c = this.toNodeData(data);
+  onClick = (data) => {
+    const c = this.toNodeData(data);
 
-        if (c.type === 'clear') {
-            this.input.clear();
-        } else if (c.type === 'command') {
-            if (Array.isArray(c.value)) {
-                c.value.forEach((vv) => {
-                    this.input.cmd(vv);
-                });
-            } else {
-                this.input.cmd(c.value);
-            }
-        } else if (c.type === 'cursor') {
-            this.input.keystroke(c.value);
-        } else {
-            this.input.write(c.value);
-        }
+    if (c.type === 'clear') {
+      this.input.clear();
+    } else if (c.type === 'command') {
+      if (Array.isArray(c.value)) {
+        c.value.forEach((vv) => {
+          this.input.cmd(vv);
+        });
+      } else {
+        this.input.cmd(c.value);
+      }
+    } else if (c.type === 'cursor') {
+      this.input.keystroke(c.value);
+    } else {
+      this.input.write(c.value);
+    }
 
-        this.input.focus();
-    };
+    this.input.focus();
+  };
 
-    callOnSessionChange = () => {
-        const {onSessionChange} = this.props;
+  callOnSessionChange = () => {
+    const { onSessionChange } = this.props;
 
-        if (onSessionChange) {
-            onSessionChange(this.state.session);
-        }
-    };
+    if (onSessionChange) {
+      onSessionChange(this.state.session);
+    }
+  };
 
-    toggleShowCorrect = (show) => {
-        this.setState({showCorrect: show}, this.handleAnswerBlockDomUpdate);
-    };
+  toggleShowCorrect = (show) => {
+    this.setState({ showCorrect: show }, this.handleAnswerBlockDomUpdate);
+  };
 
-    subFieldChanged = (name, subfieldValue) => {
-        updateSpans();
+  subFieldChanged = (name, subfieldValue) => {
+    updateSpans();
 
-        if (name) {
-            this.setState(
-                (state) => ({
-                    session: {
-                        ...state.session,
-                        completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
-                        answers: {
-                            ...state.session.answers,
-                            [name]: {value: subfieldValue},
-                        },
-                    },
-                }),
-                this.callOnSessionChange,
-            );
-        }
-    };
+    if (name) {
+      this.setState(
+        (state) => ({
+          session: {
+            ...state.session,
+            completeAnswer: this.mqStatic && this.mqStatic.mathField.latex(),
+            answers: {
+              ...state.session.answers,
+              [name]: { value: subfieldValue },
+            },
+          },
+        }),
+        this.callOnSessionChange,
+      );
+    }
+  };
 
-    getFieldName = (changeField, fields) => {
-        const {answers} = this.state.session;
+  getFieldName = (changeField, fields) => {
+    const { answers } = this.state.session;
 
-        if (Object.keys(answers || {}).length) {
-            const keys = Object.keys(answers);
+    if (Object.keys(answers || {}).length) {
+      const keys = Object.keys(answers);
 
-            return keys.find((k) => {
-                const tf = fields[k];
+      return keys.find((k) => {
+        const tf = fields[k];
 
-                return tf && tf.id == changeField.id;
-            });
-        }
-    };
+        return tf && tf.id == changeField.id;
+      });
+    }
+  };
 
-    onBlur = (e) => {
-        const {relatedTarget, currentTarget} = e || {};
+  onBlur = (e) => {
+    const { relatedTarget, currentTarget } = e || {};
 
-        function getParentWithRoleTooltip(element, depth = 0) {
-            // only run this max 16 times
-            if (!element || depth >= 16) return null;
+    function getParentWithRoleTooltip(element, depth = 0) {
+      // only run this max 16 times
+      if (!element || depth >= 16) return null;
 
-            const parent = element.offsetParent;
+      const parent = element.offsetParent;
 
-            if (!parent) return null;
+      if (!parent) return null;
 
-            if (parent.getAttribute('role') === 'tooltip') {
-                return parent;
-            }
+      if (parent.getAttribute('role') === 'tooltip') {
+        return parent;
+      }
 
-            return getParentWithRoleTooltip(parent, depth + 1);
-        }
+      return getParentWithRoleTooltip(parent, depth + 1);
+    }
 
-        function getDeepChildDataKeypad(element, depth = 0) {
-            // only run this max 4 times
-            if (!element || depth >= 4) return null;
+    function getDeepChildDataKeypad(element, depth = 0) {
+      // only run this max 4 times
+      if (!element || depth >= 4) return null;
 
-            const child = element?.children?.[0];
+      const child = element?.children?.[0];
 
-            if (!child) return null;
+      if (!child) return null;
 
-            if (child.attributes && child.attributes['data-keypad']) {
-                return child;
-            }
+      if (child.attributes && child.attributes['data-keypad']) {
+        return child;
+      }
 
-            return getDeepChildDataKeypad(child, depth + 1);
-        }
+      return getDeepChildDataKeypad(child, depth + 1);
+    }
 
-        const parentWithTooltipRole = getParentWithRoleTooltip(relatedTarget);
-        const childWithDataKeypad = parentWithTooltipRole ? getDeepChildDataKeypad(parentWithTooltipRole) : null;
+    const parentWithTooltipRole = getParentWithRoleTooltip(relatedTarget);
+    const childWithDataKeypad = parentWithTooltipRole ? getDeepChildDataKeypad(parentWithTooltipRole) : null;
 
-        if (!relatedTarget || !currentTarget || !childWithDataKeypad?.attributes['data-keypad']) {
-            this.setState({activeAnswerBlock: ''});
-        }
-        // else {
-        //     // Just for debugging purpose:
-        //     console.log('\n\nNew childWithDataKeypad', childWithDataKeypad);
-        //
-        //     if (IS_SAFARI) {
-        //         // (IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.children[0]?.attributes?.['data-keypad'])
-        //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]?.children[0]);
-        //     } else {
-        //         // (!IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.attributes?.['data-keypad']) ||
-        //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]);
-        //     }
-        // }
-    };
+    if (!relatedTarget || !currentTarget || !childWithDataKeypad?.attributes['data-keypad']) {
+      this.setState({ activeAnswerBlock: '' });
+    }
+    // else {
+    //     // Just for debugging purpose:
+    //     console.log('\n\nNew childWithDataKeypad', childWithDataKeypad);
+    //
+    //     if (IS_SAFARI) {
+    //         // (IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.children[0]?.attributes?.['data-keypad'])
+    //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]?.children[0]);
+    //     } else {
+    //         // (!IS_SAFARI && !relatedTarget?.offsetParent?.children[0]?.attributes?.['data-keypad']) ||
+    //         console.log('What was being used', relatedTarget?.offsetParent?.children[0]);
+    //     }
+    // }
+  };
 
-    setTooltipRef(ref) {
-        // Safari Hack: https://stackoverflow.com/a/42764495/5757635
-        setTimeout(() => {
-            if (ref && IS_SAFARI) {
+  setTooltipRef(ref) {
+    // Safari Hack: https://stackoverflow.com/a/42764495/5757635
+    setTimeout(() => {
+      if (ref && IS_SAFARI) {
         const div = document.querySelector("[role='tooltip']");
 
-                if (div) {
-                    const el = div.firstChild;
-                    el.setAttribute('tabindex', '-1');
-                }
-            }
-        }, 1);
+        if (div) {
+          const el = div.firstChild;
+          el.setAttribute('tabindex', '-1');
+        }
+      }
+    }, 1);
+  }
+
+  render() {
+    const { model, classes } = this.props;
+    const { activeAnswerBlock, showCorrect, session } = this.state;
+    const {
+      config,
+      correctness,
+      disabled,
+      view,
+      teacherInstructions,
+      rationale,
+      feedback,
+      animationsDisabled,
+      printMode,
+      alwaysShowCorrect,
+      language,
+    } = model || {};
+
+    if (!config) {
+      return null;
     }
 
-    render() {
-        const {model, classes} = this.props;
-        const {activeAnswerBlock, showCorrect, session} = this.state;
-        const {
-            config,
-            correctness,
-            disabled,
-            view,
-            teacherInstructions,
-            rationale,
-            feedback,
-            animationsDisabled,
-            printMode,
-            alwaysShowCorrect,
-            language,
-        } = model || {};
+    const {
+      showNote,
+      note,
+      prompt,
+      responses,
+      responseType,
+      equationEditor,
+      customKeys,
+      env: { mode, role } = {},
+    } = config || {};
+    const displayNote = (showCorrect || (mode === 'view' && role === 'instructor')) && showNote && note;
+    const emptyResponse = isEmpty(responses);
+    const showCorrectAnswerToggle = !emptyResponse && correctness && correctness.correctness !== 'correct';
+    const tooltipModeEnabled = disabled && correctness;
+    const additionalKeys = generateAdditionalKeys(customKeys);
+    const correct = correctness && correctness.correct;
+    const staticLatex = prepareForStatic(model, this.state) || '';
+    const viewMode = disabled && !correctness;
+    const studentPrintMode = printMode && !alwaysShowCorrect;
 
-        if (!config) {
-            return null;
-        }
+    const printView = (
+      <div className={classes.printContainer}>
+        <mq.Static
+          className={classes.static}
+          ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
+          latex={staticLatex}
+          onSubFieldChange={this.subFieldChanged}
+          getFieldName={this.getFieldName}
+          setInput={this.setInput}
+          onSubFieldFocus={this.onSubFieldFocus}
+          onBlur={this.onBlur}
+        />
+      </div>
+    );
 
-        const {
-            showNote,
-            note,
-            prompt,
-            responses,
-            responseType,
-            equationEditor,
-            customKeys,
-            env: {mode, role} = {},
-        } = config || {};
-        const displayNote = (showCorrect || (mode === 'view' && role === 'instructor')) && showNote && note;
-        const emptyResponse = isEmpty(responses);
-        const showCorrectAnswerToggle = !emptyResponse && correctness && correctness.correctness !== 'correct';
-        const tooltipModeEnabled = disabled && correctness;
-        const additionalKeys = generateAdditionalKeys(customKeys);
-        const correct = correctness && correctness.correct;
-        const staticLatex = prepareForStatic(model, this.state) || '';
-        const viewMode = disabled && !correctness;
-        const studentPrintMode = printMode && !alwaysShowCorrect;
+    const midContent = (
+      <div className={classes.main}>
+        {mode === 'gather' && <h2 className={classes.srOnly}>Math Equation Response Question</h2>}
 
-        const printView = (
-            <div className={classes.printContainer}>
-                <mq.Static
-                    className={classes.static}
-                    ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
-                    latex={staticLatex}
-                    onSubFieldChange={this.subFieldChanged}
-                    getFieldName={this.getFieldName}
-                    setInput={this.setInput}
-                    onSubFieldFocus={this.onSubFieldFocus}
-                    onBlur={this.onBlur}
+        {viewMode &&
+          teacherInstructions &&
+          hasText(teacherInstructions) &&
+          (!animationsDisabled ? (
+            <Collapsible
+              className={classes.collapsible}
+              labels={{ hidden: 'Show Teacher Instructions', visible: 'Hide Teacher Instructions' }}
+            >
+              <div dangerouslySetInnerHTML={{ __html: teacherInstructions }} />
+            </Collapsible>
+          ) : (
+            <div dangerouslySetInnerHTML={{ __html: teacherInstructions }} />
+          ))}
+
+        {prompt && (
+          <div className={classes.promptContainer}>
+            <PreviewPrompt prompt={prompt} />
+          </div>
+        )}
+
+        {studentPrintMode ? (
+          printView
+        ) : (
+          <Readable false>
+            <div className={classes.inputAndKeypadContainer} tabIndex={0}>
+              {responseType === ResponseTypes.simple && (
+                <SimpleQuestionBlock
+                  onSimpleResponseChange={this.onSimpleResponseChange}
+                  showCorrect={showCorrect}
+                  emptyResponse={emptyResponse}
+                  model={model}
+                  session={session}
                 />
-            </div>
-        );
+              )}
 
-        const midContent = (
-            <div className={classes.main}>
-                {mode === 'gather' && <h2 className={classes.srOnly}>Math Equation Response Question</h2>}
-
-                {viewMode &&
-                    teacherInstructions &&
-                    hasText(teacherInstructions) &&
-                    (!animationsDisabled ? (
-                        <Collapsible
-                            className={classes.collapsible}
-                            labels={{hidden: 'Show Teacher Instructions', visible: 'Hide Teacher Instructions'}}
-                        >
-                            <div dangerouslySetInnerHTML={{__html: teacherInstructions}}/>
-                        </Collapsible>
-                    ) : (
-                        <div dangerouslySetInnerHTML={{__html: teacherInstructions}}/>
-                    ))}
-
-                {prompt && (
-                    <div className={classes.promptContainer}>
-                        <PreviewPrompt prompt={prompt}/>
-                    </div>
-                )}
-
-                {studentPrintMode ? (
-                    printView
-                ) : (
-                    <Readable false>
-                        <div className={classes.inputAndKeypadContainer}>
-                            {responseType === ResponseTypes.simple && (
-                                <SimpleQuestionBlock
-                                    onSimpleResponseChange={this.onSimpleResponseChange}
-                                    showCorrect={showCorrect}
-                                    emptyResponse={emptyResponse}
-                                    model={model}
-                                    session={session}
-                                />
-                            )}
-
-                            {responseType === ResponseTypes.advanced && (
-                                <div
-                                    className={cx(classes.expression, {
-                                        [classes.incorrect]: !emptyResponse && !correct && !showCorrect,
-                                        [classes.correct]: !emptyResponse && (correct || showCorrect),
-                                        [classes.showCorrectness]: !emptyResponse && disabled && correctness && !view,
-                                        [classes.correctAnswerShown]: showCorrect,
-                                        [classes.printCorrect]: printMode && alwaysShowCorrect,
-                                    })}
-                                >
-                                    <Tooltip
-                                        ref={(ref) => this.setTooltipRef(ref)}
-                                        enterTouchDelay={0}
-                                        interactive
-                                        open={!!activeAnswerBlock}
-                                        classes={{
-                                            tooltip: classes.keypadTooltip,
-                                            popper: classes.keypadTooltipPopper,
-                                        }}
-                                        title={Object.keys(session.answers).map(
-                                            (answerId) =>
-                                                (answerId === activeAnswerBlock && !(showCorrect || disabled) && (
-                                                    <div
-                                                        data-keypad={true}
-                                                        key={answerId}
-                                                        className={classes.responseContainer}
-                                                        style={{
-                                                            // marginTop: this.mqStatic && this.mqStatic.input.offsetHeight - 20,
-                                                            width: getKeyPadWidth(additionalKeys, equationEditor),
-                                                        }}
-                                                    >
-                                                        <HorizontalKeypad
-                                                            additionalKeys={additionalKeys}
-                                                            mode={equationEditor || DEFAULT_KEYPAD_VARIANT}
-                                                            onClick={this.onClick}
-                                                        />
-                                                    </div>
-                                                )) ||
-                                                null,
-                                        )}
-                                    >
-                                        <mq.Static
-                                            className={classes.static}
-                                            ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
-                                            latex={staticLatex}
-                                            onSubFieldChange={this.subFieldChanged}
-                                            getFieldName={this.getFieldName}
-                                            setInput={this.setInput}
-                                            onSubFieldFocus={this.onSubFieldFocus}
-                                            onBlur={this.onBlur}
-                                        />
-                                    </Tooltip>
-                                </div>
-                            )}
-                        </div>
-                    </Readable>
-                )}
-
-                {viewMode && displayNote && (
-                    <div className={classes.note} dangerouslySetInnerHTML={{__html: `<strong>Note:</strong> ${note}`}}/>
-                )}
-
-                {viewMode &&
-                    rationale &&
-                    hasText(rationale) &&
-                    (!animationsDisabled ? (
-                        <Collapsible labels={{hidden: 'Show Rationale', visible: 'Hide Rationale'}}>
-                            <div dangerouslySetInnerHTML={{__html: rationale}}/>
-                        </Collapsible>
-                    ) : (
-                        <div dangerouslySetInnerHTML={{__html: rationale}}/>
-                    ))}
-            </div>
-        );
-
-        if (
-            tooltipModeEnabled &&
-            (showCorrectAnswerToggle ||
-                (teacherInstructions && hasText(teacherInstructions)) ||
-                (rationale && hasText(rationale)) ||
-                feedback)
-        ) {
-            return (
-                <Tooltip
-                    interactive
-                    enterTouchDelay={0}
-                    classes={{
-                        tooltip: classes.tooltip,
-                        popper: classes.tooltipPopper,
-                    }}
-                    title={
-                        <div>
-                            <div className={classes.main}>
-                                {showCorrectAnswerToggle && (
-                                    <CorrectAnswerToggle
-                                        language={language}
-                                        className={classes.toggle}
-                                        show
-                                        toggled={showCorrect}
-                                        onToggle={this.toggleShowCorrect}
-                                    />
-                                )}
-                            </div>
-
-                            {teacherInstructions && hasText(teacherInstructions) && (
-                                <Collapsible
-                                    className={classes.collapsible}
-                                    key="collapsible-teacher-instructions"
-                                    labels={{
-                                        hidden: 'Show Teacher Instructions',
-                                        visible: 'Hide Teacher Instructions',
-                                    }}
-                                >
-                                    <PreviewPrompt prompt={teacherInstructions}/>
-                                </Collapsible>
-                            )}
-                            {displayNote && hasText(note) && (
-                                <Collapsible
-                                    className={classes.collapsible}
-                                    key="collapsible-note"
-                                    labels={{
-                                        hidden: translator.t('common:showNote', {lng: language}),
-                                        visible: translator.t('common:hideNote', {lng: language}),
-                                    }}
-                                >
-                                    <PreviewPrompt prompt={note}/>
-                                </Collapsible>
-                            )}
-
-                            {rationale && hasText(rationale) && (
-                                <Collapsible
-                                    className={classes.collapsible}
-                                    key="collapsible-rationale"
-                                    labels={{
-                                        hidden: 'Show Rationale',
-                                        visible: 'Hide Rationale',
-                                    }}
-                                >
-                                    <PreviewPrompt prompt={rationale}/>
-                                </Collapsible>
-                            )}
-
-                            {feedback && <Feedback correctness={correctness.correctness} feedback={feedback}/>}
-                        </div>
-                    }
+              {responseType === ResponseTypes.advanced && (
+                <div
+                  className={cx(classes.expression, {
+                    [classes.incorrect]: !emptyResponse && !correct && !showCorrect,
+                    [classes.correct]: !emptyResponse && (correct || showCorrect),
+                    [classes.showCorrectness]: !emptyResponse && disabled && correctness && !view,
+                    [classes.correctAnswerShown]: showCorrect,
+                    [classes.printCorrect]: printMode && alwaysShowCorrect,
+                  })}
                 >
-                    <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
-                        {midContent}
-                    </div>
-                </Tooltip>
-            );
-        }
-
-        return (
-            <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
-                {midContent}
+                  <Tooltip
+                    ref={(ref) => this.setTooltipRef(ref)}
+                    enterTouchDelay={0}
+                    interactive
+                    open={!!activeAnswerBlock}
+                    classes={{
+                      tooltip: classes.keypadTooltip,
+                      popper: classes.keypadTooltipPopper,
+                    }}
+                    title={Object.keys(session.answers).map(
+                      (answerId) =>
+                        (answerId === activeAnswerBlock && !(showCorrect || disabled) && (
+                          <div
+                            data-keypad={true}
+                            key={answerId}
+                            className={classes.responseContainer}
+                            style={{
+                              // marginTop: this.mqStatic && this.mqStatic.input.offsetHeight - 20,
+                              width: getKeyPadWidth(additionalKeys, equationEditor),
+                            }}
+                          >
+                            <HorizontalKeypad
+                              additionalKeys={additionalKeys}
+                              mode={equationEditor || DEFAULT_KEYPAD_VARIANT}
+                              onClick={this.onClick}
+                            />
+                          </div>
+                        )) ||
+                        null,
+                    )}
+                  >
+                    <mq.Static
+                      className={classes.static}
+                      ref={(mqStatic) => (this.mqStatic = mqStatic || this.mqStatic)}
+                      latex={staticLatex}
+                      onSubFieldChange={this.subFieldChanged}
+                      getFieldName={this.getFieldName}
+                      setInput={this.setInput}
+                      onSubFieldFocus={this.onSubFieldFocus}
+                      onBlur={this.onBlur}
+                    />
+                  </Tooltip>
+                </div>
+              )}
             </div>
-        );
+          </Readable>
+        )}
+
+        {viewMode && displayNote && (
+          <div className={classes.note} dangerouslySetInnerHTML={{ __html: `<strong>Note:</strong> ${note}` }} />
+        )}
+
+        {viewMode &&
+          rationale &&
+          hasText(rationale) &&
+          (!animationsDisabled ? (
+            <Collapsible labels={{ hidden: 'Show Rationale', visible: 'Hide Rationale' }}>
+              <div dangerouslySetInnerHTML={{ __html: rationale }} />
+            </Collapsible>
+          ) : (
+            <div dangerouslySetInnerHTML={{ __html: rationale }} />
+          ))}
+      </div>
+    );
+
+    if (
+      tooltipModeEnabled &&
+      (showCorrectAnswerToggle ||
+        (teacherInstructions && hasText(teacherInstructions)) ||
+        (rationale && hasText(rationale)) ||
+        feedback)
+    ) {
+      return (
+        <Tooltip
+          interactive
+          enterTouchDelay={0}
+          classes={{
+            tooltip: classes.tooltip,
+            popper: classes.tooltipPopper,
+          }}
+          title={
+            <div>
+              <div className={classes.main}>
+                {showCorrectAnswerToggle && (
+                  <CorrectAnswerToggle
+                    language={language}
+                    className={classes.toggle}
+                    show
+                    toggled={showCorrect}
+                    onToggle={this.toggleShowCorrect}
+                  />
+                )}
+              </div>
+
+              {teacherInstructions && hasText(teacherInstructions) && (
+                <Collapsible
+                  className={classes.collapsible}
+                  key="collapsible-teacher-instructions"
+                  labels={{
+                    hidden: 'Show Teacher Instructions',
+                    visible: 'Hide Teacher Instructions',
+                  }}
+                >
+                  <PreviewPrompt prompt={teacherInstructions} />
+                </Collapsible>
+              )}
+              {displayNote && hasText(note) && (
+                <Collapsible
+                  className={classes.collapsible}
+                  key="collapsible-note"
+                  labels={{
+                    hidden: translator.t('common:showNote', { lng: language }),
+                    visible: translator.t('common:hideNote', { lng: language }),
+                  }}
+                >
+                  <PreviewPrompt prompt={note} />
+                </Collapsible>
+              )}
+
+              {rationale && hasText(rationale) && (
+                <Collapsible
+                  className={classes.collapsible}
+                  key="collapsible-rationale"
+                  labels={{
+                    hidden: 'Show Rationale',
+                    visible: 'Hide Rationale',
+                  }}
+                >
+                  <PreviewPrompt prompt={rationale} />
+                </Collapsible>
+              )}
+
+              {feedback && <Feedback correctness={correctness.correctness} feedback={feedback} />}
+            </div>
+          }
+        >
+          <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
+            {midContent}
+          </div>
+        </Tooltip>
+      );
     }
+
+    return (
+      <div className={classes.mainContainer} ref={(r) => (this.root = r || this.root)}>
+        {midContent}
+      </div>
+    );
+  }
 }
 
 const styles = (theme) => ({
-    mainContainer: {
-        color: color.text(),
-        backgroundColor: color.background(),
-        display: 'inline-block',
+  mainContainer: {
+    color: color.text(),
+    backgroundColor: color.background(),
+    display: 'inline-block',
+  },
+  tooltip: {
+    background: `${color.primaryLight()} !important`,
+    color: color.text(),
+    padding: theme.spacing.unit * 2,
+    border: `1px solid ${color.secondary()}`,
+    fontSize: '16px',
+    '& :not(.MathJax) > table tr': {
+      '&:nth-child(2n)': {
+        backgroundColor: 'unset !important',
+      },
     },
-    tooltip: {
-        background: `${color.primaryLight()} !important`,
-        color: color.text(),
-        padding: theme.spacing.unit * 2,
-        border: `1px solid ${color.secondary()}`,
-        fontSize: '16px',
-        '& :not(.MathJax) > table tr': {
-            '&:nth-child(2n)': {
-                backgroundColor: 'unset !important',
-            },
+  },
+  tooltipPopper: {
+    opacity: 1,
+  },
+  keypadTooltip: {
+    fontSize: 'initial',
+    background: 'transparent',
+    width: '600px',
+    marginTop: 0,
+    paddingTop: 0,
+  },
+  keypadTooltipPopper: {
+    background: 'transparent',
+    width: '650px',
+    opacity: 1,
+  },
+  promptContainer: {
+    marginBottom: theme.spacing.unit * 2,
+  },
+  main: {
+    width: '100%',
+    position: 'relative',
+    backgroundColor: color.background(),
+    color: color.text(),
+  },
+  title: {
+    fontSize: '1.1rem',
+    display: 'block',
+    marginTop: theme.spacing.unit * 2,
+    marginBottom: theme.spacing.unit,
+  },
+  note: {
+    paddingBottom: theme.spacing.unit * 2,
+  },
+  collapsible: {
+    marginBottom: theme.spacing.unit * 2,
+  },
+  responseContainer: {
+    zIndex: 10,
+    // position: 'absolute',
+    // right: 0,
+    minWidth: '400px',
+    marginTop: theme.spacing.unit * 2,
+  },
+  expression: {
+    maxWidth: 'fit-content',
+    '& > .mq-math-mode': {
+      '& > .mq-root-block': {
+        '& > .mq-editable-field': {
+          minWidth: '10px',
+          margin: (theme.spacing.unit * 2) / 3,
+          padding: theme.spacing.unit / 4,
         },
+      },
+      '& sup': {
+        top: 0,
+      },
     },
-    tooltipPopper: {
-        opacity: 1,
+  },
+  static: {
+    '& > .mq-root-block': {
+      '& > .mq-editable-field': {
+        borderColor: color.text(),
+      },
     },
-    keypadTooltip: {
-        fontSize: 'initial',
-        background: 'transparent',
-        width: '600px',
-        marginTop: 0,
-        paddingTop: 0,
+  },
+  inputAndKeypadContainer: {
+    position: 'relative',
+    '& .mq-overarrow-inner': {
+      border: 'none !important',
+      padding: '0 !important',
     },
-    keypadTooltipPopper: {
-        background: 'transparent',
-        width: '650px',
-        opacity: 1,
+    '& .mq-overarrow-inner-right': {
+      display: 'none !important',
     },
-    promptContainer: {
-        marginBottom: theme.spacing.unit * 2,
+    '& .mq-overarrow-inner-left': {
+      display: 'none !important',
     },
-    main: {
-        width: '100%',
-        position: 'relative',
-        backgroundColor: color.background(),
-        color: color.text(),
+    '& .mq-overarrow.mq-arrow-both': {
+      minWidth: '1.23em',
+      '& *': {
+        lineHeight: '1 !important',
+      },
+      '&:before': {
+        top: '-0.4em',
+        left: '-1px',
+      },
+      '&:after': {
+        top: '-2.4em',
+        right: '-1px',
+      },
+      '&.mq-empty:after': {
+        top: '-0.45em',
+      },
     },
-    title: {
-        fontSize: '1.1rem',
-        display: 'block',
-        marginTop: theme.spacing.unit * 2,
-        marginBottom: theme.spacing.unit,
+    '& .mq-overarrow.mq-arrow-right': {
+      '&:before': {
+        top: '-0.4em',
+        right: '-1px',
+      },
     },
-    note: {
-        paddingBottom: theme.spacing.unit * 2,
+    '& .mq-longdiv-inner': {
+      borderTop: '1px solid !important',
+      paddingTop: '1.5px !important',
     },
-    collapsible: {
-        marginBottom: theme.spacing.unit * 2,
+    '& .mq-parallelogram': {
+      lineHeight: 0.85,
     },
-    responseContainer: {
-        zIndex: 10,
-        // position: 'absolute',
-        // right: 0,
-        minWidth: '400px',
-        marginTop: theme.spacing.unit * 2,
-    },
-    expression: {
-        maxWidth: 'fit-content',
-        '& > .mq-math-mode': {
-            '& > .mq-root-block': {
-                '& > .mq-editable-field': {
-                    minWidth: '10px',
-                    margin: (theme.spacing.unit * 2) / 3,
-                    padding: theme.spacing.unit / 4,
-                },
-            },
-            '& sup': {
-                top: 0,
-            },
+  },
+  showCorrectness: {
+    border: '2px solid',
+  },
+  correctAnswerShown: {
+    padding: theme.spacing.unit,
+    letterSpacing: '0.5px',
+  },
+  printCorrect: {
+    border: `2px solid ${color.correct()} !important`,
+  },
+  correct: {
+    borderColor: `${color.correct()} !important`,
+  },
+  incorrect: {
+    borderColor: `${color.incorrect()} !important`,
+  },
+  blockContainer: {
+    margin: `${theme.spacing.unit}px !important`,
+    display: 'inline-flex',
+    border: '2px solid grey !important',
+  },
+  blockResponse: {
+    flex: 2,
+    color: 'grey',
+    background: theme.palette.grey['A100'],
+    fontSize: '0.8rem !important',
+    padding: `${theme.spacing.unit / 2}px !important`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRight: `2px solid ${color.disabled()} !important`,
+  },
+  toggle: {
+    color: color.text(),
+    marginBottom: theme.spacing.unit * 2,
+  },
+  blockMath: {
+    color: color.text(),
+    backgroundColor: color.background(),
+    padding: `${theme.spacing.unit / 2}px !important`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 8,
+    '& > .mq-math-mode': {
+      '& > .mq-hasCursor': {
+        '& > .mq-cursor': {
+          display: 'none',
         },
+      },
     },
-    static: {
-        '& > .mq-root-block': {
-            '& > .mq-editable-field': {
-                borderColor: color.text(),
-            },
-        },
-    },
-    inputAndKeypadContainer: {
-        position: 'relative',
-        '& .mq-overarrow-inner': {
-            border: 'none !important',
-            padding: '0 !important',
-        },
-        '& .mq-overarrow-inner-right': {
-            display: 'none !important',
-        },
-        '& .mq-overarrow-inner-left': {
-            display: 'none !important',
-        },
-        '& .mq-overarrow.mq-arrow-both': {
-            minWidth: '1.23em',
-            '& *': {
-                lineHeight: '1 !important',
-            },
-            '&:before': {
-                top: '-0.4em',
-                left: '-1px',
-            },
-            '&:after': {
-                top: '-2.4em',
-                right: '-1px',
-            },
-            '&.mq-empty:after': {
-                top: '-0.45em',
-            },
-        },
-        '& .mq-overarrow.mq-arrow-right': {
-            '&:before': {
-                top: '-0.4em',
-                right: '-1px',
-            },
-        },
-        '& .mq-longdiv-inner': {
-            borderTop: '1px solid !important',
-            paddingTop: '1.5px !important',
-        },
-        '& .mq-parallelogram': {
-            lineHeight: 0.85,
-        },
-    },
-    showCorrectness: {
-        border: '2px solid',
-    },
-    correctAnswerShown: {
-        padding: theme.spacing.unit,
-        letterSpacing: '0.5px',
-    },
-    printCorrect: {
-        border: `2px solid ${color.correct()} !important`,
-    },
-    correct: {
-        borderColor: `${color.correct()} !important`,
-    },
-    incorrect: {
-        borderColor: `${color.incorrect()} !important`,
-    },
-    blockContainer: {
-        margin: `${theme.spacing.unit}px !important`,
-        display: 'inline-flex',
-        border: '2px solid grey !important',
-    },
-    blockResponse: {
-        flex: 2,
-        color: 'grey',
-        background: theme.palette.grey['A100'],
-        fontSize: '0.8rem !important',
-        padding: `${theme.spacing.unit / 2}px !important`,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        borderRight: `2px solid ${color.disabled()} !important`,
-    },
-    toggle: {
-        color: color.text(),
-        marginBottom: theme.spacing.unit * 2,
-    },
-    blockMath: {
-        color: color.text(),
-        backgroundColor: color.background(),
-        padding: `${theme.spacing.unit / 2}px !important`,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flex: 8,
-        '& > .mq-math-mode': {
-            '& > .mq-hasCursor': {
-                '& > .mq-cursor': {
-                    display: 'none',
-                },
-            },
-        },
-    },
-    printContainer: {
-        marginBottom: theme.spacing.unit,
-        pointerEvents: 'none',
-    },
-    srOnly: {
-        position: 'absolute',
-        left: '-10000px',
-        top: 'auto',
-        width: '1px',
-        height: '1px',
-        overflow: 'hidden',
-    },
+  },
+  printContainer: {
+    marginBottom: theme.spacing.unit,
+    pointerEvents: 'none',
+  },
+  srOnly: {
+    position: 'absolute',
+    left: '-10000px',
+    top: 'auto',
+    width: '1px',
+    height: '1px',
+    overflow: 'hidden',
+  },
 });
 
 export default withStyles(styles)(Main);


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2482

- Modified `updateAria` to dynamically add screen-reader-only instructions span before each textarea.
- Ensured textareas are properly described by associating them with the instructions via `aria-describedby`.
- Improved accessibility by updating `aria-hidden` for `.mq-selectable` elements and providing context for math keypad input.
- Ensure screen-reader instructions are read when using keyboard (tab) to navigate the player
