### PR TITLE
feat(number-line): add circle indicator for selecting points or rays …

### DIFF
--- a/packages/number-line/src/number-line/graph/elements/line.jsx
+++ b/packages/number-line/src/number-line/graph/elements/line.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Draggable from '../../../draggable';
-import Point from './point';
-import { basePropTypes } from './base';
 import classNames from 'classnames';
 import injectSheet from 'react-jss';
 import isEqual from 'lodash/isEqual';
 import isNumber from 'lodash/isNumber';
 import { color } from '@pie-lib/pie-toolbox/render-ui';
+
+import Draggable from '../../../draggable';
+import Point from './point';
+import { basePropTypes } from './base';
 
 const duration = '150ms';
 
@@ -35,9 +36,6 @@ const style = {
   },
   selected: {
     '& .line-handle': {
-      stroke: color.primaryDark(),
-    },
-    '& circle': {
       stroke: color.primaryDark(),
     },
   },

--- a/packages/number-line/src/number-line/graph/elements/point.jsx
+++ b/packages/number-line/src/number-line/graph/elements/point.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { color } from '@pie-lib/pie-toolbox/render-ui';
-import Draggable from '../../../draggable';
 import classNames from 'classnames';
 import injectSheet from 'react-jss';
+import { color } from '@pie-lib/pie-toolbox/render-ui';
+
+import Draggable from '../../../draggable';
 
 const duration = '150ms';
 
@@ -170,7 +171,14 @@ export class Point extends React.Component {
         bounds={scaledBounds}
       >
         <g>
-          <circle r="20" strokeWidth="3" style={{ fill: 'transparent' }} cx={xScale(position)} cy={y} />
+          <circle
+            r="20"
+            strokeWidth="3"
+            style={{ fill: 'transparent' }}
+            cx={xScale(position)}
+            cy={y}
+            stroke={selected ? color.primaryDark() : 'none'}
+          />
           <circle r="5" strokeWidth="3" className={circleClass} cx={xScale(position)} cy={y} />
         </g>
       </Draggable>


### PR DESCRIPTION
…PD-4016
 Only the line (segment) had that circle indicator. I added it to point and ray too:
 
<img width="538" alt="image" src="https://github.com/user-attachments/assets/fc08c973-db9c-4d2e-810a-b1af6c15874b">


https://illuminate.atlassian.net/browse/PD-4016