### PR TITLE
fix(image-cloze-association): preserve response ids when moved back to possibleResponses, Added fallback to generate new ids only when shifted responses lack an id PD-4538

### DIFF
--- a/packages/image-cloze-association/src/__tests__/__snapshots__/root.test.jsx.snap
+++ b/packages/image-cloze-association/src/__tests__/__snapshots__/root.test.jsx.snap
@@ -1,63 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Root snapshots model renders 1`] = `
-<Memo(DndProvider)
-  backend={[Function]}
-  context={[Window]}
-  options={
-    Object {
-      "backends": Array [
-        Object {
-          "backend": [Function],
-        },
-        Object {
-          "backend": [Function],
-          "options": Object {
-            "enableMouseEvents": true,
-            "enableTouchEvents": true,
-          },
-          "preview": true,
-          "skipDispatchOnTransition": true,
-          "transition": Object {
-            "_isMBTransition": true,
-            "check": [Function],
-            "event": "touchstart",
-          },
-        },
-      ],
-    }
-  }
->
-  <WithStyles(ImageClozeAssociationComponent)
-    model={
-      Object {
-        "answers": Array [
-          Object {
-            "containerIndex": 0,
-            "id": 1,
-            "value": "1",
-          },
-          Object {
-            "containerIndex": 1,
-            "id": 2,
-            "value": "2",
-          },
-        ],
-        "canDrag": true,
-        "draggingElement": Object {},
-        "duplicateResponses": false,
-        "image": Object {},
-        "maxResponsePerZone": 5,
-        "onAnswerSelect": [Function],
-        "onDragAnswerBegin": [Function],
-        "onDragAnswerEnd": [Function],
-        "possibleResponses": Array [],
-        "responseContainers": Array [],
-        "showDashedBorder": true,
-      }
-    }
-    updateAnswer={[Function]}
+exports[`Root snapshots renders correctly 1`] = `
+<WithStyles(UiLayout)>
+  <WithStyles(PreviewPrompt)
+    className="prompt"
   />
-  <PreviewComponent />
-</Memo(DndProvider)>
+  <WithStyles(PreviewPrompt) />
+  <WithStyles(CorrectAnswerToggle)
+    onToggle={[Function]}
+    show={false}
+    toggled={false}
+  />
+  <WithStyles(InteractiveSection)
+    uiStyle={Object {}}
+  >
+    <WithStyles(ImageContainer)
+      answers={Array []}
+      canDrag={true}
+      draggingElement={
+        Object {
+          "id": "",
+          "value": "",
+        }
+      }
+      duplicateResponses={false}
+      maxResponsePerZone={1}
+      onAnswerSelect={[Function]}
+      onDragAnswerBegin={[Function]}
+      onDragAnswerEnd={[Function]}
+      responseContainers={
+        Array [
+          Object {
+            "id": "0",
+            "index": 0,
+          },
+          Object {
+            "id": "1",
+            "index": 1,
+          },
+        ]
+      }
+    />
+    <WithStyles(PossibleResponses)
+      canDrag={true}
+      customStyle={
+        Object {
+          "minWidth": "fit-content",
+        }
+      }
+      data={
+        Array [
+          Object {
+            "id": "0",
+            "value": "firstImage",
+          },
+          Object {
+            "id": "1",
+            "value": "secondImage",
+          },
+        ]
+      }
+      isVertical={false}
+      onAnswerRemove={[Function]}
+      onDragBegin={[Function]}
+      onDragEnd={[Function]}
+    />
+  </WithStyles(InteractiveSection)>
+</WithStyles(UiLayout)>
 `;

--- a/packages/image-cloze-association/src/root.jsx
+++ b/packages/image-cloze-association/src/root.jsx
@@ -33,7 +33,7 @@ const styles = (theme) => ({
   },
 });
 
-class ImageClozeAssociationComponent extends React.Component {
+export class ImageClozeAssociationComponent extends React.Component {
   constructor(props) {
     super(props);
     const {
@@ -241,6 +241,8 @@ class ImageClozeAssociationComponent extends React.Component {
     const showToggle = isEvaluateMode && !responseCorrect;
     const { possibilityListPosition = 'bottom' } = uiStyle || {};
     const isVertical = possibilityListPosition === 'left' || possibilityListPosition === 'right';
+
+    console.log(possibleResponses, "possibleResponses")
 
     const { validResponse } = validation || {};
     const correctAnswers = [];

--- a/packages/image-cloze-association/src/root.jsx
+++ b/packages/image-cloze-association/src/root.jsx
@@ -128,8 +128,8 @@ class ImageClozeAssociationComponent extends React.Component {
 
         possibleResponses.push({
           ...shiftedItem,
-          containerIndex: '',
-          id: `${_.max(possibleResponses.map((c) => parseInt(c.id)).filter((id) => !isNaN(id))) + 1}`,
+          containerIndex: undefined,
+          id: shiftedItem.id || generateId(),
         });
       }
 

--- a/packages/image-cloze-association/src/root.jsx
+++ b/packages/image-cloze-association/src/root.jsx
@@ -242,8 +242,6 @@ export class ImageClozeAssociationComponent extends React.Component {
     const { possibilityListPosition = 'bottom' } = uiStyle || {};
     const isVertical = possibilityListPosition === 'left' || possibilityListPosition === 'right';
 
-    console.log(possibleResponses, "possibleResponses")
-
     const { validResponse } = validation || {};
     const correctAnswers = [];
 


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4538