### PR TITLE
Fix wait time calculations

### DIFF
--- a/packages/categorize/src/index.js
+++ b/packages/categorize/src/index.js
@@ -162,8 +162,8 @@ export default class Categorize extends HTMLElement {
             
             let { audioStartTime, audioEndTime, waitTime } = this._session;
             if(!waitTime && audioStartTime && audioEndTime) {
-              // waitTime is elapsed time (in seconds) the user waited for auto-played audio to finish
-              this._session.waitTime = (audioEndTime - audioStartTime) / 1000;
+              // waitTime is elapsed time the user waited for auto-played audio to finish
+              this._session.waitTime = (audioEndTime - audioStartTime);
             }
             
             this.audioComplete = true;

--- a/packages/drag-in-the-blank/src/index.js
+++ b/packages/drag-in-the-blank/src/index.js
@@ -138,8 +138,10 @@ export default class DragInTheBlank extends HTMLElement {
 
           // we need to listen for the playing event to remove the toast in case the audio plays because of re-rendering
           const handlePlaying = () => {
+            //timestamp when auto-played audio started playing
+            this._session.audioStartTime = this._session.audioStartTime || new Date().getTime();
+            
             const info = this.querySelector('#play-audio-info');
-
             if (info) {
               container.removeChild(info);
             }
@@ -151,6 +153,15 @@ export default class DragInTheBlank extends HTMLElement {
 
           // we need to listen for the ended event to update the isComplete state
           const handleEnded = () => {
+            //timestamp when auto-played audio completed playing
+            this._session.audioEndTime = this._session.audioEndTime || new Date().getTime();
+            
+            let { audioStartTime, audioEndTime, waitTime } = this._session;
+            if(!waitTime && audioStartTime && audioEndTime) {
+              // waitTime is elapsed time the user waited for auto-played audio to finish
+              this._session.waitTime = (audioEndTime - audioStartTime);
+            }
+            
             this.audioComplete = true;
             this.dispatchChangedEvent();
             audio.removeEventListener('ended', handleEnded);

--- a/packages/hotspot/src/session-updater.js
+++ b/packages/hotspot/src/session-updater.js
@@ -17,3 +17,13 @@ export function updateSessionValue(session, model, data) {
     session.selector = data.selector;
   }
 }
+
+export function updateSessionMetadata(session, metadata) {
+  session.audioStartTime = session.audioStartTime || metadata.audioStartTime; //timestamp when auto-played audio started playing
+  session.audioEndTime = session.audioEndTime || metadata.audioEndTime; //timestamp when auto-played audio completed playing
+  
+  if(!session.waitTime && session.audioStartTime && session.audioEndTime) {
+    // waitTime is elapsed time the user waited for auto-played audio to finish
+    session.waitTime = (session.audioEndTime - session.audioStartTime);
+  }
+}

--- a/packages/multiple-choice/src/session-updater.js
+++ b/packages/multiple-choice/src/session-updater.js
@@ -29,7 +29,7 @@ export function updateSessionMetadata(session, metadata) {
   session.audioEndTime = session.audioEndTime || metadata.audioEndTime; //timestamp when auto-played audio completed playing
   
   if(!session.waitTime && session.audioStartTime && session.audioEndTime) {
-    // waitTime is elapsed time (in seconds) the user waited for auto-played audio to finish
-    session.waitTime = (session.audioEndTime - session.audioStartTime) / 1000;
+    // waitTime is elapsed time the user waited for auto-played audio to finish
+    session.waitTime = (session.audioEndTime - session.audioStartTime);
   }
 }


### PR DESCRIPTION
Changes:

- capture waitTime in hotspot and drag-in-the-blank
- store waitTime in milliseconds, instead of seconds (removed conversion to seconds)