### PR TITLE
fix(placement-ordering): Added translateZ(0) to body to resolve rendering issues in Chrome v106+ for drag n drop PD-3656

### DIFF
--- a/packages/placement-ordering/src/tile.jsx
+++ b/packages/placement-ordering/src/tile.jsx
@@ -110,6 +110,13 @@ export class Tile extends React.Component {
     guideIndex: PropTypes.number,
   };
 
+  componentDidMount() {
+    // Workaround for Chrome's rendering issue post version 106.
+    // Adding 'translateZ(0)' forces the browser to use hardware-accelerated rendering
+    // which fixes the issue of disappearing elements during drag and drop.
+    document.body.style.transform = 'translateZ(0)';
+  }
+
   render() {
     const {
       label,


### PR DESCRIPTION
This PR addresses the issue where drag-and-drop functionality was broken in Chrome versions 106 and later. After in-depth investigation, the root cause was found to be related to Chrome's rendering engine changes in v106, which affected React DnD's handling of drag events.

A workaround has been applied by adding translateZ(0) to the body, forcing Chrome to use hardware-accelerated rendering, which resolves the issue.

For full details regarding the issue, root cause, and fixes, please refer to the comments section in
https://illuminate.atlassian.net/browse/PD-3656
