### PR TITLE
fix(categorize): title in alternate section not rendering rows and math PD-4283

### DIFF
--- a/packages/categorize/configure/src/design/categories/category.jsx
+++ b/packages/categorize/configure/src/design/categories/category.jsx
@@ -157,8 +157,10 @@ const styles = (theme) => ({
     overflow: 'visible',
   },
   categoryHeader: {
-    display: 'flex',
     padding: theme.spacing.unit * 2,
+    '& p': {
+      margin: 0
+    }
   },
   duplicateError: {
     border: '1px solid red',

--- a/packages/categorize/configure/src/index.js
+++ b/packages/categorize/configure/src/index.js
@@ -7,6 +7,7 @@ import {
   InsertSoundEvent,
   DeleteSoundEvent,
 } from '@pie-framework/pie-configure-events';
+import { renderMath } from '@pie-lib/pie-toolbox/math-rendering-accessible';
 
 import Main from './main';
 
@@ -139,6 +140,8 @@ export default class CategorizeConfigure extends HTMLElement {
       },
     });
 
-    ReactDOM.render(el, this);
+    ReactDOM.render(el, this, () => {
+      renderMath(this);
+    });
   }
 }


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4283 
**_Before:_**
_**category label defined like this:**_
<img width="296" alt="image" src="https://github.com/user-attachments/assets/951e981a-183b-4e5c-9f80-c6344634717a">

**_was rendering like this in the alternate section:_**
 
<img width="305" alt="image" src="https://github.com/user-attachments/assets/86aac88e-3cd3-4700-b8bc-3e37d1dd968d">

**_After:_**
<img width="341" alt="image" src="https://github.com/user-attachments/assets/e7edc50e-8373-49cd-990d-5f15e9568a34">
