### PR TITLE
fix(math-inline): fix session save being called on render PD-4604

### DIFF
--- a/packages/math-inline/src/__tests__/simple-question-block.test.js
+++ b/packages/math-inline/src/__tests__/simple-question-block.test.js
@@ -106,4 +106,9 @@ describe('SimpleQuestionBlock', () => {
 
     expect(component.instance().props.showKeypad).toEqual(false);
   });
+
+  it('does not call session change on render', () => {
+    component = wrapper();
+    expect(defaultProps.onSimpleResponseChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/math-inline/src/simple-question-block.jsx
+++ b/packages/math-inline/src/simple-question-block.jsx
@@ -70,7 +70,7 @@ export class SimpleQuestionBlockRaw extends React.Component {
           <div id={this.mathToolBarId}>
             <MathToolbar
               classNames={{ editor: classes.responseEditor }}
-              latex={session.response || ''}
+              latex={session.response}
               keypadMode={equationEditor}
               onChange={onSimpleResponseChange}
               onDone={() => {}}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4604

The sanity check was actually triggering the updateLatex method in `Input` since the session needs to be undefined or null in order to be marked as "not answered". 
<img width="368" alt="image" src="https://github.com/user-attachments/assets/aed0c620-32fa-4e11-873d-6c13dc7282c2" />


No need for a sanity check here
