### PR TITLE
feat(image-cloze-association): style choice pool based on possibility…

### DIFF
--- a/packages/image-cloze-association/src/possible-responses.jsx
+++ b/packages/image-cloze-association/src/possible-responses.jsx
@@ -15,23 +15,31 @@ const PossibleResponses = ({
   onDragEnd,
   answerChoiceTransparency,
   customStyle,
-}) => (
-  <div className={classes.base} style={customStyle}>
-    <ICADroppablePlaceholder classes={classes.pool} disabled={!canDrag} onRemoveAnswer={onAnswerRemove}>
-      {(data || []).map((item) => (
-        <PossibleResponse
-          canDrag={canDrag}
-          key={item.id}
-          data={item}
-          onDragBegin={onDragBegin}
-          onDragEnd={onDragEnd}
-          answerChoiceTransparency={answerChoiceTransparency}
-          containerStyle={{ margin: '4px' }}
-        />
-      ))}
-    </ICADroppablePlaceholder>
-  </div>
-);
+  isVertical,
+  minHeight
+}) =>
+  (
+    <div className={classes.base} style={customStyle}>
+      <ICADroppablePlaceholder
+        classes={classes.pool}
+        disabled={!canDrag}
+        onRemoveAnswer={onAnswerRemove}
+        isVerticalPool={isVertical}
+        minHeight={minHeight}>
+        {(data || []).map((item) => (
+          <PossibleResponse
+            canDrag={canDrag}
+            key={item.id}
+            data={item}
+            onDragBegin={onDragBegin}
+            onDragEnd={onDragEnd}
+            answerChoiceTransparency={answerChoiceTransparency}
+            containerStyle={{ margin: '4px' }}
+          />
+        ))}
+      </ICADroppablePlaceholder>
+    </div>
+  );
 
 PossibleResponses.propTypes = {
   canDrag: PropTypes.bool.isRequired,
@@ -42,6 +50,8 @@ PossibleResponses.propTypes = {
   onDragEnd: PropTypes.func.isRequired,
   answerChoiceTransparency: PropTypes.bool,
   customStyle: PropTypes.object,
+  isVertical: PropTypes.bool,
+  minHeight: PropTypes.number
 };
 
 PossibleResponses.defaultProps = {

--- a/packages/image-cloze-association/src/root.jsx
+++ b/packages/image-cloze-association/src/root.jsx
@@ -239,6 +239,8 @@ class ImageClozeAssociationComponent extends React.Component {
     } = this.state;
     const isEvaluateMode = mode === 'evaluate';
     const showToggle = isEvaluateMode && !responseCorrect;
+    const { possibilityListPosition = 'bottom' } = uiStyle || {};
+    const isVertical = possibilityListPosition === 'left' || possibilityListPosition === 'right';
 
     const { validResponse } = validation || {};
     const correctAnswers = [];
@@ -339,7 +341,11 @@ class ImageClozeAssociationComponent extends React.Component {
               onDragBegin={this.beginDrag}
               onDragEnd={this.handleOnDragEnd}
               answerChoiceTransparency={answerChoiceTransparency}
-              customStyle={{ minWidth: image?.width || 'fit-content' }}
+              customStyle={{
+                minWidth: isVertical ? '130px' : image?.width || 'fit-content',
+              }}
+              isVertical={isVertical}
+              minHeight={isVertical ? image?.height : undefined}
             />
           </InteractiveSection>
         )}


### PR DESCRIPTION
…ListPosition left or right PD-4387
From pie-elements we mostly send the correct props to pie-lib for styling. PR [here](https://github.com/pie-framework/pie-lib/pull/1570)

https://illuminate.atlassian.net/browse/PD-4387

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/133f7363-7df7-4432-874c-dbe316483f5f">
