### PR TITLE
fix(graphing): Filtering incomplete graph objects added by student before scoring.

### DIFF
--- a/packages/graphing/controller/src/index.js
+++ b/packages/graphing/controller/src/index.js
@@ -103,6 +103,9 @@ export const getBestAnswer = (question, session, env = {}) => {
 
   // initialize answer if no values
   answer = answer || [];
+  
+  //filter the incomplete objects for student response - Fix for SC-33160
+  answer = answer.filter((mark) => !mark.building);
 
   // initialize one possible answer if no values
   if (isEmpty(questionPossibleAnswers)) {


### PR DESCRIPTION
Filtering incomplete graph objects added by student before scoring. This is the case when student add some graph object and click undo and object is in building state.
Jira - [https://illuminate.atlassian.net/browse/SC-33160](https://illuminate.atlassian.net/browse/SC-33160)