### PR TITLE
fix(placement-ordering): Align grid items vertically centered for consistent layout PD-4592

### DIFF
--- a/packages/placement-ordering/configure/src/choice-editor.jsx
+++ b/packages/placement-ordering/configure/src/choice-editor.jsx
@@ -349,6 +349,7 @@ const styles = (theme) => ({
     gridAutoFlow: 'column',
     display: 'grid',
     gridGap: '10px',
+    alignItems: 'center'
   },
   columnLabel: {
     width: '100%',


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4592

<img width="915" alt="Screenshot 2024-12-16 at 16 56 56" src="https://github.com/user-attachments/assets/38423a75-91ac-4385-a1f0-e0266657ec4a" />
