### PR TITLE
feat(placement-ordering): send type to placeholder in order to apply styles differently PD-3946

### DIFF
--- a/packages/placement-ordering/src/tile.jsx
+++ b/packages/placement-ordering/src/tile.jsx
@@ -18,7 +18,7 @@ const Holder = withStyles((theme) => ({
     color: `rgba(${theme.palette.common.black}, 0.6)`,
   },
 }))(({ classes, type, index, isOver, disabled }) => (
-  <PlaceHolder isOver={isOver} disabled={disabled}>
+  <PlaceHolder type={type} isOver={isOver} disabled={disabled}>
     {type === 'target' && index !== undefined && <div className={classes.number}>{index}</div>}
   </PlaceHolder>
 ));


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3946
Based on George's comment regarding the placement-ordering in which only the "target" area should have the dashed border, I needed to send the type to Placeholder in order to apply different styles.