### PR TITLE
fix: ensure correct response is only included in model for evaluate mode, refactor and add corresponding tests for drag-in-the-blank and image-cloze-association PD-4785

### DIFF
--- a/packages/drag-in-the-blank/controller/src/__tests__/index.test.js
+++ b/packages/drag-in-the-blank/controller/src/__tests__/index.test.js
@@ -49,6 +49,34 @@ describe('controller', () => {
       });
     });
 
+    describe('correctResponse behavior across modes', () => {
+      it('does not include correctResponse in gather mode', async () => {
+        const result = await model(question, {}, { mode: 'gather' });
+    
+        expect(result.correctResponse).toBeUndefined();
+      });
+    
+      it('does not include correctResponse in view mode', async () => {
+        const result = await model(question, {}, { mode: 'view' });
+    
+        expect(result.correctResponse).toBeUndefined();
+      });
+    
+      it('includes correctResponse only in evaluate mode', async () => {
+        const result = await model(question, {}, { mode: 'evaluate' });
+    
+        expect(result.correctResponse).toBeDefined();
+      });
+    
+      it('ensures correctResponse is explicitly undefined when not in evaluate mode', async () => {
+        const gatherResult = await model(question, {}, { mode: 'gather' });
+        const viewResult = await model(question, {}, { mode: 'view' });
+    
+        expect(gatherResult.correctResponse).toBeUndefined();
+        expect(viewResult.correctResponse).toBeUndefined();
+      });
+    });    
+
     const assertGather = (label, extra, session, expected) => {
       it(`'mode: gather, ${label}'`, async () => {
         q = {
@@ -67,6 +95,7 @@ describe('controller', () => {
           disabled: false,
           feedback: {},
           responseCorrect: undefined,
+          correctResponse: undefined,
           ...expected,
         });
       });
@@ -129,6 +158,7 @@ describe('controller', () => {
           disabled: true,
           feedback: {},
           responseCorrect: undefined,
+          correctResponse: undefined,
           ...expected,
         });
       });
@@ -188,6 +218,7 @@ describe('controller', () => {
           disabled: true,
           feedback: {},
           responseCorrect: undefined,
+          correctResponse: undefined,
           ...expected,
         });
       });

--- a/packages/drag-in-the-blank/controller/src/index.js
+++ b/packages/drag-in-the-blank/controller/src/index.js
@@ -68,6 +68,7 @@ export function model(question, session, env, updateSession) {
       mode: env.mode,
       disabled: env.mode !== 'gather',
       responseCorrect: env.mode === 'evaluate' ? getScore(normalizedQuestion, session) === 1 : undefined,
+      correctResponse: env.mode === 'evaluate' ? normalizedQuestion.correctResponse : undefined,
     };
 
     if (env.role === 'instructor' && (env.mode === 'view' || env.mode === 'evaluate')) {

--- a/packages/image-cloze-association/controller/src/__tests__/index.test.js
+++ b/packages/image-cloze-association/controller/src/__tests__/index.test.js
@@ -469,12 +469,7 @@ describe('controller', () => {
       });
 
       it('returns validation', () => {
-        expect(result.validation).toEqual({
-          validResponse: {
-            score: 1,
-            value: [{ images: [rhomb, square] }, { images: [rhomb, square, trapeze] }],
-          },
-        });
+        expect(result.validation).toBeUndefined();
       });
 
       it('returns responseContainers', () => {
@@ -518,6 +513,15 @@ describe('controller', () => {
         return result;
       });
 
+      it('returns validation', () => {
+        expect(result.validation).toEqual({
+          validResponse: {
+            score: 1,
+            value: [{ images: [rhomb, square] }, { images: [rhomb, square, trapeze] }],
+          },
+        });
+      });
+
       it('returns is response correct', () => {
         expect(result.responseCorrect).toEqual(false);
       });
@@ -538,6 +542,34 @@ describe('controller', () => {
       returnModel({});
     });
   });
+
+  describe('validation property behavior across modes', () => {
+    it('does not include validation in gather mode', async () => {
+      const result = await model(question, {}, { mode: 'gather' });
+  
+      expect(result.validation).toBeUndefined();
+    });
+  
+    it('does not include validation in view mode', async () => {
+      const result = await model(question, {}, { mode: 'view' });
+  
+      expect(result.validation).toBeUndefined();
+    });
+  
+    it('includes validation only in evaluate mode', async () => {
+      const result = await model(question, {}, { mode: 'evaluate' });
+  
+      expect(result.validation).toBeDefined();
+    });
+  
+    it('ensures validation is explicitly undefined when not in evaluate mode', async () => {
+      const gatherResult = await model(question, {}, { mode: 'gather' });
+      const viewResult = await model(question, {}, { mode: 'view' });
+  
+      expect(gatherResult.validation).toBeUndefined();
+      expect(viewResult.validation).toBeUndefined();
+    });
+  });  
 
   describe('getPartialScore', () => {
     const returnPartialScore = (sess) => {

--- a/packages/image-cloze-association/controller/src/index.js
+++ b/packages/image-cloze-association/controller/src/index.js
@@ -20,6 +20,7 @@ export const model = (question, session, env) => {
       mode: env.mode,
       ...questionCamelized,
       responseCorrect: env.mode === 'evaluate' ? getScore(questionCamelized, session) === 1 : undefined,
+      validation: env.mode === 'evaluate' ? questionCamelized.validation : undefined,
     };
 
     if (questionNormalized.shuffle) {


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4785