### PR TITLE
fix(inline-dropdown, match, math-templated, multiple-choice): set Typography component to div to prevent overwriting of p styling in client platforms PD-3913

### DIFF
--- a/packages/inline-dropdown/configure/src/__tests__/__snapshots__/main.test.jsx.snap
+++ b/packages/inline-dropdown/configure/src/__tests__/__snapshots__/main.test.jsx.snap
@@ -330,7 +330,9 @@ exports[`Main snapshot renders with teacher instructions, prompt and rationale e
     />
   </InputContainer>
   <div>
-    <WithStyles(Typography)>
+    <WithStyles(Typography)
+      component="div"
+    >
       Define Template, Choices, and Correct Responses
     </WithStyles(Typography)>
     <WithStyles(Tooltip)
@@ -1005,7 +1007,9 @@ exports[`Main snapshot renders without teacher instructions, prompt and rational
   }
 >
   <div>
-    <WithStyles(Typography)>
+    <WithStyles(Typography)
+      component="div"
+    >
       Define Template, Choices, and Correct Responses
     </WithStyles(Typography)>
     <WithStyles(Tooltip)

--- a/packages/inline-dropdown/configure/src/main.jsx
+++ b/packages/inline-dropdown/configure/src/main.jsx
@@ -498,7 +498,7 @@ export class Main extends React.Component {
         )}
 
         <div className={classes.flexContainer}>
-          <Typography className={classes.text}>Define Template, Choices, and Correct Responses</Typography>
+          <Typography className={classes.text} component={'div'}>Define Template, Choices, and Correct Responses</Typography>
           <Tooltip
             classes={{ tooltip: classes.tooltip }}
             disableFocusListener

--- a/packages/match/configure/src/general-config-block.jsx
+++ b/packages/match/configure/src/general-config-block.jsx
@@ -75,7 +75,7 @@ class GeneralConfigBlock extends React.Component {
     return (
       <React.Fragment>
         <div className={classes.flexContainer}>
-          <Typography className={classes.titleText}>Define questions</Typography>
+          <Typography className={classes.titleText} component={'div'}>Define questions</Typography>
           <Tooltip
             classes={{ tooltip: classes.tooltip }}
             disableFocusListener

--- a/packages/math-templated/configure/src/__tests__/__snapshots__/design.test.js.snap
+++ b/packages/math-templated/configure/src/__tests__/__snapshots__/design.test.js.snap
@@ -285,7 +285,9 @@ exports[`Render Main Component Match Snapshot 1`] = `
     />
   </InputContainer>
   <div>
-    <WithStyles(Typography)>
+    <WithStyles(Typography)
+      component="div"
+    >
       Response Template
     </WithStyles(Typography)>
     <WithStyles(Tooltip)

--- a/packages/math-templated/configure/src/design.jsx
+++ b/packages/math-templated/configure/src/design.jsx
@@ -392,7 +392,7 @@ export class Design extends React.Component {
           </InputContainer>
         )}
         <div className={classes.tooltipContainer}>
-          <Typography className={classes.title}>Response Template</Typography>
+          <Typography className={classes.title} component={'div'}>Response Template</Typography>
           <Tooltip
             classes={{ tooltip: classes.tooltip }}
             disableFocusListener

--- a/packages/multiple-choice/configure/src/main.jsx
+++ b/packages/multiple-choice/configure/src/main.jsx
@@ -266,7 +266,7 @@ const Design = withStyles(styles)((props) => {
       )}
 
       <div className={classes.flexContainer}>
-        <Typography className={classes.titleText}>Choices</Typography>
+        <Typography className={classes.titleText} component={'div'}>Choices</Typography>
         <Tooltip
           classes={{ tooltip: classes.tooltip }}
           disableFocusListener


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3913