### PR TITLE
feat(multiple-choice): use isSelectionButtonBelow for choice prefix and button position PD-3842

### DIFF
--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -90,7 +90,7 @@ export async function model(question, session, env, updateSession) {
     language: normalizedQuestion.language,
     extraCSSRules: normalizedQuestion.extraCSSRules,
     fontSizeFactor: normalizedQuestion.fontSizeFactor,
-    selectionButtonPosition: normalizedQuestion.selectionButtonPosition,
+    isSelectionButtonBelow: normalizedQuestion.isSelectionButtonBelow,
   };
 
   const { role, mode } = env || {};

--- a/packages/multiple-choice/controller/src/index.js
+++ b/packages/multiple-choice/controller/src/index.js
@@ -90,6 +90,7 @@ export async function model(question, session, env, updateSession) {
     language: normalizedQuestion.language,
     extraCSSRules: normalizedQuestion.extraCSSRules,
     fontSizeFactor: normalizedQuestion.fontSizeFactor,
+    selectionButtonPosition: normalizedQuestion.selectionButtonPosition,
   };
 
   const { role, mode } = env || {};

--- a/packages/multiple-choice/docs/demo/generate.js
+++ b/packages/multiple-choice/docs/demo/generate.js
@@ -27,7 +27,7 @@ exports.model = (id, element) => ({
     },
     {
       value: 'norway',
-      label: 'Norway testing layout',
+      label: 'Norway',
       feedback: {
         type: 'none',
         value: '',
@@ -38,7 +38,7 @@ exports.model = (id, element) => ({
     {
       correct: true,
       value: 'finland',
-      label: 'Longer answer choice for testing',
+      label: 'Finland',
       feedback: {
         type: 'none',
         value: '',

--- a/packages/multiple-choice/docs/demo/generate.js
+++ b/packages/multiple-choice/docs/demo/generate.js
@@ -3,6 +3,7 @@ exports.model = (id, element) => ({
   element,
   choiceMode: 'checkbox',
   choicePrefix: 'numbers',
+  selectionButtonPosition: 'below',
   choices: [
     {
       correct: true,
@@ -26,7 +27,7 @@ exports.model = (id, element) => ({
     },
     {
       value: 'norway',
-      label: 'Norway',
+      label: 'Norway testing layout',
       feedback: {
         type: 'none',
         value: '',
@@ -37,7 +38,7 @@ exports.model = (id, element) => ({
     {
       correct: true,
       value: 'finland',
-      label: 'Finland',
+      label: 'Longer answer choice for testing',
       feedback: {
         type: 'none',
         value: '',

--- a/packages/multiple-choice/docs/demo/generate.js
+++ b/packages/multiple-choice/docs/demo/generate.js
@@ -3,7 +3,6 @@ exports.model = (id, element) => ({
   element,
   choiceMode: 'checkbox',
   choicePrefix: 'numbers',
-  selectionButtonPosition: 'below',
   choices: [
     {
       correct: true,

--- a/packages/multiple-choice/docs/pie-schema.json
+++ b/packages/multiple-choice/docs/pie-schema.json
@@ -193,6 +193,11 @@
       "type": "string",
       "title": "language"
     },
+    "isSelectionButtonBelow": {
+      "description": "Indicates if the selection button and choice prefix should be positioned below the corresponding answer choice",
+      "type": "boolean",
+      "title": "isSelectionButtonBelow"
+    },
     "id": {
       "description": "Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.",
       "type": "string",

--- a/packages/multiple-choice/docs/pie-schema.json.md
+++ b/packages/multiple-choice/docs/pie-schema.json.md
@@ -169,6 +169,10 @@ Indicates if Rubric is enabled
 Indicates the language of the component
 Supported options: en, es, en_US, en-US, es_ES, es-ES, es_MX, es-MX
 
+# `isSelectionButtonBelow` (boolean)
+
+Indicates if the selection button and choice prefix should be positioned below the corresponding answer choice
+
 # `id` (string, required)
 
 Identifier to identify the Pie Element in html markup, Must be unique within a pie item config.

--- a/packages/multiple-choice/src/choice-input.jsx
+++ b/packages/multiple-choice/src/choice-input.jsx
@@ -2,12 +2,12 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-
 import Checkbox from '@material-ui/core/Checkbox';
 import { Feedback, color, PreviewPrompt } from '@pie-lib/pie-toolbox/render-ui';
-import FeedbackTick from './feedback-tick';
 import Radio from '@material-ui/core/Radio';
 import classNames from 'classnames';
+
+import FeedbackTick from './feedback-tick';
 
 const CLASS_NAME = 'multiple-choice-component';
 

--- a/packages/multiple-choice/src/choice-input.jsx
+++ b/packages/multiple-choice/src/choice-input.jsx
@@ -39,6 +39,12 @@ const styleSheet = (theme) => ({
       alignItems: 'flex-start'
     }
   },
+  belowLayoutCenter: {
+    justifyContent: 'center',
+    '& > label': {
+      alignItems: 'center'
+    }
+  },
   belowSelectionComponent: {
     display: 'flex',
     alignItems: 'center',
@@ -172,7 +178,7 @@ export class ChoiceInput extends React.Component {
     isEvaluateMode: PropTypes.bool,
     choicesLayout: PropTypes.oneOf(['vertical', 'grid', 'horizontal']),
     updateSession: PropTypes.func,
-    selectionButtonPosition: PropTypes.oneOf(['left', 'below'])
+    isSelectionButtonBelow: PropTypes.bool
   };
 
   static defaultProps = {
@@ -217,7 +223,7 @@ export class ChoiceInput extends React.Component {
       choicesLayout,
       value,
       checked,
-      selectionButtonPosition
+      isSelectionButtonBelow
     } = this.props;
 
     const Tag = choiceMode === 'checkbox' ? StyledCheckbox : StyledRadio;
@@ -225,12 +231,14 @@ export class ChoiceInput extends React.Component {
 
     const holderClassNames = classNames(classes.checkboxHolder, {
       [classes.horizontalLayout]: choicesLayout === 'horizontal',
-      [classes.belowLayout]: selectionButtonPosition === 'below',
+      [classes.belowLayout]: isSelectionButtonBelow && choicesLayout !== 'grid',
+      [classes.belowLayoutCenter]: isSelectionButtonBelow && choicesLayout === 'grid',
+
     });
 
     const choicelabel = (
       <>
-        {displayKey && selectionButtonPosition !== 'below'? (
+        {displayKey && !isSelectionButtonBelow ? (
           <span className={classes.row}>
             {displayKey}.{'\u00A0'}
             <PreviewPrompt className="label" prompt={label} tagName="span" />
@@ -246,7 +254,7 @@ export class ChoiceInput extends React.Component {
         <div className={classes.row}>
           {!hideTick && isEvaluateMode && <FeedbackTick correctness={correctness}/>}
           <div className={classNames(holderClassNames, 'checkbox-holder')}>
-            {selectionButtonPosition === 'below' ? (
+            {isSelectionButtonBelow ? (
               <StyledFormControlLabel
                 label={choicelabel}
                 value={value}

--- a/packages/multiple-choice/src/choice-input.jsx
+++ b/packages/multiple-choice/src/choice-input.jsx
@@ -34,6 +34,18 @@ const styleSheet = (theme) => ({
       paddingRight: theme.spacing.unit,
     },
   },
+  belowLayout: {
+    '& > label': {
+      alignItems: 'flex-start'
+    }
+  },
+  belowSelectionComponent: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > span': {
+      paddingLeft: 0
+    }
+  }
 });
 
 const formStyleSheet = {
@@ -160,6 +172,7 @@ export class ChoiceInput extends React.Component {
     isEvaluateMode: PropTypes.bool,
     choicesLayout: PropTypes.oneOf(['vertical', 'grid', 'horizontal']),
     updateSession: PropTypes.func,
+    selectionButtonPosition: PropTypes.oneOf(['left', 'below'])
   };
 
   static defaultProps = {
@@ -204,6 +217,7 @@ export class ChoiceInput extends React.Component {
       choicesLayout,
       value,
       checked,
+      selectionButtonPosition
     } = this.props;
 
     const Tag = choiceMode === 'checkbox' ? StyledCheckbox : StyledRadio;
@@ -211,11 +225,12 @@ export class ChoiceInput extends React.Component {
 
     const holderClassNames = classNames(classes.checkboxHolder, {
       [classes.horizontalLayout]: choicesLayout === 'horizontal',
+      [classes.belowLayout]: selectionButtonPosition === 'below',
     });
 
     const choicelabel = (
       <>
-        {displayKey ? (
+        {displayKey && selectionButtonPosition !== 'below'? (
           <span className={classes.row}>
             {displayKey}.{'\u00A0'}
             <PreviewPrompt className="label" prompt={label} tagName="span" />
@@ -229,28 +244,50 @@ export class ChoiceInput extends React.Component {
     return (
       <div className={classNames(className, 'corespring-' + classSuffix, 'choice-input')}>
         <div className={classes.row}>
-          {!hideTick && isEvaluateMode && <FeedbackTick correctness={correctness} />}
+          {!hideTick && isEvaluateMode && <FeedbackTick correctness={correctness}/>}
           <div className={classNames(holderClassNames, 'checkbox-holder')}>
-            <StyledFormControlLabel
-              label={choicelabel}
-              value={value}
-              htmlFor={this.choiceId}
-              control={
-                <Tag
-                  accessibility={accessibility}
-                  disabled={disabled}
-                  checked={checked}
-                  correctness={correctness}
-                  value={value}
-                  id={this.choiceId}
-                  onChange={this.onToggleChoice}
-                />
-              }
-            />
+            {selectionButtonPosition === 'below' ? (
+              <StyledFormControlLabel
+                label={choicelabel}
+                value={value}
+                htmlFor={this.choiceId}
+                labelPlacement={'top'}
+                control={
+                  <span className={classes.belowSelectionComponent}>
+                    <Tag
+                      accessibility={accessibility}
+                      disabled={disabled}
+                      checked={checked}
+                      correctness={correctness}
+                      value={value}
+                      id={this.choiceId}
+                      onChange={this.onToggleChoice}
+                      style={{ padding: 0 }}
+                    />
+                    {displayKey}.
+                  </span>
+                }
+              />
+            ) : (
+              <StyledFormControlLabel
+                label={choicelabel}
+                value={value}
+                htmlFor={this.choiceId}
+                control={
+                  <Tag
+                    accessibility={accessibility}
+                    disabled={disabled}
+                    checked={checked}
+                    correctness={correctness}
+                    value={value}
+                    id={this.choiceId}
+                    onChange={this.onToggleChoice}
+                  />}
+              />)}
           </div>
         </div>
-        {rationale && <PreviewPrompt className="rationale" defaultClassName="rationale" prompt={rationale} />}
-        <Feedback feedback={feedback} correctness={correctness} />
+        {rationale && <PreviewPrompt className="rationale" defaultClassName="rationale" prompt={rationale}/>}
+        <Feedback feedback={feedback} correctness={correctness}/>
       </div>
     );
   }

--- a/packages/multiple-choice/src/choice.jsx
+++ b/packages/multiple-choice/src/choice.jsx
@@ -33,6 +33,7 @@ export class Choice extends React.Component {
       choicesLayout,
       gridColumns,
       updateSession,
+      selectionButtonPosition
     } = this.props;
     const choiceClass = 'choice' + (index === choicesLength - 1 ? ' last' : '');
 
@@ -52,6 +53,7 @@ export class Choice extends React.Component {
       updateSession,
       onChange: this.onChange,
       isEvaluateMode,
+      selectionButtonPosition
     };
 
     const names = classNames(classes.choice, {
@@ -82,6 +84,7 @@ Choice.propTypes = {
   displayKey: PropTypes.string,
   choicesLayout: PropTypes.oneOf(['vertical', 'grid', 'horizontal']),
   gridColumns: PropTypes.string,
+  selectionButtonPosition: PropTypes.oneOf(['left', 'below']),
 };
 
 export default withStyles((theme) => ({

--- a/packages/multiple-choice/src/choice.jsx
+++ b/packages/multiple-choice/src/choice.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
+
 import ChoiceInput from './choice-input';
 
 export class Choice extends React.Component {
@@ -33,7 +34,7 @@ export class Choice extends React.Component {
       choicesLayout,
       gridColumns,
       updateSession,
-      selectionButtonPosition
+      isSelectionButtonBelow
     } = this.props;
     const choiceClass = 'choice' + (index === choicesLength - 1 ? ' last' : '');
 
@@ -53,7 +54,7 @@ export class Choice extends React.Component {
       updateSession,
       onChange: this.onChange,
       isEvaluateMode,
-      selectionButtonPosition
+      isSelectionButtonBelow
     };
 
     const names = classNames(classes.choice, {
@@ -84,7 +85,7 @@ Choice.propTypes = {
   displayKey: PropTypes.string,
   choicesLayout: PropTypes.oneOf(['vertical', 'grid', 'horizontal']),
   gridColumns: PropTypes.string,
-  selectionButtonPosition: PropTypes.oneOf(['left', 'below']),
+  isSelectionButtonBelow: PropTypes.bool
 };
 
 export default withStyles((theme) => ({

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -4,6 +4,7 @@ import { CorrectAnswerToggle } from '@pie-lib/pie-toolbox/correct-answer-toggle'
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import { color, Collapsible, PreviewPrompt } from '@pie-lib/pie-toolbox/render-ui';
+
 import StyledChoice from './choice';
 
 // MultipleChoice

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -72,7 +72,7 @@ export class MultipleChoice extends React.Component {
         animationsDisabled: PropTypes.bool,
         language: PropTypes.string,
         onShowCorrectToggle: PropTypes.func,
-        selectionButtonPosition: PropTypes.oneOf(['left', 'below']),
+        isSelectionButtonBelow: PropTypes.bool,
     };
 
     constructor(props) {
@@ -229,7 +229,7 @@ export class MultipleChoice extends React.Component {
             alwaysShowCorrect,
             animationsDisabled,
             language,
-            selectionButtonPosition
+            isSelectionButtonBelow
         } = this.props;
         const {showCorrect} = this.state;
         const isEvaluateMode = mode === 'evaluate';
@@ -305,7 +305,7 @@ export class MultipleChoice extends React.Component {
                                 checked={this.getChecked(choice)}
                                 correctness={isEvaluateMode ? this.getCorrectness(choice) : undefined}
                                 displayKey={this.indexToSymbol(index)}
-                                selectionButtonPosition={selectionButtonPosition}
+                                isSelectionButtonBelow={isSelectionButtonBelow}
                             />
                         ))}
                     </div>

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -72,6 +72,7 @@ export class MultipleChoice extends React.Component {
         animationsDisabled: PropTypes.bool,
         language: PropTypes.string,
         onShowCorrectToggle: PropTypes.func,
+        selectionButtonPosition: PropTypes.oneOf(['left', 'below']),
     };
 
     constructor(props) {
@@ -227,7 +228,8 @@ export class MultipleChoice extends React.Component {
             classes,
             alwaysShowCorrect,
             animationsDisabled,
-            language
+            language,
+            selectionButtonPosition
         } = this.props;
         const {showCorrect} = this.state;
         const isEvaluateMode = mode === 'evaluate';
@@ -303,6 +305,7 @@ export class MultipleChoice extends React.Component {
                                 checked={this.getChecked(choice)}
                                 correctness={isEvaluateMode ? this.getCorrectness(choice) : undefined}
                                 displayKey={this.indexToSymbol(index)}
+                                selectionButtonPosition={selectionButtonPosition}
                             />
                         ))}
                     </div>

--- a/packages/pie-models/src/pie/multiple-choice/index.ts
+++ b/packages/pie-models/src/pie/multiple-choice/index.ts
@@ -100,6 +100,9 @@ export interface MultipleChoicePie extends PieModel {
    * Supported options: en, es, en_US, en-US, es_ES, es-ES, es_MX, es-MX
    */
   language?: string;
+
+  /** Indicates if the selection button and choice prefix should be positioned below the corresponding answer choice */
+  isSelectionButtonBelow?: boolean;
 }
 
 interface ConfigureMaxImageDimensionsProp {


### PR DESCRIPTION
If this new added property is true, the selection button and choice prefix will be positioned below the corresponding answer choice.
https://illuminate.atlassian.net/browse/PD-3842

for vertical layout
![image](https://github.com/user-attachments/assets/b6fa6ed8-0e3a-44ae-8fbb-632581655ccd)

for grid layout
![image](https://github.com/user-attachments/assets/ca5dd3d0-34a5-4b62-a7e5-0aa6020155b8)

for horizontal layout
![image](https://github.com/user-attachments/assets/17b2e05f-7d3b-4011-b543-974410c60434)
