### PR TITLE
fix(math-inline): resolve issue where math editor closes when interacting with the keypad PD-4155 DNA-22415

### DIFF
--- a/packages/math-inline/src/__tests__/main.test.js
+++ b/packages/math-inline/src/__tests__/main.test.js
@@ -151,13 +151,10 @@ describe('Math-Inline Main', () => {
     });
 
     it('should deactivate the keypad if the input is not focused and a click or touch event occurs', () => {
-      textarea.blur();
+      const event = { key: 'ArrowDown', target: document.activeElement };
       wrapper.setState({ activeAnswerBlock: 'r1' });
 
-      const differentElement = document.createElement('div');
-      document.body.appendChild(differentElement);
-
-      instance.handleKeyDown({ type: 'click', target: differentElement }, 'r2');
+      instance.onBlur(event);
 
       expect(wrapper.state('activeAnswerBlock')).toEqual('');
     });

--- a/packages/math-inline/src/main.jsx
+++ b/packages/math-inline/src/main.jsx
@@ -325,24 +325,26 @@ export class Main extends React.Component {
   handleKeyDown = (event, id) => {
     const isAnswerInputFocused = document.activeElement.getAttribute('aria-label') === 'Enter answer.';
     const isClickOrTouchEvent = event.type === 'click' || event.type === 'touchstart';
-
+  
     if (isAnswerInputFocused && (event.key === 'ArrowDown' || isClickOrTouchEvent)) {
-      this.setState({ activeAnswerBlock: id }, () => {
-        if (event.key === 'ArrowDown') {
-          this.focusFirstKeypadElement();
-        }
-      });
+      if (this.state.activeAnswerBlock !== id) {
+        this.setState({ activeAnswerBlock: id });
+      }
+  
+      if (event.key === 'ArrowDown') {
+        this.focusFirstKeypadElement();
+      }
+    } else if ( event.key === 'Escape') {
+         this.setState({ activeAnswerBlock: '' });
     }
-
-    if ((!isAnswerInputFocused && isClickOrTouchEvent) || event.key === 'Escape') {
-      this.setState({ activeAnswerBlock: '' });
-    }
-  };
+  };  
 
   onSubFieldFocus = (id) => {
     const handleEvent = (event) => {
       this.handleKeyDown(event, id);
     };
+
+    this.handleEvent = handleEvent;
 
     document.addEventListener('keydown', handleEvent);
     document.addEventListener('click', handleEvent);
@@ -350,9 +352,12 @@ export class Main extends React.Component {
   };
 
   cleanupKeyDownListener = () => {
-    document.removeEventListener('keydown', this.handleEvent);
-    document.removeEventListener('click', this.handleEvent);
-    document.removeEventListener('touchstart', this.handleEvent);
+    if (this.handleEvent) {
+      document.removeEventListener('keydown', this.handleEvent);
+      document.removeEventListener('click', this.handleEvent);
+      document.removeEventListener('touchstart', this.handleEvent);
+      this.handleEvent = null;
+    }
   };
 
   componentWillUnmount() {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/DNA-22415
https://illuminate.atlassian.net/browse/PD-4155

- Fixed an issue where the math editor was closing unexpectedly when students clicked on the keypad buttons during input.
- Added checks to handle the focus state of the input field more reliably, ensuring proper handling of keyboard interactions like `ArrowDown` and click events.
- Optimized the `handleKeyDown` logic to reduce redundant state updates and improve performance.