### PR TITLE
fix(explicit-constructed-response): update regex to find response are…

### DIFF
--- a/packages/explicit-constructed-response/controller/src/index.js
+++ b/packages/explicit-constructed-response/controller/src/index.js
@@ -184,7 +184,7 @@ export const getScore = (config, session) => {
     return 0;
   }
 
-  const responseAreas = config.markup && config.markup.match(/\{\{(.)\}\}/g);
+  const responseAreas = config.markup && config.markup.match(/\{\{(.+?)\}\}/g);
   const maxScore = responseAreas ? responseAreas.length : 0;
   const correctCount = reduce(
     config.choices,


### PR DESCRIPTION
…as mapped with 2 digits score PD-4535