### PR TITLE
fix(ica): Misalignment of answer choices and response areas PD-4386

### DIFF
--- a/packages/image-cloze-association/src/image-container.jsx
+++ b/packages/image-cloze-association/src/image-container.jsx
@@ -21,6 +21,7 @@ class ImageContainer extends Component {
       answerChoiceTransparency,
       responseContainerPadding,
       imageDropTargetPadding,
+      maxResponsePerZone,
     } = this.props;
 
     return (
@@ -54,6 +55,7 @@ class ImageContainer extends Component {
               answerChoiceTransparency={answerChoiceTransparency}
               responseContainerPadding={responseContainerPadding}
               imageDropTargetPadding={imageDropTargetPadding}
+              maxResponsePerZone={maxResponsePerZone}
             />
           );
         })}
@@ -77,6 +79,7 @@ ImageContainer.propTypes = {
   responseAreaFill: PropTypes.string,
   responseContainerPadding: PropTypes.string,
   imageDropTargetPadding: PropTypes.string,
+  maxResponsePerZone: PropTypes.number,
 };
 
 ImageContainer.defaultProps = {

--- a/packages/image-cloze-association/src/image-drop-target.jsx
+++ b/packages/image-cloze-association/src/image-drop-target.jsx
@@ -28,7 +28,8 @@ class ImageDropTarget extends React.Component {
       imageDropTargetPadding,
       // dnd-related props
       connectDropTarget,
-      answerChoiceTransparency
+      answerChoiceTransparency,
+      maxResponsePerZone,
     } = this.props;
     const { shouldHaveSmallPadding } = this.state;
 
@@ -38,7 +39,7 @@ class ImageDropTarget extends React.Component {
     });
 
     const updatedContainerStyle = {
-      padding: responseContainerPadding,
+      padding: maxResponsePerZone === 1 ? '0' : responseContainerPadding,
       ...containerStyle,
       ...(responseAreaFill && { backgroundColor: responseAreaFill })
     };
@@ -105,6 +106,7 @@ ImageDropTarget.propTypes = {
   answerChoiceTransparency: PropTypes.bool,
   responseContainerPadding: PropTypes.string,
   imageDropTargetPadding: PropTypes.string,
+  maxResponsePerZone: PropTypes.number,
 };
 
 ImageDropTarget.defaultProps = {

--- a/packages/image-cloze-association/src/root.jsx
+++ b/packages/image-cloze-association/src/root.jsx
@@ -307,6 +307,7 @@ class ImageClozeAssociationComponent extends React.Component {
               responseAreaFill={responseAreaFill}
               responseContainerPadding={responseContainerPadding}
               imageDropTargetPadding={imageDropTargetPadding}
+              maxResponsePerZone={maxResponsePerZone}
             />
           </InteractiveSection>
         ) : (
@@ -326,6 +327,7 @@ class ImageClozeAssociationComponent extends React.Component {
               answerChoiceTransparency={answerChoiceTransparency}
               responseContainerPadding={responseContainerPadding}
               imageDropTargetPadding={imageDropTargetPadding}
+              maxResponsePerZone={maxResponsePerZone}
             />
 
             {maxResponsePerZoneWarning && <WarningInfo message={warningMessage} />}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4386
Following George's suggestion, adjusted the response container's default behavior to apply "responseContainerPadding": "0px" when "max_response_per_zone" is either absent or set to 1. ( in code, if maxResponsePerZone is absent is automatically set to 1 )

Before:
<img width="834" alt="Screenshot 2024-11-05 at 16 41 40" src="https://github.com/user-attachments/assets/4a2503f6-bbde-4f59-ae8f-9f50b5afecee">
After:
<img width="842" alt="Screenshot 2024-11-05 at 16 40 42" src="https://github.com/user-attachments/assets/e899cb60-f111-4213-927d-c584440e4f51">
