### PR TITLE
fix(math-inline): enhance keypad visibility by setting Popper boundariesElement to body, adjusting placement to bottom-start, and enabling flip PD-2452

### DIFF
--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -643,6 +643,16 @@ export class Main extends React.Component {
                     }}
                     PopperProps={{
                       container: tooltipContainerRef?.current || undefined,
+                      placement: 'bottom-start',
+                      modifiers: {
+                        preventOverflow: {
+                          enabled: true,
+                          boundariesElement: 'body',
+                        },
+                        flip: {
+                          enabled: true,
+                        },
+                      },
                     }}
                     title={Object.keys(session.answers).map(
                       (answerId) =>


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-2452?focusedCommentId=1512835