### PR TITLE
fix(categorize): on touch devices on long press do not remove choice PD-4763

### DIFF
--- a/packages/categorize/src/categorize/__tests__/choice.test.jsx
+++ b/packages/categorize/src/categorize/__tests__/choice.test.jsx
@@ -76,6 +76,7 @@ describe('spec', () => {
       monitor = {
         getItem: jest.fn().mockReturnValue(item),
         didDrop: jest.fn().mockReturnValue(false),
+        getDifferenceFromInitialOffset: jest.fn().mockReturnValue({ x: 10, y: 10 }), // Mock movement
       };
     });
 
@@ -93,7 +94,13 @@ describe('spec', () => {
     it('does not call onRemoveChoice monitor.didDrop returns true', () => {
       monitor.didDrop.mockReturnValue(true);
       spec.endDrag(props, monitor);
-      expect(props.onRemoveChoice).not.toBeCalledWith(item);
+      expect(props.onRemoveChoice).not.toBeCalled();
+    });
+
+    it('does not call onRemoveChoice if movement is too small', () => {
+      monitor.getDifferenceFromInitialOffset.mockReturnValue({ x: 2, y: 2 }); // Small movement
+      spec.endDrag(props, monitor);
+      expect(props.onRemoveChoice).not.toBeCalled();
     });
   });
 });

--- a/packages/categorize/src/categorize/choice.jsx
+++ b/packages/categorize/src/categorize/choice.jsx
@@ -120,12 +120,17 @@ export const spec = {
     return out;
   },
   endDrag: (props, monitor) => {
-    if (!monitor.didDrop()) {
-      const item = monitor.getItem();
-      if (item.categoryId) {
-        log('wasnt droppped - what to do?');
-        props.onRemoveChoice(item);
+    const delta = monitor.getDifferenceFromInitialOffset();
+    if (delta && (Math.abs(delta.x) > 5 || Math.abs(delta.y) > 5)) {
+      if (!monitor.didDrop()) {
+        const item = monitor.getItem();
+        if (item.categoryId) {
+          log('wasnt droppped - what to do?');
+          props.onRemoveChoice(item);
+        }
       }
+    } else {
+      log('long press on touch devices, not removing item');
     }
   },
 };


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4763
The fix involves checking the drag movement. If the movement is less than a small threshold (5px), endDrag is prevented from removing the item. This ensures long press without movement won't trigger item removal by mistake.