### PR TITLE
fix(number-line): select a segment or ray near endpoints PD-4015

### DIFF
--- a/packages/number-line/src/number-line/graph/elements/point.jsx
+++ b/packages/number-line/src/number-line/graph/elements/point.jsx
@@ -174,7 +174,7 @@ export class Point extends React.Component {
           <circle
             r="20"
             strokeWidth="3"
-            style={{ fill: 'transparent', pointerEvents: 'none' }}
+            style={{ fill: 'transparent', pointerEvents: 'visibleStroke' }}
             cx={xScale(position)}
             cy={y}
             stroke={selected ? color.primaryDark() : 'none'}

--- a/packages/number-line/src/number-line/graph/elements/point.jsx
+++ b/packages/number-line/src/number-line/graph/elements/point.jsx
@@ -174,7 +174,7 @@ export class Point extends React.Component {
           <circle
             r="20"
             strokeWidth="3"
-            style={{ fill: 'transparent' }}
+            style={{ fill: 'transparent', pointerEvents: 'none' }}
             cx={xScale(position)}
             cy={y}
             stroke={selected ? color.primaryDark() : 'none'}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4015

Set pointer-events to visibleStroke on endpoint circles to prevent them from blocking clicks on the line
This allows interactions with the visible stroke of the circle without interfering with line selection

