### PR TITLE
fix(hotspot): use rectangular shape for all hover shapes, show select outline when hover is in effect and selected PD-4492, PD-4367

### DIFF
--- a/packages/hotspot/docs/demo/generate.js
+++ b/packages/hotspot/docs/demo/generate.js
@@ -13,6 +13,7 @@ exports.model = (id, element) => ({
     'rgba(254, 241, 96, 0.25)',
     'rgba(0, 0, 0, 0.1)',
   ],
+  'hoverOutlineColor': 'rgba(51, 51, 51, 0.5)',
   outlineColor: 'blue',
   outlineList: ['blue', 'red', 'yellow'],
   multipleCorrect: true,

--- a/packages/hotspot/docs/demo/generate.js
+++ b/packages/hotspot/docs/demo/generate.js
@@ -13,7 +13,6 @@ exports.model = (id, element) => ({
     'rgba(254, 241, 96, 0.25)',
     'rgba(0, 0, 0, 0.1)',
   ],
-  'hoverOutlineColor': 'rgba(51, 51, 51, 0.5)',
   outlineColor: 'blue',
   outlineList: ['blue', 'red', 'yellow'],
   multipleCorrect: true,

--- a/packages/hotspot/src/hotspot/circle.jsx
+++ b/packages/hotspot/src/hotspot/circle.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Circle, Group } from 'react-konva';
+import { Circle, Group, Rect } from 'react-konva';
 import { withStyles } from '@material-ui/core/styles';
 import { ImageComponent } from '@pie-lib/pie-toolbox/icons';
 import { faCorrect, faWrong } from './icons';
@@ -95,13 +95,13 @@ class CircleComponent extends React.Component {
     return (
       <Group scaleX={scale} scaleY={scale}>
         {useHoveredStyle && (
-          <Circle
-            radius={radius}
-            x={x}
-            y={y}
-            stroke={selected ? outlineColor : hoverOutlineColor}
-            strokeWidth={selected ? outlineWidth : 2}
-            listening={false}
+          <Rect
+            x={x - radius}
+            y={y - radius}
+            width={radius * 2}
+            height={radius * 2}
+            stroke={selected ? 'transparent' : hoverOutlineColor}
+            strokeWidth={strokeWidth}
           />
         )}
         <Circle
@@ -111,8 +111,8 @@ class CircleComponent extends React.Component {
           onClick={this.handleClick}
           onTap={this.handleClick}
           draggable={false}
-          stroke={useHoveredStyle ? 'transparent' : outlineColorParsed}
-          strokeWidth={useHoveredStyle ? 0 : outlineWidth}
+          stroke={useHoveredStyle && !selected ? 'transparent' : outlineColorParsed}
+          strokeWidth={useHoveredStyle && !selected ? 0 : outlineWidth}
           onMouseLeave={this.handleMouseLeave}
           onMouseEnter={this.handleMouseEnter}
           x={x}

--- a/packages/hotspot/src/hotspot/circle.jsx
+++ b/packages/hotspot/src/hotspot/circle.jsx
@@ -90,10 +90,19 @@ class CircleComponent extends React.Component {
       }
     }
 
+    const useHoveredStyle = hovered && hoverOutlineColor;
+
     return (
       <Group scaleX={scale} scaleY={scale}>
-        {hoverOutlineColor && hovered && (
-          <Circle radius={radius} x={x} y={y} stroke={hoverOutlineColor} strokeWidth={2} listening={false} />
+        {useHoveredStyle && (
+          <Circle
+            radius={radius}
+            x={x}
+            y={y}
+            stroke={selected ? outlineColor : hoverOutlineColor}
+            strokeWidth={selected ? outlineWidth : 2}
+            listening={false}
+          />
         )}
         <Circle
           classes={classes.base}
@@ -102,8 +111,8 @@ class CircleComponent extends React.Component {
           onClick={this.handleClick}
           onTap={this.handleClick}
           draggable={false}
-          stroke={hovered && hoverOutlineColor ? 'transparent' : outlineColorParsed}
-          strokeWidth={!(hovered && hoverOutlineColor) ? outlineWidth : 0}
+          stroke={useHoveredStyle ? 'transparent' : outlineColorParsed}
+          strokeWidth={useHoveredStyle ? 0 : outlineWidth}
           onMouseLeave={this.handleMouseLeave}
           onMouseEnter={this.handleMouseEnter}
           x={x}

--- a/packages/hotspot/src/hotspot/polygon.jsx
+++ b/packages/hotspot/src/hotspot/polygon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Line, Group } from 'react-konva';
+import { Line, Group, Rect } from 'react-konva';
 import { withStyles } from '@material-ui/core/styles';
 import { ImageComponent } from '@pie-lib/pie-toolbox/icons';
 import { faCorrect, faWrong } from './icons';
@@ -122,17 +122,31 @@ class PolygonComponent extends React.Component {
         iconSrc = faWrong;
       }
     }
+    const useHoveredStyle = hovered && hoverOutlineColor;
+
+    const xValues = pointsParsed.filter((_, index) => index % 2 === 0); // Even indices are x-coordinates
+    const yValues = pointsParsed.filter((_, index) => index % 2 !== 0); // Odd indices are y-coordinates
+
+    const minX = Math.min(...xValues);
+    const maxX = Math.max(...xValues);
+    const minY = Math.min(...yValues);
+    const maxY = Math.max(...yValues);
+
+    const rectX = minX;
+    const rectY = minY;
+    const rectWidth = maxX - minX;
+    const rectHeight = maxY - minY;
 
     return (
       <Group scaleX={scale} scaleY={scale}>
-        {hoverOutlineColor && hovered && (
-          <Line
-            closed={true}
-            draggable={false}
-            points={pointsParsed}
-            stroke={hoverOutlineColor}
-            strokeWidth={2}
-            listening={false}
+        {useHoveredStyle && (
+          <Rect
+            x={rectX}
+            y={rectY}
+            width={rectWidth}
+            height={rectHeight}
+            stroke={selected ? 'transparent' : hoverOutlineColor}
+            strokeWidth={strokeWidth}
           />
         )}
         <Line
@@ -143,8 +157,8 @@ class PolygonComponent extends React.Component {
           onClick={this.handleClick}
           onTap={this.handleClick}
           draggable={false}
-          stroke={hovered && hoverOutlineColor ? 'transparent' : outlineColorParsed}
-          strokeWidth={!(hovered && hoverOutlineColor) ? outlineWidth : 0}
+          stroke={useHoveredStyle && !selected ? 'transparent' : outlineColorParsed}
+          strokeWidth={useHoveredStyle && !selected ? 0 : outlineWidth}
           onMouseLeave={this.handleMouseLeave}
           onMouseEnter={this.handleMouseEnter}
         />

--- a/packages/hotspot/src/hotspot/rectangle.jsx
+++ b/packages/hotspot/src/hotspot/rectangle.jsx
@@ -105,17 +105,18 @@ class RectComponent extends React.Component {
     }
 
     const { hovered } = this.state;
+    const useHoveredStyle = hovered && hoverOutlineColor;
 
     return (
       <Group scaleX={scale} scaleY={scale}>
-        {hoverOutlineColor && hovered && (
+        {useHoveredStyle && (
           <Rect
             x={x}
             y={y}
             width={width}
             height={height}
-            stroke={hoverOutlineColor}
-            strokeWidth={2}
+            stroke={selected ? 'transparent' : hoverOutlineColor}
+            strokeWidth={strokeWidth}
             listening={false}
           />
         )}
@@ -127,8 +128,8 @@ class RectComponent extends React.Component {
           onClick={this.handleClick}
           onTap={this.handleClick}
           draggable={false}
-          stroke={hovered && hoverOutlineColor ? 'transparent' : outlineColorParsed}
-          strokeWidth={!(hovered && hoverOutlineColor) ? outlineWidth : 0}
+          stroke={useHoveredStyle && !selected ? 'transparent' : outlineColorParsed}
+          strokeWidth={useHoveredStyle && !selected ? 0 : outlineWidth}
           onMouseLeave={this.handleMouseLeave}
           onMouseEnter={this.handleMouseEnter}
           x={x}


### PR DESCRIPTION
rectangular shape for hover: https://illuminate.atlassian.net/browse/PD-4367
select bug on hover: https://illuminate.atlassian.net/browse/PD-4492

https://github.com/user-attachments/assets/d0c44c8f-a2ab-46d2-876f-b1f43955fe51

