### PR TITLE
fix(categorize): added pointerEvents none for categorize card to prevent other interactions with touch events PD-3652

### DIFF
--- a/packages/categorize/src/categorize/choice.jsx
+++ b/packages/categorize/src/categorize/choice.jsx
@@ -81,6 +81,9 @@ const styles = (theme) => ({
     color: color.text(),
     backgroundColor: color.background(),
     width: '100%',
+    // Added for touch devices, for image content.
+    // This will prevent the context menu from appearing and not allowing other interactions with the image.
+    pointerEvents: 'none',
   },
 });
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-3652

The primary goal behind this change was to address an issue on touch devices when interacting with image-based tokens in categorize element. There was a problem where a long press on the image—intended to trigger a drag-and-drop action— caused the browser to respond with a default gesture showing a green plus icon, indicating that it was trying to open the image in a new tab.

Specifically, a long press on the image led to the creation of a new DOM node (an "image-overlay"). To prevent this unwanted interaction, I added the CSS property pointerEvents: 'none'. By doing so, I disabled pointer events for the images, stopping the context menu or other interactions from being triggered during a long press. This solution solved the problem by preventing the default browser behaviour and allowing users to drag and drop without interruptions.