### PR TITLE
fix(ica): Fix Chrome behavior on iPads for image cloze association PD-4553

### DIFF
--- a/packages/image-cloze-association/src/possible-response.jsx
+++ b/packages/image-cloze-association/src/possible-response.jsx
@@ -76,6 +76,12 @@ const styles = () => ({
     justifyContent: 'center',
     minHeight: '28px',
     width: 'fit-content',
+    '& span img':{
+      // Added for touch devices, for image content.
+      // This will prevent the context menu from appearing and not allowing other interactions with the image.
+      // If interactions with the image in the token will be requested we should handle only the context Menu.
+      pointerEvents: 'none',
+    }
   },
   answerChoiceTransparency: {
     border: 'none',
@@ -93,10 +99,6 @@ const styles = () => ({
   },
   span: {
     backgroundColor: color.background(),
-    // Added for touch devices, for image content.
-    // This will prevent the context menu from appearing and not allowing other interactions with the image.
-    // If interactions with the image in the token will be requested we should handle only the context Menu.
-    pointerEvents: 'none',
   },
   hiddenSpan: {
     visibility: 'hidden',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4553
Issue:
On touch devices, specifically iPads using Chrome, dragging an image within a draggable container triggered unwanted behaviors:
Context Menu: Long-pressing on the image would bring up the browser’s context menu or the image itself being opened in a new tab.

Solution: 
I've applied the following CSS rule:
'& span img': {
  pointerEvents: 'none',
}

Explanation:
Ensures the image doesn't receive pointer events, avoiding context menus and unintended opening in a new tab.
 Keeps the wrapping div fully draggable as intended.
Resolves touch-specific issues without additional event handling logic.



