### PR TITLE
feat(select-text): update Legend component to show only correct answe…

### DIFF
--- a/packages/select-text/src/main.jsx
+++ b/packages/select-text/src/main.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { TextSelect, Legend } from '@pie-lib/pie-toolbox/text-select';
-import {CorrectAnswerToggle} from '@pie-lib/pie-toolbox/correct-answer-toggle';
-import {color, Feedback, Collapsible, hasText, hasMedia, PreviewPrompt, UiLayout} from '@pie-lib/pie-toolbox/render-ui';
+import { CorrectAnswerToggle } from '@pie-lib/pie-toolbox/correct-answer-toggle';
+import { color, Feedback, Collapsible, hasText, hasMedia, PreviewPrompt, UiLayout } from '@pie-lib/pie-toolbox/render-ui';
 import { withStyles } from '@material-ui/core/styles';
 import generateModel from './utils';
 
@@ -113,7 +113,7 @@ export class Main extends React.Component {
           maxNoOfSelections={model.maxSelections}
           animationsDisabled={model.animationsDisabled}
         />
-        {mode === 'evaluate' && <Legend language={model.language} />}
+        {mode === 'evaluate' && <Legend language={model.language} showOnlyCorrect={showCorrectAnswer} />}
 
         {showRationale &&
           (!model.animationsDisabled ? (


### PR DESCRIPTION
…rs in evaluate mode PD-5100
https://illuminate.atlassian.net/browse/PD-5100

evaluate: 
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/ca46c1ca-40a8-436e-a193-1a9ef8365e94" />

show correct: 
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/3248e7dc-5bba-4475-a18d-cfbaa1d06af9" />
https://github.com/pie-framework/pie-lib/pull/1883 - is needed for this to work 