### PR TITLE
fix(multiple-choice):  stroke style condition in Choice component PD-…

### DIFF
--- a/packages/multiple-choice/src/choice.jsx
+++ b/packages/multiple-choice/src/choice.jsx
@@ -119,13 +119,14 @@ export class Choice extends React.Component {
       currentBackgroundColor = hoverAnswerBackgroundColor;
     }
 
-     const strokeStyle = (hasSelectedStroke || hasHoverStroke) ? {
+    const hasStroke = hasSelectedStroke || hasHoverStroke;
+    const strokeStyle = hasStroke ? {
       border: `${normalizeStrokeWidth(currentStrokeWidth)} solid ${currentStrokeColor}`,
       borderRadius: '8px',
     } : {};
 
     const names = classNames(classes.choice, {
-      [classes.noBorder]: index === choicesLength - 1 || choicesLayout !== 'vertical' || strokeStyle,
+      [classes.noBorder]: index === choicesLength - 1 || choicesLayout !== 'vertical' || hasStroke,
       [classes.horizontalLayout]: choicesLayout === 'horizontal',
     });
 


### PR DESCRIPTION
…4768

The condition was not ok before because I was checking for truthy value of {}, which is true. so noBorder style was always applied
https://illuminate.atlassian.net/browse/PD-4768?focusedCommentId=2057912 