### PR TITLE
fix(ditb): Prevent sentence break in authoring view with images PD-4394

### DIFF
--- a/packages/drag-in-the-blank/configure/src/choice.jsx
+++ b/packages/drag-in-the-blank/configure/src/choice.jsx
@@ -31,6 +31,9 @@ export const BlankContent = withStyles((theme) => ({
     position: 'relative',
     padding: '8px 35px 8px 35px',
     cursor: 'grab',
+    '& img': {
+        display: 'flex'
+    }
   },
   deleteIcon: {
     position: 'absolute',


### PR DESCRIPTION
Findings: https://illuminate.atlassian.net/browse/PD-4394
Fix: Prevent sentence break in authoring view when an image is uploaded at the end of a sentence. 
