### PR TITLE
fix(ICA): Refactored interactive styles to reduce duplication and added 'width: fit-content' PD-3658

### DIFF
--- a/packages/image-cloze-association/src/interactive-section.jsx
+++ b/packages/image-cloze-association/src/interactive-section.jsx
@@ -80,22 +80,27 @@ InteractiveSection.defaultProps = {
   responseCorrect: undefined,
 };
 
-const styles = (theme) => ({
-  interactiveDefault: {
+const styles = (theme) => {
+  const baseInteractiveStyle = {
     marginTop: theme.spacing.unit * 2,
-    border: `1px solid ${color.disabled()}`,
     display: 'flex',
-  },
-  interactiveCorrect: {
-    marginTop: theme.spacing.unit * 2,
-    border: `2px solid ${color.correct()}`,
-    display: 'flex',
-  },
-  interactiveIncorrect: {
-    marginTop: theme.spacing.unit * 2,
-    border: `2px solid ${color.incorrect()}`,
-    display: 'flex',
-  },
-});
+    width: 'fit-content',
+  };
+
+  return {
+    interactiveDefault: {
+      ...baseInteractiveStyle,
+      border: `1px solid ${color.disabled()}`,
+    },
+    interactiveCorrect: {
+      ...baseInteractiveStyle,
+      border: `2px solid ${color.correct()}`,
+    },
+    interactiveIncorrect: {
+      ...baseInteractiveStyle,
+      border: `2px solid ${color.incorrect()}`,
+    },
+  };
+};
 
 export default withStyles(styles)(InteractiveSection);


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3658

Without the fit-content:
<img width="381" alt="Screenshot 2024-08-08 at 13 55 38" src="https://github.com/user-attachments/assets/76e1bf79-a6cd-4a46-a85e-26509e0662d1">

After the fix:
<img width="1305" alt="Screenshot 2024-08-08 at 13 56 06" src="https://github.com/user-attachments/assets/f8d739c6-e390-4d02-8c9f-7812aeb24764">
