### PR TITLE
fix(multiple-choice/ebsr): add options prop to component for print co…

### DIFF
--- a/packages/ebsr/src/print.js
+++ b/packages/ebsr/src/print.js
@@ -142,6 +142,9 @@ export default class Ebsr extends HTMLElement {
         partLabel: labels[key]
       };
 
+      // pass options to enable print mode detection in multiple-choice component
+      part.options = this._options;
+
       if (!part._session) {
         // for print, "set session" is not called,
         // but ebsr needs sessions in order to render the elements,

--- a/packages/multiple-choice/src/multiple-choice.jsx
+++ b/packages/multiple-choice/src/multiple-choice.jsx
@@ -103,6 +103,7 @@ export class MultipleChoice extends React.Component {
       playImage: PropTypes.string,
       pauseImage: PropTypes.string,
     },
+    options: PropTypes.object,
   };
 
   constructor(props) {
@@ -209,17 +210,21 @@ export class MultipleChoice extends React.Component {
   };
 
   getChecked(choice) {
-    // to determine if we are in evaluate mode or print mode
-    // since both modes have showCorrect but it interferes with "browse mode" in IBX if the print props are set
-    const isEvaluateMode = this.state.showCorrect && this.props.mode === 'evaluate';
-    const isPrintMode =
-      this.props.alwaysShowCorrect &&
-      (!this.props.session || !this.props.session.value || this.props.session.value.length === 0);
-
-    if (isEvaluateMode || isPrintMode) {
+    // check for print context: options prop is passed from print.js and alwaysShowCorrect is true
+    const isPrintMode = this.props.options && this.props.alwaysShowCorrect;
+    
+    if (isPrintMode) {
       return choice.correct || false;
     }
 
+    // evaluate mode with show correct toggled
+    const isEvaluateMode = this.state.showCorrect && this.props.mode === 'evaluate';
+    
+    if (isEvaluateMode) {
+      return choice.correct || false;
+    }
+
+    // default behavior: show what the user has selected
     return this.isSelected(choice.value);
   }
 

--- a/packages/multiple-choice/src/print.js
+++ b/packages/multiple-choice/src/print.js
@@ -61,6 +61,7 @@ export default class MultipleChoicePrint extends HTMLElement {
             React.createElement(Main, {
               model: printModel,
               session: {},
+              options: this._options,
             });
 
           ReactDOM.render(element, this, () => {


### PR DESCRIPTION
…ntext handling PD-5252
The issue was happening when we had the combination of `alwaysShowCorrect` set to true and `evaluate` mode -> this was resulting in showing the correct answers in simple evaluate mode.
I added better handling to check the `options` prop presence, which is print specific.
https://illuminate.atlassian.net/browse/PD-5252 