### PR TITLE
fix(placement-ordering): conditionally add autoWidthToolbar to accommodate toolbar buttons when placementArea is true

### DIFF
--- a/packages/placement-ordering/configure/src/design.jsx
+++ b/packages/placement-ordering/configure/src/design.jsx
@@ -268,6 +268,7 @@ export class Design extends React.Component {
                 className={classes.promptHolder}
               >
                 <EditableHtml
+                  {...(model.placementArea && { autoWidthToolbar: true })}
                   className={classes.prompt}
                   markup={model.choiceLabel}
                   onChange={this.onChoiceAreaLabelChange}
@@ -289,6 +290,7 @@ export class Design extends React.Component {
                 className={classes.promptHolder}
               >
                 <EditableHtml
+                  autoWidthToolbar
                   className={classes.prompt}
                   markup={model.targetLabel}
                   onChange={this.onAnswerAreaLabelChange}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4591

<img width="855" alt="Screenshot 2024-12-16 at 18 25 29" src="https://github.com/user-attachments/assets/6d271b8c-f196-4cf3-b11e-c66677b6c9c2" />

<img width="866" alt="Screenshot 2024-12-16 at 18 25 39" src="https://github.com/user-attachments/assets/8b9bcd45-b05a-42ed-aea8-f9945ad716b6" />

<img width="931" alt="Screenshot 2024-12-16 at 18 25 44" src="https://github.com/user-attachments/assets/0d4bab46-7894-445a-af7e-8ab52c30d8dc" />
