### PR TITLE
fix(categorize, hotspot, multiple-choice, drag-in-the-blank): prevent…

### DIFF
--- a/packages/categorize/src/index.js
+++ b/packages/categorize/src/index.js
@@ -11,6 +11,9 @@ export default class Categorize extends HTMLElement {
 
     this.eliminateBlindAnswersFromSession();
     this.dispatchEvent(new ModelSetEvent(this.tagName.toLowerCase(), this.isComplete(), !!this._model));
+    // reset the audioInitialized to false since the model changed, and we might need to reinitialize the audio
+    this._audioInitialized = false;
+
     this.render();
   }
 
@@ -110,6 +113,7 @@ export default class Categorize extends HTMLElement {
     const observer = new MutationObserver((mutationsList, observer) => {
       mutationsList.forEach((mutation) => {
         if (mutation.type === 'childList') {
+          if (this._audioInitialized) return;
           const audio = this.querySelector('audio');
           const isInsidePrompt = audio && audio.closest('#preview-prompt');
 
@@ -180,6 +184,8 @@ export default class Categorize extends HTMLElement {
           this._handlePlaying = handlePlaying;
           this._handleEnded = handleEnded;
           this._enableAudio = enableAudio;
+          // set to true to prevent multiple initializations
+          this._audioInitialized = true;
 
           observer.disconnect();
         }

--- a/packages/drag-in-the-blank/src/index.js
+++ b/packages/drag-in-the-blank/src/index.js
@@ -24,13 +24,15 @@ export default class DragInTheBlank extends HTMLElement {
     super();
     this._model = null;
     this._session = null;
+    this._audioInitialized = false;
     this.audioComplete = false;
   }
 
   set model(m) {
     this._model = m;
     this.dispatchEvent(new ModelSetEvent(this.tagName.toLowerCase(), isComplete(this._session, this._model, this.audioComplete), !!this._model));
-
+    // reset the audioInitialized to false since the model changed, and we might need to reinitialize the audio
+    this._audioInitialized = false;
     this._render();
   }
 
@@ -105,6 +107,7 @@ export default class DragInTheBlank extends HTMLElement {
     const observer = new MutationObserver((mutationsList, observer) => {
       mutationsList.forEach((mutation) => {
         if (mutation.type === 'childList') {
+          if (this._audioInitialized) return;
           const audio = this.querySelector('audio');
           const isInsidePrompt = audio && audio.closest('#preview-prompt');
 
@@ -174,6 +177,8 @@ export default class DragInTheBlank extends HTMLElement {
           this._handlePlaying = handlePlaying;
           this._handleEnded = handleEnded;
           this._enableAudio = enableAudio;
+          // set to true to prevent multiple initializations
+          this._audioInitialized = true;
 
           observer.disconnect();
         }

--- a/packages/hotspot/src/index.js
+++ b/packages/hotspot/src/index.js
@@ -12,6 +12,7 @@ export default class Hotspot extends HTMLElement {
     super();
     this._model = null;
     this._session = null;
+    this._audioInitialized = false;
     this.audioComplete = false;
   }
 
@@ -19,6 +20,7 @@ export default class Hotspot extends HTMLElement {
     this._model = m;
 
     this.dispatchEvent(new ModelSetEvent(this.tagName.toLowerCase(), this.isComplete(), !!this._model));
+    this._audioInitialized = false;
     this._render();
   }
 
@@ -96,6 +98,7 @@ export default class Hotspot extends HTMLElement {
     const observer = new MutationObserver((mutationsList, observer) => {
       mutationsList.forEach((mutation) => {
         if (mutation.type === 'childList') {
+          if (this._audioInitialized) return;
           const audio = this.querySelector('audio');
           const isInsidePrompt = audio && audio.closest('#preview-prompt');
 
@@ -166,6 +169,8 @@ export default class Hotspot extends HTMLElement {
           this._handlePlaying = handlePlaying;
           this._handleEnded = handleEnded;
           this._enableAudio = enableAudio;
+          // set to true to prevent multiple initializations
+          this._audioInitialized = true;
 
           observer.disconnect();
         }

--- a/packages/multiple-choice/src/index.js
+++ b/packages/multiple-choice/src/index.js
@@ -43,6 +43,7 @@ export default class MultipleChoice extends HTMLElement {
     this.audioComplete = false;
     this._boundHandleKeyDown = this.handleKeyDown.bind(this);
     this._keyboardEventsEnabled = false;
+    this._audioInitialized = false;
 
     this._rerender = debounce(
       () => {
@@ -112,6 +113,8 @@ export default class MultipleChoice extends HTMLElement {
   set model(s) {
     this._model = s;
     this._rerender();
+    // reset the audioInitialized to false since the model changed, and we might need to reinitialize the audio
+    this._audioInitialized = false;
     this._dispatchModelSet();
   }
 
@@ -168,6 +171,8 @@ export default class MultipleChoice extends HTMLElement {
     const observer = new MutationObserver((mutationsList, observer) => {
       mutationsList.forEach((mutation) => {
         if (mutation.type === 'childList') {
+          if (this._audioInitialized) return;
+
           const audio = this.querySelector('audio');
           const isInsidePrompt = audio && audio.closest('#preview-prompt');
 
@@ -228,6 +233,8 @@ export default class MultipleChoice extends HTMLElement {
           this._handlePlaying = handlePlaying;
           this._handleEnded = handleEnded;
           this._enableAudio = enableAudio;
+          // set to true to prevent multiple initializations
+          this._audioInitialized = true;
 
           observer.disconnect();
         }


### PR DESCRIPTION
… multiple initializations of event listeners for audio autoplay PD-4975

https://illuminate.atlassian.net/browse/PD-4975

this prevents multiple session-change events that are triggered by the audio ended event
we had: 
drag-in-the-blank: 10
multiple-choice: 2 
image-cloze-association:  1 (normal)
hotspot: 3
categorize: 16