### PR TITLE
fix: bump math-validation PD-5052

### DIFF
--- a/packages/math-inline/controller/package.json
+++ b/packages/math-inline/controller/package.json
@@ -9,7 +9,7 @@
     "test": "./node_modules/.bin/jest"
   },
   "dependencies": {
-    "@pie-framework/math-validation": "^1.4.1",
+    "@pie-framework/math-validation": "^1.4.2",
     "@pie-lib/pie-toolbox": "2.22.3",
     "debug": "^3.1.0",
     "lodash": "^4.17.15"

--- a/packages/math-templated/controller/package.json
+++ b/packages/math-templated/controller/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "dependencies": {
-    "@pie-framework/math-validation": "^1.4.1",
+    "@pie-framework/math-validation": "^1.4.2",
     "@pie-lib/pie-toolbox": "2.22.3",
     "debug": "^3.1.0",
     "lodash": "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,10 +2227,10 @@
     mathjs "^7.0.1"
     numeric "^1.2.6"
 
-"@pie-framework/math-validation@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@pie-framework/math-validation/-/math-validation-1.4.1.tgz#091284ddb850c9486dada9528f4bafc497d989ba"
-  integrity sha512-uUPlJjg9PC2GSbSRYAA21ra1XM3cSlqy2IhK1FX5ziRTxtW6uf1hpqVjKwYSCnLQ6oR8kVztorQaN8ozsJo7Lw==
+"@pie-framework/math-validation@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@pie-framework/math-validation/-/math-validation-1.4.2.tgz#0148f0c06c476456820995c2d30cf1dd462693e5"
+  integrity sha512-qQPvLb6fAhQOPyqkpiYTrw6nsaARlGZcAIqBA13a2WLNkeRYodqRGH/+31UdRWnDc/ibqGRG/I41wTCb50kl7Q==
   dependencies:
     lodash "^4.17.21"
     mathjs "^9.4.2"


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-5052

This fix addresses an issue where symbolic validation incorrectly rejected answers that included both leading spaces and trailing zeros (e.g., " 1.30").

The new logic ensures numerical equivalence is preserved regardless of surrounding whitespace and insignificant decimal padding.

Added extensive tests to confirm correct behavior for digits 0–9, including edge cases with negative numbers and leading zero values.