### PR TITLE
fix: allow math-inline scoring to continue even if one alternate answer fails parsing PD-4848

### DIFF
--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -69,7 +69,7 @@ function getIsAnswerCorrect(correctResponseItems, answerItem) {
           break;
         }
       } catch (e) {
-        log('Parse failure for value:', acceptedValues[i], e);
+        log('Parse failure when evaluating math', acceptedValues[i], answerItem, e);
         continue;
       }
     }

--- a/packages/math-inline/controller/src/index.js
+++ b/packages/math-inline/controller/src/index.js
@@ -41,39 +41,36 @@ const getResponseCorrectness = (model, answerItem, isOutcome) => {
   return correctnessObject;
 };
 
-function getIsAnswerCorrect(correctResponseItem, answerItem) {
+function getIsAnswerCorrect(correctResponseItems, answerItem) {
   let answerCorrect = false;
 
-  (correctResponseItem || []).forEach((correctResponse) => {
-    let opts = {
+  (correctResponseItems || []).forEach((correctResponse) => {
+    if (answerCorrect) return;
+
+    const opts = {
       mode: correctResponse.validation || defaults.validationDefault,
     };
 
-    if (opts.mode == 'literal') {
+    if (opts.mode === 'literal') {
       opts.literal = {
         allowTrailingZeros: correctResponse.allowTrailingZeros || false,
         ignoreOrder: correctResponse.ignoreOrder || false,
       };
     }
 
-    if (!answerCorrect) {
-      const acceptedValues =
-        [correctResponse.answer].concat(
-          Object.keys(correctResponse.alternates || {}).map((alternateId) => correctResponse.alternates[alternateId]),
-        ) || [];
+    const acceptedValues = [correctResponse.answer].concat(
+      Object.keys(correctResponse.alternates || {}).map((alternateId) => correctResponse.alternates[alternateId]),
+    );
 
+    for (let i = 0; i < acceptedValues.length; i++) {
       try {
-        for (let i = 0; i < acceptedValues.length; i++) {
-          answerCorrect = mv.latexEqual(answerItem, acceptedValues[i], opts);
-
-          if (answerCorrect) {
-            break;
-          }
+        if (mv.latexEqual(answerItem, acceptedValues[i], opts)) {
+          answerCorrect = true;
+          break;
         }
       } catch (e) {
-        log('Parse failure when evaluating math', e, correctResponse, answerItem);
-
-        answerCorrect = false;
+        log('Parse failure for value:', acceptedValues[i], e);
+        continue;
       }
     }
   });


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-4848