### PR TITLE
fix(ebsr): allow tabbing into second radio group, fix behavior of radio button groups PD-4562

### DIFF
--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -293,7 +293,7 @@ export class MultipleChoice extends React.Component {
           </div>
         )}
 
-        <fieldset className={classes.fieldset} role={choiceMode === 'radio' ? 'radiogroup' : 'group'}>
+        <fieldset tabIndex={0} className={classes.fieldset} role={choiceMode === 'radio' ? 'radiogroup' : 'group'}>
           <PreviewPrompt
             className="prompt"
             defaultClassName="prompt"

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -293,7 +293,7 @@ export class MultipleChoice extends React.Component {
           </div>
         )}
 
-        <fieldset className={classes.fieldset}>
+        <fieldset className={classes.fieldset} role={choiceMode === 'radio' ? 'radiogroup' : 'group'}>
           <PreviewPrompt
             className="prompt"
             defaultClassName="prompt"


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4562

We observed two main accessibility issues in this EBSR item:

Arrow key navigation was not trapped within each radio group. Users could move from one group to the next using arrow keys, which violates expected radio group behavior—navigation with arrow keys should stay within a group, and only Tab should move between groups.

The second group of radio buttons was not tabbable at all. This was caused by a custom component structure where the actual radio inputs were wrapped in spans, breaking the native focus behavior expected by the browser and Material UI.

To address the second issue, we added tabindex="0" to the <fieldset> of each group. This allows keyboard users to tab into each radio group as expected. Arrow trapping is still under review, but this change restores basic keyboard accessibility across groups.
