### PR TITLE
fix(image-cloze-association): refactor in order to speed up load time…

### DIFF
--- a/packages/image-cloze-association/src/evaluation-icon.jsx
+++ b/packages/image-cloze-association/src/evaluation-icon.jsx
@@ -6,10 +6,10 @@ import Close from '@material-ui/icons/Close';
 import { color } from '@pie-lib/pie-toolbox/render-ui';
 
 const getCorrectnessClass = (isCorrect, filled) => {
-  if (filled) {
-    return isCorrect ? 'correctFilled' : 'incorrectFilled';
-  }
-  return isCorrect ? 'correctEmpty' : 'incorrectEmpty';
+  const correctness = isCorrect ? 'correct' : 'incorrect';
+  const fillState = filled ? 'Filled' : 'Empty';
+
+  return `${correctness}${fillState}`;
 };
 
 const EvaluationIcon = ({ classes, containerStyle, isCorrect, filled }) => {

--- a/packages/image-cloze-association/src/possible-response.jsx
+++ b/packages/image-cloze-association/src/possible-response.jsx
@@ -4,10 +4,10 @@ import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import { DragSource } from '@pie-lib/pie-toolbox/drag';
 import { color } from '@pie-lib/pie-toolbox/render-ui';
-import { PreviewPrompt } from '@pie-lib/pie-toolbox/render-ui';
 
 import EvaluationIcon from './evaluation-icon';
 import c from './constants';
+import StaticHTMLSpan from './static-html-span';
 
 export class PossibleResponse extends React.Component {
   render() {
@@ -40,11 +40,7 @@ export class PossibleResponse extends React.Component {
 
     return connectDragSource(
       <div className={containerClassNames} style={containerStyle}>
-        <PreviewPrompt
-          defaultClassName={promptClassNames}
-          prompt={data.value}
-          tagName="span"
-        />
+        <StaticHTMLSpan html={data.value} className={promptClassNames} />
         <EvaluationIcon isCorrect={data.isCorrect} containerStyle={evaluationStyle} />
       </div>,
     );

--- a/packages/image-cloze-association/src/static-html-span.jsx
+++ b/packages/image-cloze-association/src/static-html-span.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class StaticHTMLSpan extends React.PureComponent {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+    const { html, className } = this.props;
+
+    return (
+      <span
+        className={className}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+}
+
+StaticHTMLSpan.propTypes = {
+  html: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+StaticHTMLSpan.defaultProps = {
+  className: '',
+};
+
+export default StaticHTMLSpan;


### PR DESCRIPTION
… of choices when moving them PD-4941

https://illuminate.atlassian.net/browse/PD-4941

- refactored logic as much as posibile to get rid of unnecessary array mapping / filtering or if else statements, to improve load time
- removed PreviewPrompt to reduce logic and added simple span with needed functionality (should behave the same)

visually it improves with about 1 sec load, the small rectangle still shows up but we can't really use dangerously set html and not have that small flickering 