### PR TITLE
Refactor Categorize package to use MUI styled components and replace …

### DIFF
--- a/packages/categorize/configure/package.json
+++ b/packages/categorize/configure/package.json
@@ -26,8 +26,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.6.2",
     "react": "18.2.0",
-    "react-dnd": "^14.0.5",
-    "react-dnd-html5-backend": "^14.0.2",
+    "@dnd-kit/core": "6.1.0",
     "react-dom": "18.2.0"
   },
   "gitHead": "a53e5e851a76da9c1d1a919b277ca0c4c8a8bff2"

--- a/packages/categorize/configure/src/design/buttons.jsx
+++ b/packages/categorize/configure/src/design/buttons.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import Button from '@mui/material/Button';
-import MuiDivider from '@mui/material/Divider';
+
+const StyledAddButton = styled(Button)(({ theme }) => ({
+  height: theme.spacing(4),
+}));
 
 export class RawAddButton extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     label: PropTypes.string,
     onClick: PropTypes.func,
@@ -19,38 +20,33 @@ export class RawAddButton extends React.Component {
   };
 
   render() {
-    const { classes, className, label, onClick, disabled } = this.props;
+    const { className, label, onClick, disabled } = this.props;
     return (
-      <Button
+      <StyledAddButton
         onClick={onClick}
         disabled={disabled}
-        className={classNames(classes.addButton, className)}
+        className={className}
         size="small"
         variant="contained"
         color="primary"
       >
         {label}
-      </Button>
+      </StyledAddButton>
     );
   }
 }
-const styles = (theme) => ({
-  addButton: {
-    height: theme.spacing.unit * 4,
-  },
+
+const AddButton = RawAddButton;
+
+const StyledDeleteButton = styled(Button)({
+  margin: 0,
+  padding: 0,
 });
 
-const AddButton = withStyles(styles)(RawAddButton);
-
-const DeleteButton = withStyles(() => ({
-  deleteButton: {
-    margin: 0,
-    padding: 0,
-  },
-}))(({ classes, label, onClick, disabled }) => (
-  <Button className={classes.deleteButton} onClick={onClick} size="small" color="primary" disabled={disabled}>
+const DeleteButton = ({ label, onClick, disabled }) => (
+  <StyledDeleteButton onClick={onClick} size="small" color="primary" disabled={disabled}>
     {label}
-  </Button>
-));
+  </StyledDeleteButton>
+);
 
 export { AddButton, DeleteButton };

--- a/packages/categorize/configure/src/design/categories/RowLabel.jsx
+++ b/packages/categorize/configure/src/design/categories/RowLabel.jsx
@@ -1,23 +1,16 @@
 import { getPluginProps } from '../utils';
 import React from 'react';
-import withStyles from '@mui/styles/withStyles';
+import { styled } from '@mui/material/styles';
 import EditableHtml from '@pie-lib/editable-html';
 import { InputContainer } from '@pie-lib/render-ui';
 
-const styles = (theme) => ({
-  rowLabel: {
-    gridColumn: '1/3',
-  },
-  rowLabelHolder: {
-    paddingTop: theme.spacing.unit * 2,
-    width: '100%',
-  },
-});
+const RowLabelContainer = styled(InputContainer)(({ theme }) => ({
+  paddingTop: theme.spacing(2),
+  width: '100%',
+}));
 
-export const RowLabel = withStyles(styles)(
-  ({
+export const RowLabel = ({
     categoriesPerRow,
-    classes,
     configuration,
     disabled,
     markup,
@@ -39,7 +32,7 @@ export const RowLabel = withStyles(styles)(
           width: '100%',
         }}
       >
-        <InputContainer label="Row Label" className={classes.rowLabelHolder}>
+        <RowLabelContainer label="Row Label">
           <EditableHtml
             disabled={disabled}
             markup={markup}
@@ -55,8 +48,7 @@ export const RowLabel = withStyles(styles)(
             languageCharactersProps={[{ language: 'spanish' }, { language: 'special' }]}
             mathMlOptions={mathMlOptions}
           />
-        </InputContainer>
+        </RowLabelContainer>
       </div>
     );
-  },
-);
+  };

--- a/packages/categorize/configure/src/design/categories/alternateResponses.jsx
+++ b/packages/categorize/configure/src/design/categories/alternateResponses.jsx
@@ -1,34 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
-import { moveChoiceToAlternate, removeChoiceFromAlternate } from '@pie-lib/categorize';
+import { styled } from '@mui/material/styles';
+import { removeChoiceFromAlternate } from '@pie-lib/categorize';
 
 import Category from './category';
-import { getMaxCategoryChoices } from '../../utils';
 
-const styles = (theme) => ({
-  categories: {
-    marginBottom: theme.spacing.unit * 2.5,
-  },
-  categoriesHolder: {
-    display: 'grid',
-    gridRowGap: `${theme.spacing.unit}px`,
-    gridColumnGap: `${theme.spacing.unit}px`,
-  },
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(2, 1fr)',
-    gridColumnGap: `${theme.spacing.unit}px`,
-    alignItems: 'baseline',
-    width: '100%',
-    marginTop: theme.spacing.unit,
-    marginBottom: 2 * theme.spacing.unit,
-  },
-  rowLabel: {
-    gridColumn: '1/3',
-  },
-});
+const CategoriesContainer = styled('div')(({ theme }) => ({
+  marginBottom: theme.spacing(2.5),
+}));
+
+const CategoriesHolder = styled('div')(({ theme }) => ({
+  display: 'grid',
+  gridRowGap: `${theme.spacing(1)}px`,
+  gridColumnGap: `${theme.spacing(1)}px`,
+}));
+
+const RowLabel = styled('div')(({ theme }) => ({
+  gridColumn: '1/3',
+}));
 
 export class AlternateResponses extends React.Component {
   static propTypes = {
@@ -38,7 +27,6 @@ export class AlternateResponses extends React.Component {
       add: PropTypes.func.isRequired,
       delete: PropTypes.func.isRequired,
     }),
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     categories: PropTypes.array,
     onModelChanged: PropTypes.func,
@@ -50,85 +38,6 @@ export class AlternateResponses extends React.Component {
     spellCheck: PropTypes.bool,
   };
 
-  addChoiceToCategory = (addedChoice, categoryId) => {
-    const {
-      altIndex,
-      model: { correctResponse, choices, maxChoicesPerCategory = 0 },
-      onModelChanged,
-    } = this.props;
-
-    const choice = choices.find((c) => c.id === addedChoice.id);
-
-    correctResponse.forEach((a) => {
-      if (a.category === categoryId) {
-        a.alternateResponses = a.alternateResponses || [];
-
-        if (!a.alternateResponses[altIndex]) {
-          a.alternateResponses[altIndex] = [];
-        }
-
-        a.alternateResponses[altIndex].push(addedChoice.id);
-        if (choice.categoryCount && choice.categoryCount !== 0) {
-          a.alternateResponses[altIndex] = a.alternateResponses[altIndex].reduce((acc, currentValue) => {
-            if (currentValue === choice.id) {
-              const foundIndex = acc.findIndex((c) => c === choice.id);
-              if (foundIndex === -1) {
-                acc.push(currentValue);
-              }
-            } else {
-              acc.push(currentValue);
-            }
-
-            return acc;
-          }, []);
-        }
-
-        return a;
-      } else {
-        if (a.alternateResponses[altIndex] && choice.categoryCount !== 0) {
-          a.alternateResponses[altIndex] = a.alternateResponses[altIndex].filter((c) => c !== addedChoice.id);
-          return a;
-        }
-      }
-
-      return a;
-    });
-
-    const maxCategoryChoices = getMaxCategoryChoices(this.props.model);
-    // when maxChoicesPerCategory is set to 0, there is no limit so it should not be updated
-    onModelChanged({
-      correctResponse,
-      maxChoicesPerCategory:
-        maxChoicesPerCategory !== 0 && maxChoicesPerCategory < maxCategoryChoices
-          ? maxChoicesPerCategory + 1
-          : maxChoicesPerCategory,
-    });
-  };
-
-  moveChoice = (choiceId, from, to, choiceIndex, alternateIndex) => {
-    const { model, onModelChanged } = this.props;
-    let { choices, correctResponse = [], maxChoicesPerCategory = 0 } = model || {};
-    const choice = (choices || []).find((choice) => choice.id === choiceId);
-    correctResponse = moveChoiceToAlternate(
-      choiceId,
-      from,
-      to,
-      choiceIndex,
-      correctResponse,
-      alternateIndex,
-      choice?.categoryCount,
-    );
-
-    const maxCategoryChoices = getMaxCategoryChoices(this.props.model);
-    // when maxChoicesPerCategory is set to 0, there is no limit so it should not be updated
-    onModelChanged({
-      correctResponse,
-      maxChoicesPerCategory:
-        maxChoicesPerCategory !== 0 && maxChoicesPerCategory < maxCategoryChoices
-          ? maxChoicesPerCategory + 1
-          : maxChoicesPerCategory,
-    });
-  };
 
   deleteChoiceFromCategory = (category, choice, choiceIndex) => {
     const { model, altIndex, onModelChanged } = this.props;
@@ -149,7 +58,6 @@ export class AlternateResponses extends React.Component {
       altIndex,
       model,
       configuration,
-      classes,
       className,
       categories,
       imageSupport,
@@ -166,8 +74,8 @@ export class AlternateResponses extends React.Component {
     const isDuplicated = duplicateAlternate ? duplicateAlternate.index === altIndex : false;
 
     return (
-      <div className={classNames(classes.categories, className)}>
-        <div className={classes.categoriesHolder} style={holderStyle}>
+      <CategoriesContainer className={className}>
+        <CategoriesHolder style={holderStyle}>
           {categories.map((category, index) => {
             const hasRowLabel = index % categoriesPerRow === 0;
             const rowIndex = index / categoriesPerRow;
@@ -175,16 +83,15 @@ export class AlternateResponses extends React.Component {
             return (
               <React.Fragment key={index}>
                 {hasRowLabel && (
-                  <div
+                  <RowLabel
                     style={{
                       gridColumn: `1/${categoriesPerRow + 1}`,
                       width: '100%',
                     }}
-                    className={classes.rowLabel}
                     dangerouslySetInnerHTML={{
                       __html: rowLabels[rowIndex] || '',
                     }}
-                  ></div>
+                  />
                 )}
 
                 <Category
@@ -194,22 +101,19 @@ export class AlternateResponses extends React.Component {
                   isDuplicated={isDuplicated && duplicateAlternate.category === category.id}
                   category={category}
                   spellCheck={spellCheck}
-                  onAddChoice={this.addChoiceToCategory}
                   onDeleteChoice={(choice, choiceIndex) => this.deleteChoiceFromCategory(category, choice, choiceIndex)}
-                  onMoveChoice={(choiceId, from, to, choiceIndex, alternateIndex) =>
-                    this.moveChoice(choiceId, from, to, choiceIndex, alternateIndex)
-                  }
                   uploadSoundSupport={uploadSoundSupport}
                   mathMlOptions={mathMlOptions}
                   configuration={configuration}
+                  isAlternate={true}
                 />
               </React.Fragment>
             );
           })}
-        </div>
-      </div>
+        </CategoriesHolder>
+      </CategoriesContainer>
     );
   }
 }
 
-export default withStyles(styles)(AlternateResponses);
+export default AlternateResponses;

--- a/packages/categorize/configure/src/design/categories/category.jsx
+++ b/packages/categorize/configure/src/design/categories/category.jsx
@@ -1,18 +1,46 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import Card from '@mui/material/Card';
-import InputHeader from '../input-header';
 import CardActions from '@mui/material/CardActions';
+import InputHeader from '../input-header';
 import { DeleteButton } from '../buttons';
 
 import PlaceHolder from './droppable-placeholder';
 
+const StyledCard = styled(Card, {
+  shouldForwardProp: (prop) => prop !== 'isDuplicated',
+})(({ theme, isDuplicated }) => ({
+  minWidth: '196px',
+  padding: theme.spacing(1),
+  overflow: 'visible',
+  ...(isDuplicated && {
+    border: '1px solid red',
+  }),
+}));
+
+const StyledCardActions = styled(CardActions)(({ theme }) => ({
+  padding: 0,
+  paddingBottom: 0,
+  paddingTop: theme.spacing(1),
+}));
+
+const CategoryHeader = styled('div')(({ theme }) => ({
+  padding: theme.spacing(2),
+  '& p': {
+    margin: 0,
+  },
+}));
+
+const ErrorText = styled('div')(({ theme }) => ({
+  fontSize: theme.typography.fontSize - 2,
+  color: theme.palette.error.main,
+  paddingBottom: theme.spacing(1),
+}));
+
 export class Category extends React.Component {
   static propTypes = {
     alternateResponseIndex: PropTypes.number,
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     category: PropTypes.object.isRequired,
     configuration: PropTypes.object.isRequired,
@@ -28,8 +56,6 @@ export class Category extends React.Component {
     onChange: PropTypes.func,
     onDelete: PropTypes.func,
     onDeleteChoice: PropTypes.func,
-    onAddChoice: PropTypes.func,
-    onMoveChoice: PropTypes.func,
     imageSupport: PropTypes.shape({
       add: PropTypes.func.isRequired,
       delete: PropTypes.func.isRequired,
@@ -40,6 +66,7 @@ export class Category extends React.Component {
       add: PropTypes.func.isRequired,
       delete: PropTypes.func.isRequired,
     }),
+    isAlternate: PropTypes.bool,
   };
 
   static defaultProps = {};
@@ -54,7 +81,6 @@ export class Category extends React.Component {
     const {
       alternateResponseIndex,
       category,
-      classes,
       className,
       configuration,
       deleteFocusedEl,
@@ -64,8 +90,6 @@ export class Category extends React.Component {
       isDuplicated,
       onDelete,
       onDeleteChoice,
-      onAddChoice,
-      onMoveChoice,
       imageSupport,
       spellCheck,
       toolbarOpts,
@@ -77,10 +101,9 @@ export class Category extends React.Component {
 
     const isCategoryHeaderDisabled = !!alternateResponseIndex || alternateResponseIndex === 0;
     return (
-      <Card
-        className={classNames(classes.category, className, {
-          [classes.duplicateError]: isDuplicated,
-        })}
+      <StyledCard
+        className={className}
+        isDuplicated={isDuplicated}
       >
         <span>
           {!isCategoryHeaderDisabled ? (
@@ -103,76 +126,31 @@ export class Category extends React.Component {
               configuration={configuration}
             />
           ) : (
-            <div
-              className={classes.categoryHeader}
+            <CategoryHeader
               dangerouslySetInnerHTML={{
                 __html: category.label,
               }}
-            ></div>
+            />
           )}
-          {error && <div className={classes.errorText}>{error}</div>}
+          {error && <ErrorText>{error}</ErrorText>}
         </span>
         <PlaceHolder
-          className={classes.placeHolder}
           alternateResponseIndex={alternateResponseIndex}
           category={category}
           choices={category.choices}
           onDeleteChoice={onDeleteChoice}
-          onDropChoice={onAddChoice}
-          onMoveChoice={onMoveChoice}
           categoryId={category.id}
+          extraStyles={{ minHeight: '100px', }}
+          isAlternate={this.props.isAlternate}
         />
         {onDelete && (
-          <CardActions className={classes.actions}>
+          <StyledCardActions>
             <DeleteButton label={'delete'} onClick={onDelete} />
-          </CardActions>
+          </StyledCardActions>
         )}
-      </Card>
+      </StyledCard>
     );
   }
 }
-const styles = (theme) => ({
-  placeHolder: {
-    minHeight: '100px',
-  },
-  deleteButton: {
-    margin: 0,
-  },
-  actions: {
-    padding: 0,
-    paddingBottom: 0,
-    paddingTop: theme.spacing.unit,
-  },
-  iconButtonRoot: {
-    width: 'auto',
-    height: 'auto',
-  },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-  category: {
-    minWidth: '196px',
-    padding: theme.spacing.unit,
-    overflow: 'visible',
-  },
-  categoryHeader: {
-    padding: theme.spacing.unit * 2,
-    '& p': {
-      margin: 0
-    }
-  },
-  duplicateError: {
-    border: '1px solid red',
-  },
-  errorText: {
-    fontSize: theme.typography.fontSize - 2,
-    color: theme.palette.error.main,
-    paddingBottom: theme.spacing.unit,
-  },
-  editor: {
-    flex: '1',
-    paddingBottom: theme.spacing.unit * 2,
-  },
-});
-export default withStyles(styles)(Category);
+
+export default Category;

--- a/packages/categorize/configure/src/design/categories/choice-preview.jsx
+++ b/packages/categorize/configure/src/design/categories/choice-preview.jsx
@@ -1,18 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
-import { Choice } from '@pie-lib/drag';
+import { styled } from '@mui/material/styles';
+import { DraggableChoice } from '@pie-lib/drag';
 import IconButton from '@mui/material/IconButton';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import { HtmlAndMath } from '@pie-lib/render-ui';
 import { color } from '@pie-lib/render-ui';
 
+const ChoicePreviewContainer = styled('div')({
+  position: 'relative',
+  overflow: 'auto',
+});
+
+const DeleteIconButton = styled(IconButton)({
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  color: `${color.tertiary()} !important`,
+});
+
 export class ChoicePreview extends React.Component {
   static propTypes = {
     alternateResponseIndex: PropTypes.number,
     category: PropTypes.object,
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     choice: PropTypes.object.isRequired,
     choiceIndex: PropTypes.number,
@@ -26,51 +36,32 @@ export class ChoicePreview extends React.Component {
   };
 
   render() {
-    const { alternateResponseIndex, category, classes, className, choice, choiceIndex } = this.props;
+    const { alternateResponseIndex, category, className, choice, choiceIndex } = this.props;
     return (
-      <div className={classNames(classes.choicePreview, className)}>
+      <ChoicePreviewContainer className={className}>
         {choice ? (
-          <Choice
+          <DraggableChoice
             alternateResponseIndex={alternateResponseIndex}
             category={category}
             choice={choice}
             choiceIndex={choiceIndex}
-            className={classes.overflowChoice}
-            onRemoveChoice={() => this.delete()}
+            onRemoveChoice={this.delete}
+            type={'choice-preview'}
+            id={choice.id}
+            categoryId={category && category.id}
           >
-            <HtmlAndMath html={choice?.content} className={`${classes.breakWord}`} />
-            <IconButton
-              aria-label="delete"
-              className={classNames(classes.delete, classes.customColor)}
-              onClick={this.delete}
-              size="large">
-              <RemoveCircleOutlineIcon />
-            </IconButton>
-          </Choice>
+            <HtmlAndMath html={choice?.content} />
+          </DraggableChoice>
         ) : null}
-      </div>
+        <DeleteIconButton
+          aria-label="delete"
+          onClick={this.delete}
+          size="large">
+          <RemoveCircleOutlineIcon />
+        </DeleteIconButton>
+      </ChoicePreviewContainer>
     );
   }
 }
-const styles = () => ({
-  choicePreview: {
-    position: 'relative',
-    overflow: 'auto',
-  },
-  delete: {
-    position: 'absolute',
-    right: 0,
-    top: 0,
-  },
-  breakWord: {
-    maxWidth: '90%',
-    wordBreak: 'break-all',
-  },
-  customColor: {
-    color: `${color.tertiary()} !important`,
-  },
-  overflowChoice: {
-    overflow: 'auto',
-  },
-});
-export default withStyles(styles)(ChoicePreview);
+
+export default ChoicePreview;

--- a/packages/categorize/configure/src/design/categories/droppable-placeholder.jsx
+++ b/packages/categorize/configure/src/design/categories/droppable-placeholder.jsx
@@ -1,39 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import ChoicePreview from './choice-preview';
-import { DropTarget } from 'react-dnd';
+import { useDroppable } from '@dnd-kit/core';
 import { uid, PlaceHolder } from '@pie-lib/drag';
 import debug from 'debug';
 
 const log = debug('@pie-element:categorize:configure');
 
-const Helper = withStyles((theme) => ({
-  helper: {
-    display: 'flex',
-    alignItems: 'center',
-    fontSize: theme.typography.fontSize - 2,
-    color: `rgba(${theme.palette.common.black}, 0.4)`,
-    width: '100%',
-    height: '100%',
-  },
-}))(({ classes }) => <div className={classes.helper}>Drag your correct answers here</div>);
+const HelperText = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: theme.typography.fontSize - 2,
+  color: `rgba(${theme.palette.common.black}, 0.4)`,
+  width: '100%',
+  height: '100%',
+}));
+
+const Helper = () => <HelperText>Drag your correct answers here</HelperText>;
+
+const DroppablePlaceholderContainer = styled('div')({
+  minHeight: '100px',
+});
 
 const Previews = ({ alternateResponseIndex, category, choices, onDeleteChoice }) => (
   <React.Fragment>
-    {choices.map(
-      (c, index) =>
-        c && (
-          <ChoicePreview
-            alternateResponseIndex={alternateResponseIndex}
-            category={category}
-            choice={c}
-            key={index}
-            choiceIndex={index}
-            onDelete={(choice) => onDeleteChoice(choice, index)}
-          />
-        ),
+    {(choices || []).map((c, index) =>
+      c && (
+        <ChoicePreview
+          alternateResponseIndex={alternateResponseIndex}
+          category={category}
+          choice={c}
+          key={index}
+          choiceIndex={index}
+          onDelete={(choice) => onDeleteChoice(choice, index)}
+        />
+      )
     )}
   </React.Fragment>
 );
@@ -45,29 +47,36 @@ Previews.propTypes = {
   onDeleteChoice: PropTypes.func,
 };
 
-export class DroppablePlaceHolder extends React.Component {
-  static propTypes = {
-    alternateResponseIndex: PropTypes.number,
-    category: PropTypes.object,
-    classes: PropTypes.object.isRequired,
-    className: PropTypes.string,
-    connectDropTarget: PropTypes.func.isRequired,
-    choices: PropTypes.array,
-    onDropChoice: PropTypes.func.isRequired,
-    onMoveChoice: PropTypes.func,
-    isOver: PropTypes.bool,
-    onDeleteChoice: PropTypes.func,
-    categoryId: PropTypes.string.isRequired,
-  };
+const DroppablePlaceHolder = ({
+  alternateResponseIndex,
+  category,
+  className,
+  choices,
+  onDeleteChoice,
+  categoryId,
+  isAlternate
+}) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `${categoryId}-${isAlternate ? 'alternate' : 'standard'}`,
+    data: {
+      accepts: ['choice', 'choice-preview'],
+      alternateResponseIndex,
+      categoryId,
+      type: isAlternate ? 'category-alternate' : 'category',
+      id: categoryId,
+    },
+  });
 
-  static defaultProps = {};
-  render() {
-    const { alternateResponseIndex, isOver, category, choices, classes, className, connectDropTarget, onDeleteChoice } =
-      this.props;
-
-    return connectDropTarget(
-      <div className={classNames(classes.droppablePlaceholder, className)}>
-        <PlaceHolder isOver={isOver} className={classes.placeHolder}>
+  return (
+    <div ref={setNodeRef} className={className}>
+      <DroppablePlaceholderContainer>
+        <PlaceHolder
+          isOver={isOver}
+          extraStyles={{
+            width: '100%',
+            minHeight: '100px',
+            height: 'auto',
+          }}>
           {(choices || []).length === 0 ? (
             <Helper />
           ) : (
@@ -79,47 +88,19 @@ export class DroppablePlaceHolder extends React.Component {
             />
           )}
         </PlaceHolder>
-      </div>,
-    );
-  }
-}
-const styles = () => ({
-  droppablePlaceholder: {
-    minHeight: '100px',
-  },
-  placeHolder: {
-    width: '100%',
-    minHeight: '100px',
-    height: 'auto',
-  },
-});
-
-const Styled = withStyles(styles)(DroppablePlaceHolder);
-
-export const spec = {
-  drop: (props, monitor) => {
-    log('[drop] props: ', props);
-    const item = monitor.getItem();
-
-    if (item.from && item.alternateResponseIndex === props.alternateResponseIndex) {
-      props.onMoveChoice(item.choiceId, item.from, props.categoryId, item.choiceIndex, item.alternateResponseIndex);
-    } else if (!item.from) {
-      // avoid dropping choice when user tries to move it to an alternate with other index
-      props.onDropChoice(item, props.categoryId);
-    }
-  },
-  canDrop: (props /*, monitor*/) => {
-    return !props.disabled;
-  },
+      </DroppablePlaceholderContainer>
+    </div>
+  );
 };
 
-const WithTarget = DropTarget(
-  ({ uid }) => uid,
-  spec,
-  (connect, monitor) => ({
-    connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver(),
-  }),
-)(Styled);
+DroppablePlaceHolder.propTypes = {
+  alternateResponseIndex: PropTypes.number,
+  category: PropTypes.object,
+  className: PropTypes.string,
+  choices: PropTypes.array,
+  onDeleteChoice: PropTypes.func,
+  categoryId: PropTypes.string.isRequired,
+  isAlternate: PropTypes.bool,
+};
 
-export default uid.withUid(WithTarget);
+export default uid.withUid(DroppablePlaceHolder);

--- a/packages/categorize/configure/src/design/choices/choice.jsx
+++ b/packages/categorize/configure/src/design/choices/choice.jsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import InputHeader from '../input-header';
 import { Checkbox } from '@pie-lib/config-ui';
 import { DeleteButton } from '../buttons';
 import DragHandle from '@mui/icons-material/DragHandle';
-import { DragSource, DropTarget } from 'react-dnd';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
 import debug from 'debug';
 import { uid } from '@pie-lib/drag';
 import { multiplePlacements } from '../../utils';
-import flow from 'lodash/flow';
 
 const log = debug('@pie-element:categorize:configure:choice');
 
@@ -28,48 +26,84 @@ const canDrag = (props) => {
   }
 };
 
-export class Choice extends React.Component {
-  static propTypes = {
-    allowMultiplePlacements: PropTypes.string,
-    classes: PropTypes.object.isRequired,
-    className: PropTypes.string,
-    configuration: PropTypes.object.isRequired,
-    choice: PropTypes.object.isRequired,
-    connectDropTarget: PropTypes.func,
-    deleteFocusedEl: PropTypes.func,
-    focusedEl: PropTypes.number,
-    index: PropTypes.number,
-    lockChoiceOrder: PropTypes.bool,
-    maxImageHeight: PropTypes.object,
-    maxImageWidth: PropTypes.object,
-    onChange: PropTypes.func.isRequired,
-    onDelete: PropTypes.func.isRequired,
-    connectDragSource: PropTypes.func.isRequired,
-    connectDragPreview: PropTypes.func.isRequired,
-    correctResponseCount: PropTypes.number.isRequired,
-    imageSupport: PropTypes.shape({
-      add: PropTypes.func.isRequired,
-      delete: PropTypes.func.isRequired,
-    }),
-    toolbarOpts: PropTypes.object,
-    error: PropTypes.string,
-    uploadSoundSupport: PropTypes.shape({
-      add: PropTypes.func.isRequired,
-      delete: PropTypes.func.isRequired,
-    }),
-    spellCheck: PropTypes.bool,
-  };
+const StyledCard = styled(Card)(({ theme }) => ({
+  minWidth: '196px',
+  padding: theme.spacing(1),
+  overflow: 'visible',
+}));
 
-  static defaultProps = {};
+const StyledCardActions = styled(CardActions)({
+  padding: 0,
+  justifyContent: 'space-between',
+});
 
-  changeContent = (content) => {
-    const { onChange, choice } = this.props;
+const DragHandleContainer = styled('span', {
+  shouldForwardProp: (prop) => prop !== 'draggable',
+})(({ draggable }) => ({
+  cursor: draggable ? 'move' : 'inherit',
+}));
+
+const ErrorText = styled('div')(({ theme }) => ({
+  fontSize: theme.typography.fontSize - 2,
+  color: theme.palette.error.main,
+  paddingBottom: theme.spacing(1),
+}));
+
+const Choice = ({
+  allowMultiplePlacements,
+  className,
+  configuration,
+  choice,
+  deleteFocusedEl,
+  focusedEl,
+  index,
+  onDelete,
+  onChange,
+  correctResponseCount,
+  lockChoiceOrder,
+  imageSupport,
+  spellCheck,
+  toolbarOpts,
+  error,
+  maxImageWidth,
+  maxImageHeight,
+  uploadSoundSupport,
+}) => {
+  const draggable = canDrag({ choice, correctResponseCount, lockChoiceOrder });
+  
+  const {
+    attributes: dragAttributes,
+    listeners: dragListeners,
+    setNodeRef: setDragNodeRef,
+    isDragging,
+  } = useDraggable({
+    id: `choice-${choice.id}`,
+    data: {
+      id: choice.id,
+      index,
+      type: 'choice',
+    },
+    disabled: !draggable,
+  });
+
+  const {
+    setNodeRef: setDropNodeRef,
+    isOver,
+  } = useDroppable({
+    id: `choice-drop-${choice.id}`,
+    data: {
+      id: choice.id,
+      index,
+      type: 'choice',
+    },
+  });
+
+  const changeContent = (content) => {
     choice.content = content;
     onChange(choice);
   };
 
-  changeCategoryCount = () => {
-    const { onChange, choice } = this.props;
+  const changeCategoryCount = () => {
     if (choice.categoryCount === 1) {
       choice.categoryCount = 0;
     } else {
@@ -78,158 +112,83 @@ export class Choice extends React.Component {
     onChange(choice);
   };
 
-  isCheckboxShown = (allowMultiplePlacements) => allowMultiplePlacements === multiplePlacements.perChoice;
+  const isCheckboxShown = (allowMultiplePlacements) => allowMultiplePlacements === multiplePlacements.perChoice;
 
-  render() {
-    const {
-      allowMultiplePlacements,
-      classes,
-      className,
-      configuration,
-      choice,
-      deleteFocusedEl,
-      focusedEl,
-      index,
-      onDelete,
-      connectDropTarget,
-      connectDragSource,
-      connectDragPreview,
-      imageSupport,
-      spellCheck,
-      toolbarOpts,
-      error,
-      maxImageWidth,
-      maxImageHeight,
-      uploadSoundSupport,
-    } = this.props;
+  const showRemoveAfterPlacing = isCheckboxShown(allowMultiplePlacements);
 
-    const showRemoveAfterPlacing = this.isCheckboxShown(allowMultiplePlacements);
-    const draggable = canDrag(this.props);
+  // Combine refs for both drag and drop
+  const setNodeRef = (element) => {
+    setDragNodeRef(element);
+    setDropNodeRef(element);
+  };
 
-    return (
-      <Card className={classNames(classes.choice, className)}>
-        <CardActions className={classes.actions}>
-          {connectDragSource(
-            connectDropTarget(
-              <span className={classNames(classes.dragHandle, draggable === false && classes.dragDisabled)}>
-                <DragHandle color={draggable ? 'primary' : 'disabled'} />
-              </span>,
-            ),
-          )}
-        </CardActions>
-        {connectDragPreview(
-          <span>
-            <InputHeader
-              imageSupport={imageSupport}
-              focusedEl={focusedEl}
-              deleteFocusedEl={deleteFocusedEl}
-              index={index}
-              label={choice.content}
-              onChange={this.changeContent}
-              onDelete={onDelete}
-              toolbarOpts={toolbarOpts}
-              spellCheck={spellCheck}
-              error={error}
-              maxImageWidth={maxImageWidth}
-              maxImageHeight={maxImageHeight}
-              uploadSoundSupport={uploadSoundSupport}
-              configuration={configuration}
-            />
-            {error && <div className={classes.errorText}>{error}</div>}
-          </span>,
+  return (
+    <StyledCard ref={setNodeRef} className={className} style={{ opacity: isDragging ? 0.5 : 1 }}>
+      <StyledCardActions>
+        <DragHandleContainer draggable={draggable} {...dragAttributes} {...dragListeners}>
+          <DragHandle color={draggable ? 'primary' : 'disabled'} />
+        </DragHandleContainer>
+      </StyledCardActions>
+      
+      <InputHeader
+        imageSupport={imageSupport}
+        focusedEl={focusedEl}
+        deleteFocusedEl={deleteFocusedEl}
+        index={index}
+        label={choice.content}
+        onChange={changeContent}
+        onDelete={onDelete}
+        toolbarOpts={toolbarOpts}
+        spellCheck={spellCheck}
+        error={error}
+        maxImageWidth={maxImageWidth}
+        maxImageHeight={maxImageHeight}
+        uploadSoundSupport={uploadSoundSupport}
+        configuration={configuration}
+      />
+      {error && <ErrorText>{error}</ErrorText>}
+
+      <StyledCardActions>
+        <DeleteButton label={'delete'} onClick={onDelete} />
+        {showRemoveAfterPlacing && (
+          <Checkbox
+            mini
+            label={'Remove after placing'}
+            checked={choice.categoryCount === 1}
+            onChange={changeCategoryCount}
+          />
         )}
-
-        <CardActions className={classes.actions}>
-          <DeleteButton label={'delete'} onClick={onDelete} />
-          {showRemoveAfterPlacing && (
-            <Checkbox
-              mini
-              label={'Remove after placing'}
-              checked={choice.categoryCount === 1}
-              onChange={this.changeCategoryCount}
-            />
-          )}
-        </CardActions>
-      </Card>
-    );
-  }
-}
-const styles = (theme) => ({
-  actions: {
-    padding: 0,
-    justifyContent: 'space-between',
-  },
-  choice: {
-    minWidth: '196px',
-    padding: theme.spacing.unit,
-    overflow: 'visible',
-  },
-  dragHandle: {
-    cursor: 'move',
-  },
-  dragDisabled: {
-    cursor: 'inherit',
-  },
-  errorText: {
-    fontSize: theme.typography.fontSize - 2,
-    color: theme.palette.error.main,
-    paddingBottom: theme.spacing.unit,
-  },
-});
-
-const StyledChoice = withStyles(styles)(Choice);
-
-export const spec = {
-  canDrag,
-  beginDrag: (props) => {
-    const out = {
-      id: props.choice.id,
-      index: props.index,
-    };
-    log('[beginDrag] out:', out);
-    return out;
-  },
-  endDrag: (props, monitor) => {
-    if (!monitor.didDrop()) {
-      const item = monitor.getItem();
-      if (item.categoryId) {
-        log('wasnt droppped - what to do?');
-        props.onRemoveChoice(item);
-      }
-    }
-  },
+      </StyledCardActions>
+    </StyledCard>
+  );
 };
 
-export const specTarget = {
-  drop: (props, monitor) => {
-    log('[drop] props: ', props);
-    const item = monitor.getItem();
-    props.rearrangeChoices(item.index, props.index);
-  },
-  canDrop: (props, monitor) => {
-    const item = monitor.getItem();
-    return props.choice.id !== item.id;
-  },
+Choice.propTypes = {
+  allowMultiplePlacements: PropTypes.string,
+  className: PropTypes.string,
+  configuration: PropTypes.object.isRequired,
+  choice: PropTypes.object.isRequired,
+  deleteFocusedEl: PropTypes.func,
+  focusedEl: PropTypes.number,
+  index: PropTypes.number,
+  lockChoiceOrder: PropTypes.bool,
+  maxImageHeight: PropTypes.object,
+  maxImageWidth: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  correctResponseCount: PropTypes.number.isRequired,
+  imageSupport: PropTypes.shape({
+    add: PropTypes.func.isRequired,
+    delete: PropTypes.func.isRequired,
+  }),
+  toolbarOpts: PropTypes.object,
+  error: PropTypes.string,
+  uploadSoundSupport: PropTypes.shape({
+    add: PropTypes.func.isRequired,
+    delete: PropTypes.func.isRequired,
+  }),
+  spellCheck: PropTypes.bool,
+  rearrangeChoices: PropTypes.func,
 };
 
-export default uid.withUid(
-  flow(
-    DragSource(
-      ({ uid }) => uid,
-      spec,
-      (connect, monitor) => ({
-        connectDragSource: connect.dragSource(),
-        connectDragPreview: connect.dragPreview(),
-        isDragging: monitor.isDragging(),
-      }),
-    ),
-    DropTarget(
-      ({ uid }) => uid,
-      specTarget,
-      (connect, monitor) => ({
-        connectDropTarget: connect.dropTarget(),
-        isOver: monitor.isOver(),
-      }),
-    ),
-  )(StyledChoice),
-);
+export default uid.withUid(Choice);

--- a/packages/categorize/configure/src/design/choices/config.jsx
+++ b/packages/categorize/configure/src/design/choices/config.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
+
+const ConfigContainer = styled('div')(({ theme }) => ({
+  paddingTop: theme.spacing(1),
+  marginBottom: theme.spacing(1),
+}));
+
+const StyledTextField = styled(TextField)({
+  width: '100%',
+});
 
 export class Config extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     config: PropTypes.object,
     onModelChanged: PropTypes.func,
@@ -14,18 +21,17 @@ export class Config extends React.Component {
   };
 
   static defaultProps = {};
-
+  
   changeLabel = ({ target }) => {
     this.props.onModelChanged({ choicesLabel: target.value });
   };
 
   render() {
-    const { classes, className, config, spellCheck } = this.props;
+    const { className, config, spellCheck } = this.props;
 
     return (
-      <div className={classNames(classes.config, className)}>
-        <TextField
-          className={classes.label}
+      <ConfigContainer className={className}>
+        <StyledTextField
           InputLabelProps={{
             shrink: true,
           }}
@@ -35,19 +41,9 @@ export class Config extends React.Component {
           onChange={this.changeLabel}
           spellCheck={spellCheck}
         />
-      </div>
+      </ConfigContainer>
     );
   }
 }
 
-const styles = (theme) => ({
-  config: {
-    paddingTop: theme.spacing.unit,
-    marginBottom: theme.spacing.unit,
-  },
-  label: {
-    width: '100%',
-  },
-});
-
-export default withStyles(styles)(Config);
+export default Config;

--- a/packages/categorize/configure/src/design/choices/index.jsx
+++ b/packages/categorize/configure/src/design/choices/index.jsx
@@ -1,19 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import Choice from './choice';
 import Header from '../header';
 import Config from './config';
 import { choiceUtils as utils } from '@pie-lib/config-ui';
 import { removeAllChoices } from '@pie-lib/categorize';
-import { rearrangeChoices } from '@pie-lib/categorize';
+
+const ChoicesContainer = styled('div')(({ theme }) => ({
+  marginBottom: theme.spacing(2.5),
+}));
+
+const ChoiceHolder = styled('div')(({ theme }) => ({
+  paddingTop: theme.spacing(1),
+  paddingBottom: theme.spacing(1),
+  display: 'grid',
+  gridRowGap: `${theme.spacing(1)}px`,
+  gridColumnGap: `${theme.spacing(1)}px`,
+}));
+
+const ErrorText = styled('div')(({ theme }) => ({
+  fontSize: theme.typography.fontSize - 2,
+  color: theme.palette.error.main,
+  paddingTop: theme.spacing(0.5),
+}));
 
 export class Choices extends React.Component {
   static propTypes = {
     model: PropTypes.object.isRequired,
     configuration: PropTypes.object.isRequired,
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     choices: PropTypes.array.isRequired,
     defaultImageMaxWidth: PropTypes.number,
@@ -91,17 +106,9 @@ export class Choices extends React.Component {
     }
   };
 
-  rearrangeChoices = (indexFrom, indexTo) => {
-    const { model, onModelChanged } = this.props || {};
-    let { choices } = model || [];
-    choices = rearrangeChoices(choices, indexFrom, indexTo);
-    onModelChanged({ choices });
-  };
-
   render() {
     const { focusedEl } = this.state;
     const {
-      classes,
       className,
       choices,
       model,
@@ -124,7 +131,7 @@ export class Choices extends React.Component {
       maxAnswerChoices && choices?.length >= maxAnswerChoices ? `Only ${maxAnswerChoices} allowed maximum` : '';
 
     return (
-      <div className={classNames(classes.choices, className)}>
+      <ChoicesContainer className={className}>
         <Header
           label="Choices"
           buttonLabel="ADD A CHOICE"
@@ -135,10 +142,11 @@ export class Choices extends React.Component {
 
         <Config config={model} onModelChanged={onModelChanged} spellCheck={spellCheck} />
 
-        <div className={classes.choiceHolder} style={choiceHolderStyle}>
+        <ChoiceHolder style={choiceHolderStyle}>
           {choices.map((h, index) => {
             return (
               <Choice
+                key={h.id}
                 choice={h}
                 focusedEl={focusedEl}
                 deleteFocusedEl={this.deleteFocusedEl}
@@ -146,11 +154,9 @@ export class Choices extends React.Component {
                 allowMultiplePlacements={allowMultiplePlacementsEnabled}
                 lockChoiceOrder={lockChoiceOrder}
                 index={index}
-                key={index}
                 imageSupport={imageSupport}
                 onChange={this.changeChoice}
                 onDelete={() => this.deleteChoice(h)}
-                rearrangeChoices={(indexFrom, indexTo) => this.rearrangeChoices(indexFrom, indexTo)}
                 toolbarOpts={toolbarOpts}
                 spellCheck={spellCheck}
                 error={choicesErrors && choicesErrors[h.id]}
@@ -161,29 +167,11 @@ export class Choices extends React.Component {
               />
             );
           })}
-        </div>
-        {choicesError && <div className={classes.errorText}>{choicesError}</div>}
-      </div>
+        </ChoiceHolder>
+        {choicesError && <ErrorText>{choicesError}</ErrorText>}
+      </ChoicesContainer>
     );
   }
 }
 
-const styles = (theme) => ({
-  choiceHolder: {
-    paddingTop: theme.spacing.unit,
-    paddingBottom: theme.spacing.unit,
-    display: 'grid',
-    gridRowGap: `${theme.spacing.unit}px`,
-    gridColumnGap: `${theme.spacing.unit}px`,
-  },
-  choices: {
-    marginBottom: theme.spacing.unit * 2.5,
-  },
-  errorText: {
-    fontSize: theme.typography.fontSize - 2,
-    color: theme.palette.error.main,
-    paddingTop: theme.spacing.unit / 2,
-  },
-});
-
-export default withStyles(styles)(Choices);
+export default Choices;

--- a/packages/categorize/configure/src/design/header.jsx
+++ b/packages/categorize/configure/src/design/header.jsx
@@ -2,13 +2,30 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import { AddButton } from './buttons';
+
+const HeaderContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'space-between',
+  marginBottom: theme.spacing(1),
+}));
+
+const TitleContainer = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+});
+
+const StyledTooltip = styled(Tooltip)(({ theme }) => ({
+  '& .MuiTooltip-tooltip': {
+    fontSize: theme.typography.fontSize - 2,
+    whiteSpace: 'pre',
+    maxWidth: '500px',
+  },
+}));
 
 export class Header extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     buttonLabel: PropTypes.string,
     onAdd: PropTypes.func.isRequired,
@@ -22,43 +39,27 @@ export class Header extends React.Component {
   static defaultProps = {};
 
   render() {
-    const { classes, className, onAdd, label, buttonLabel, info, buttonDisabled, variant, tooltip } = this.props;
+    const { className, onAdd, label, buttonLabel, info, buttonDisabled, variant, tooltip } = this.props;
     return (
-      <div className={classNames(classes.header, className)}>
-        <div className={classes.titleContainer}>
-          <Typography variant={variant || 'title'} className={classes.title}>
+      <HeaderContainer className={className}>
+        <TitleContainer>
+          <Typography variant={variant || 'title'}>
             {label}
           </Typography>
           {info}
-        </div>
-        <Tooltip
+        </TitleContainer>
+        <StyledTooltip
             title={tooltip || ''}
-            classes={{ tooltip: classes.tooltip }}
             enterTouchDelay={50} // Appear quickly after a touch
             leaveTouchDelay={3000} // Stay visible for 3 seconds
         >
           <span>
             <AddButton onClick={onAdd} label={buttonLabel} disabled={buttonDisabled} />
           </span>
-        </Tooltip>
-      </div>
+        </StyledTooltip>
+      </HeaderContainer>
     );
   }
 }
-const styles = (theme) => ({
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    marginBottom: theme.spacing.unit,
-  },
-  titleContainer: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  tooltip: {
-    fontSize: theme.typography.fontSize - 2,
-    whiteSpace: 'pre',
-    maxWidth: '500px',
-  },
-});
-export default withStyles(styles)(Header);
+
+export default Header;

--- a/packages/categorize/configure/src/design/input-header.jsx
+++ b/packages/categorize/configure/src/design/input-header.jsx
@@ -1,13 +1,22 @@
 import { getPluginProps } from './utils';
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import EditableHtml from '@pie-lib/editable-html';
+
+const StyledEditableHtml = styled(EditableHtml)(({ theme }) => ({
+  flex: '1',
+  paddingBottom: theme.spacing(1),
+  maxWidth: '100%',
+}));
+
+const InputHeaderContainer = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+});
 
 export class InputHeader extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     configuration: PropTypes.object.isRequired,
     deleteFocusedEl: PropTypes.func,
@@ -50,7 +59,6 @@ export class InputHeader extends React.Component {
       onChange,
       configuration,
       label,
-      classes,
       className,
       deleteFocusedEl,
       disabled,
@@ -67,8 +75,8 @@ export class InputHeader extends React.Component {
     const { headers, baseInputConfiguration } = configuration;
 
     return (
-      <div className={classNames(classes.inputHeader, className)}>
-        <EditableHtml
+      <InputHeaderContainer className={className}>
+        <StyledEditableHtml
           imageSupport={imageSupport}
           disabled={disabled}
           ref={(ref) => (this.inputRef = ref)}
@@ -76,7 +84,6 @@ export class InputHeader extends React.Component {
           label={'label'}
           markup={label}
           onChange={onChange}
-          className={classes.editor}
           pluginProps={getPluginProps(headers?.inputConfiguration, baseInputConfiguration)}
           toolbarOpts={toolbarOpts}
           spellCheck={spellCheck}
@@ -90,23 +97,9 @@ export class InputHeader extends React.Component {
           }}
           mathMlOptions={mathMlOptions}
         />
-      </div>
+      </InputHeaderContainer>
     );
   }
 }
-const styles = (theme) => ({
-  editor: {
-    flex: '1',
-    paddingBottom: theme.spacing.unit,
-    maxWidth: '100%',
-  },
-  iconButtonRoot: {
-    width: 'auto',
-    height: 'auto',
-  },
-  inputHeader: {
-    display: 'flex',
-    justifyContent: 'space-between',
-  },
-});
-export default withStyles(styles)(InputHeader);
+
+export default InputHeader;

--- a/packages/categorize/configure/src/main.jsx
+++ b/packages/categorize/configure/src/main.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
 import Design from './design';
 
 export class Main extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     configuration: PropTypes.object,
     className: PropTypes.string,
     onConfigurationChanged: PropTypes.func,
@@ -34,6 +32,5 @@ export class Main extends React.Component {
     );
   }
 }
-const styles = () => ({});
 
-export default withStyles(styles)(Main);
+export default Main;

--- a/packages/categorize/package.json
+++ b/packages/categorize/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.6.1",
     "react": "18.2.0",
-    "react-dnd": "^14.0.5",
+    "@dnd-kit/core": "6.1.0",
     "react-dom": "18.2.0"
   },
   "gitHead": "0e14ff981bcdc8a89a0e58484026496701bfdbc3",

--- a/packages/categorize/src/categorize/categories.jsx
+++ b/packages/categorize/src/categorize/categories.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { styled } from '@mui/material/styles';
 import { color } from '@pie-lib/render-ui';
 
 import GridContent from './grid-content';
@@ -10,7 +10,6 @@ export { CategoryType };
 
 export class Categories extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     categories: PropTypes.arrayOf(PropTypes.shape(CategoryType)),
     model: PropTypes.shape({
       categoriesPerRow: PropTypes.number,
@@ -28,7 +27,7 @@ export class Categories extends React.Component {
   };
 
   render() {
-    const { classes, categories, model, disabled, onDropChoice, onRemoveChoice, rowLabels } = this.props;
+    const { categories, model, disabled, onDropChoice, onRemoveChoice, rowLabels } = this.props;
     const { categoriesPerRow, minRowHeight } = model;
 
     // split categories into an array of arrays (inner array),
@@ -54,8 +53,8 @@ export class Categories extends React.Component {
     return (
       <GridContent
         columns={categoriesPerRow}
-        className={classes.categories}
         rows={Math.ceil(categories.length / categoriesPerRow) * 2}
+        extraStyle={{ flex: 1 }}
       >
         {chunkedCategories.map((cat, rowIndex) => {
           let items = [];
@@ -66,17 +65,15 @@ export class Categories extends React.Component {
             items.push(
               <div style={{ display: 'flex' }}>
                 {columnIndex === 0 && hasNonEmptyString(rowLabels) ? (
-                  <div
+                  <StyledRowLabel
                     key={rowIndex}
-                    className={classes.rowLabel}
                     dangerouslySetInnerHTML={{
                       __html: rowLabels[rowIndex] || '',
                     }}
                   />
                 ) : null}
-                <div className={classes.categoryWrapper}>
-                  <div
-                    className={classes.label}
+                <StyledCategoryWrapper>
+                  <StyledLabel
                     key={`category-label-${rowIndex}-${columnIndex}`}
                     dangerouslySetInnerHTML={{ __html: c.label }}
                   />
@@ -86,11 +83,10 @@ export class Categories extends React.Component {
                     onDropChoice={(h) => onDropChoice(c.id, h)}
                     onRemoveChoice={onRemoveChoice}
                     disabled={disabled}
-                    className={classes.category}
                     key={`category-element-${rowIndex}-${columnIndex}`}
                     {...c}
                   />
-                </div>
+                </StyledCategoryWrapper>
               </div>,
             );
           });
@@ -109,27 +105,25 @@ export class Categories extends React.Component {
   }
 }
 
-const styles = (theme) => ({
-  categories: {
-    flex: 1,
-  },
-  label: {
-    color: color.text(),
-    backgroundColor: color.background(),
-    textAlign: 'center',
-    paddingTop: theme.spacing.unit,
-  },
-  rowLabel: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'center',
-    flex: 0.5,
-    marginRight: '12px',
-  },
-  categoryWrapper: {
-    display: 'flex',
-    flex: '2',
-    flexDirection: 'column',
-  },
-});
-export default withStyles(styles)(Categories);
+const StyledLabel = styled('div')(({ theme }) => ({
+  color: color.text(),
+  backgroundColor: color.background(),
+  textAlign: 'center',
+  paddingTop: theme.spacing(1),
+}));
+
+const StyledRowLabel = styled('div')(({ theme }) => ({
+  alignItems: 'center',
+  display: 'flex',
+  justifyContent: 'center',
+  flex: 0.5,
+  marginRight: '12px',
+}));
+
+const StyledCategoryWrapper = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flex: '2',
+  flexDirection: 'column',
+}));
+
+export default Categories;

--- a/packages/categorize/src/categorize/category.jsx
+++ b/packages/categorize/src/categorize/category.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 import Choice from './choice';
 import PlaceHolder from './droppable-placeholder';
 import { color } from '@pie-lib/render-ui';
@@ -16,7 +15,6 @@ export class Category extends React.Component {
     ...CategoryType,
     className: PropTypes.string,
     disabled: PropTypes.bool,
-    classes: PropTypes.object.isRequired,
     onDropChoice: PropTypes.func,
     onRemoveChoice: PropTypes.func,
     minRowHeight: PropTypes.string,
@@ -26,7 +24,6 @@ export class Category extends React.Component {
 
   render() {
     const {
-      classes,
       className,
       choices = [],
       disabled,
@@ -37,19 +34,13 @@ export class Category extends React.Component {
       minRowHeight,
     } = this.props;
 
-    const names = classNames(classes.category, className);
-    const placeholderNames = classNames(
-      classes.placeholder,
-      correct === false && classes.incorrect,
-      correct === true && classes.correct,
-    );
-
     return (
-      <div className={names}>
-        <PlaceHolder
+      <StyledDiv className={className} id={id}>
+        <StyledPlaceHolder
+          id={id}
           onDropChoice={onDropChoice}
           disabled={disabled}
-          className={placeholderNames}
+          correct={correct}
           minRowHeight={minRowHeight}
         >
           {choices.map((c, index) => (
@@ -62,35 +53,36 @@ export class Category extends React.Component {
               {...c}
             />
           ))}
-        </PlaceHolder>
-      </div>
+        </StyledPlaceHolder>
+      </StyledDiv>
     );
   }
 }
 
-const styles = (theme) => ({
-  incorrect: {
-    border: `solid 2px ${color.incorrect()}`,
-  },
-  correct: {
-    border: `solid 2px ${color.correct()}`,
-  },
-  placeholder: {
-    padding: theme.spacing.unit / 2,
-    borderRadius: theme.spacing.unit / 2,
-    gridColumnGap: 0,
-    gridRowGap: 0,
-    display: 'flex',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    alignItems: 'center',
-    alignContent: 'flex-start',
-  },
-  category: {
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 2,
-  },
-});
+const StyledDiv = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 2,
+}));
 
-export default withStyles(styles)(Category);
+const StyledPlaceHolder = styled(PlaceHolder, {
+  shouldForwardProp: (prop) => prop !== 'correct',
+})(({ theme, correct }) => ({
+  padding: theme.spacing(0.5),
+  borderRadius: theme.spacing(0.5),
+  gridColumnGap: 0,
+  gridRowGap: 0,
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  alignItems: 'center',
+  alignContent: 'flex-start',
+  ...(correct === false && {
+    border: `solid 2px ${color.incorrect()}`,
+  }),
+  ...(correct === true && {
+    border: `solid 2px ${color.correct()}`,
+  }),
+}));
+
+export default Category;

--- a/packages/categorize/src/categorize/choice.jsx
+++ b/packages/categorize/src/categorize/choice.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
-import { DragSource } from 'react-dnd';
+import { styled } from '@mui/material/styles';
+import { useDraggable } from '@dnd-kit/core';
 import { uid } from '@pie-lib/drag';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -16,142 +15,110 @@ export const ChoiceType = {
   id: PropTypes.string,
 };
 
+const ChoiceContainer = styled('div', {
+  shouldForwardProp: (prop) => !['isDragging', 'disabled', 'correct'].includes(prop),
+})(({ isDragging, disabled, correct }) => ({
+  direction: 'initial',
+  cursor: disabled ? 'not-allowed' : isDragging ? 'move' : 'pointer',
+  width: '100%',
+  borderRadius: '6px',
+  ...(correct === true && {
+    border: `solid 2px ${color.correct()}`,
+  }),
+  ...(correct === false && {
+    border: `solid 2px ${color.incorrect()}`,
+  }),
+}));
+
+const StyledCard = styled(Card)({
+  color: color.text(),
+  backgroundColor: color.background(),
+  width: '100%',
+});
+
+const StyledCardContent = styled(CardContent)(({ theme }) => ({
+  color: color.text(),
+  backgroundColor: color.white(),
+  '&:last-child': {
+    paddingBottom: theme.spacing(2),
+  },
+  borderRadius: '4px',
+  border: '1px solid',
+}));
+
 export class Layout extends React.Component {
   static propTypes = {
     ...ChoiceType,
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     disabled: PropTypes.bool,
     correct: PropTypes.bool,
+    isDragging: PropTypes.bool
   };
   static defaultProps = {};
   render() {
-    const { classes, className, content, isDragging, disabled, correct } = this.props;
+    const { className, content, isDragging, disabled, correct } = this.props;
 
-    const rootNames = classNames(
-      correct === true && 'correct',
-      correct === false && 'incorrect',
-      classes.choice,
-      isDragging && classes.dragging,
-      disabled && classes.disabled,
-      className,
-    );
-    const cardNames = classNames(classes.card);
     return (
-      <div className={rootNames}>
-        <Card className={cardNames}>
-          <CardContent classes={{ root: classes.cardRoot }} dangerouslySetInnerHTML={{ __html: content }} />
-        </Card>
-      </div>
+      <ChoiceContainer
+        className={className}
+        isDragging={isDragging}
+        disabled={disabled}
+        correct={correct}
+      >
+        <StyledCard>
+          <StyledCardContent dangerouslySetInnerHTML={{ __html: content }} />
+        </StyledCard>
+      </ChoiceContainer>
     );
   }
 }
 
-const styles = (theme) => ({
-  choice: {
-    direction: 'initial',
-    cursor: 'pointer',
-    width: '100%',
-    '&.correct': {
-      border: `solid 2px ${color.correct()}`,
-    },
-    '&.incorrect': {
-      border: `solid 2px ${color.incorrect()}`,
-    },
-    borderRadius: '6px',
-  },
-  cardRoot: {
-    color: color.text(),
-    backgroundColor: color.white(),
-    '&:last-child': {
-      paddingBottom: theme.spacing.unit * 2,
-    },
-    borderRadius: '4px',
-    border: '1px solid',
-  },
-  disabled: {
-    cursor: 'not-allowed',
-  },
-  dragging: {
-    cursor: 'move',
-  },
-  card: {
-    color: color.text(),
-    backgroundColor: color.background(),
-    width: '100%',
-    // Added for touch devices, for image content.
-    // This will prevent the context menu from appearing and not allowing other interactions with the image.
-    pointerEvents: 'none',
-  },
-});
-
-const Styled = withStyles(styles)(Layout);
-
-export class Choice extends React.Component {
-  static propTypes = {
-    ...ChoiceType,
-    extraStyle: PropTypes.object,
-    connectDragSource: PropTypes.func.isRequired,
-  };
-
-  componentDidMount() {
-    if (this.ref) {
-      this.ref.addEventListener('touchstart', this.handleTouchStart, { passive: false });
-    }
-  }
-
-  componentWillUnmount() {
-    if (this.ref) {
-      this.ref.removeEventListener('touchstart', this.handleTouchStart);
-    }
-  }
-
-  handleTouchStart = (e) => {
-    e.preventDefault();
-  };
-
-  render() {
-    const { connectDragSource, id, content, disabled, isDragging, correct, extraStyle } = this.props;
-
-    return connectDragSource(
-      <div style={{ margin: '4px', ...extraStyle }} ref={(ref) => (this.ref = ref)} draggable={!disabled}>
-        <Styled id={id} content={content} disabled={disabled} correct={correct} isDragging={isDragging} />
-      </div>,
-    );
-  }
-}
-
-export const spec = {
-  canDrag: (props) => !props.disabled,
-  beginDrag: (props) => {
-    const out = {
-      id: props.id,
-      categoryId: props.categoryId,
-      choiceIndex: props.choiceIndex,
-      value: props.content,
+const DraggableChoice = ({
+  id,
+  content,
+  disabled,
+  correct,
+  extraStyle,
+  categoryId,
+  choiceIndex,
+}) => {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `choice-${id}`,
+    data: {
+      id,
+      categoryId,
+      choiceIndex,
+      value: content,
       itemType: 'categorize',
-    };
-    log('[beginDrag] out:', out);
-    return out;
-  },
-  endDrag: (props, monitor) => {
-    if (!monitor.didDrop()) {
-      const item = monitor.getItem();
-      if (item.categoryId) {
-        log('wasnt droppped - what to do?');
-        props.onRemoveChoice(item);
-      }
-    }
-  },
+      type: 'choice',
+    },
+    disabled,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ margin: '4px', ...extraStyle }}
+      {...listeners}
+      {...attributes}
+    >
+      <Layout
+        id={id}
+        content={content}
+        disabled={disabled}
+        correct={correct}
+        isDragging={isDragging}
+      />
+    </div>
+  );
 };
 
-const DraggableChoice = DragSource(
-  ({ uid }) => uid,
-  spec,
-  (connect, monitor) => ({
-    connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging(),
-  }),
-)(Choice);
+DraggableChoice.propTypes = {
+  ...ChoiceType,
+  extraStyle: PropTypes.object,
+  categoryId: PropTypes.string,
+  choiceIndex: PropTypes.number,
+  onRemoveChoice: PropTypes.func,
+};
 
 export default uid.withUid(DraggableChoice);

--- a/packages/categorize/src/categorize/choices.jsx
+++ b/packages/categorize/src/categorize/choices.jsx
@@ -1,15 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
+import { styled } from '@mui/material/styles';
 import Choice, { ChoiceType } from './choice';
 import DroppablePlaceholder from './droppable-placeholder';
 export { ChoiceType };
 
-const Blank = () => <div />;
+const Wrapper = styled('div')({
+  flex: 1,
+  touchAction: 'none',
+});
+
+const LabelHolder = styled('div')(({ theme }) => ({
+  margin: '0 auto',
+  textAlign: 'center',
+  paddingTop: theme.spacing(1),
+}));
 
 export class Choices extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     choices: PropTypes.arrayOf(
       PropTypes.oneOfType([PropTypes.shape(ChoiceType), PropTypes.shape({ empty: PropTypes.bool })]),
     ),
@@ -31,7 +39,7 @@ export class Choices extends React.Component {
   };
 
   render() {
-    const { classes, choices = [], model, disabled, onDropChoice, onRemoveChoice, choicePosition } = this.props;
+    const { choices = [], model, disabled, onDropChoice, onRemoveChoice, choicePosition } = this.props;
 
     let style = {
       textAlign: 'center',
@@ -42,8 +50,9 @@ export class Choices extends React.Component {
     }
 
     return (
-      <div className={classes.wrapper}>
+      <Wrapper>
         <DroppablePlaceholder
+          id="choices-board"
           onDropChoice={onDropChoice}
           onRemoveChoice={onRemoveChoice}
           disabled={disabled}
@@ -51,15 +60,14 @@ export class Choices extends React.Component {
           choiceBoard={true}
         >
           {model.choicesLabel && model.choicesLabel !== '' && (
-            <div className={classes.labelHolder} dangerouslySetInnerHTML={{ __html: model.choicesLabel }}></div>
+            <LabelHolder dangerouslySetInnerHTML={{ __html: model.choicesLabel }} />
           )}
           {choices.map((c, index) => {
             return c.empty ? (
-              <Blank key={index} />
+              <div key={index} />
             ) : (
               <Choice
                 disabled={disabled}
-                className={classes.choice}
                 key={index}
                 extraStyle={{ maxWidth: `${95 / model.categoriesPerRow}%` }}
                 {...c}
@@ -67,27 +75,9 @@ export class Choices extends React.Component {
             );
           })}
         </DroppablePlaceholder>
-      </div>
+      </Wrapper>
     );
   }
 }
 
-const styles = (theme) => ({
-  wrapper: {
-    flex: 1,
-    touchAction: 'none',
-  },
-  choices: {
-    padding: theme.spacing.unit / 2,
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  labelHolder: {
-    margin: '0 auto',
-    textAlign: 'center',
-    paddingTop: theme.spacing.unit,
-  },
-});
-
-export default withStyles(styles)(Choices);
+export default Choices;

--- a/packages/categorize/src/categorize/droppable-placeholder.jsx
+++ b/packages/categorize/src/categorize/droppable-placeholder.jsx
@@ -1,61 +1,61 @@
 import React from 'react';
-import { PlaceHolder } from '@pie-lib/drag';
 import PropTypes from 'prop-types';
-import { DropTarget } from 'react-dnd';
-import { uid } from '@pie-lib/drag';
 import debug from 'debug';
+import { useDroppable } from '@dnd-kit/core';
+import { PlaceHolder } from '@pie-lib/drag';
 
 const log = debug('@pie-ui:categorize:droppable-placeholder');
 
-export class DroppablePlaceholder extends React.Component {
-  static propTypes = {
-    choiceBoard: PropTypes.bool,
-    connectDropTarget: PropTypes.func.isRequired,
-    isOver: PropTypes.bool,
-    children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
-    className: PropTypes.string,
-    grid: PropTypes.object,
-    disabled: PropTypes.bool,
-    minRowHeight: PropTypes.string,
-  };
-  render() {
-    const { children, connectDropTarget, isOver, className, grid, disabled, choiceBoard, minRowHeight } = this.props;
+const DroppablePlaceholder = ({
+  children,
+  className,
+  grid,
+  disabled,
+  choiceBoard,
+  minRowHeight,
+  id
+}) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id,
+    data: {
+      itemType: 'categorize',
+      categoryId: id
+    },
+    disabled,
+  });
 
-    return connectDropTarget(
-      <div style={{ flex: 1, minHeight: minRowHeight || '80px' }}>
-        <PlaceHolder
-          className={className}
-          isOver={isOver}
-          grid={grid}
-          disabled={disabled}
-          choiceBoard={choiceBoard}
-          isCategorize
-        >
-          {children}
-        </PlaceHolder>
-      </div>,
-    );
-  }
-}
-
-export const spec = {
-  drop: (props, monitor) => {
-    log('[drop] props: ', props);
-    const item = monitor.getItem();
-    props.onDropChoice(item);
-  },
-  canDrop: (props /*, monitor*/) => {
-    return !props.disabled;
-  },
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        flex: 1,
+        minHeight: minRowHeight || '80px',
+        position: 'relative'
+      }}
+    >
+      <PlaceHolder
+        className={className}
+        isOver={isOver}
+        grid={grid}
+        disabled={disabled}
+        choiceBoard={choiceBoard}
+        isCategorize
+      >
+        {children}
+      </PlaceHolder>
+    </div>
+  );
 };
 
-const WithTarget = DropTarget(
-  ({ uid }) => uid,
-  spec,
-  (connect, monitor) => ({
-    connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver(),
-  }),
-)(DroppablePlaceholder);
+DroppablePlaceholder.propTypes = {
+  choiceBoard: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  grid: PropTypes.object,
+  disabled: PropTypes.bool,
+  minRowHeight: PropTypes.string,
+  onDropChoice: PropTypes.func,
+  id: PropTypes.string.isRequired
+};
 
-export default uid.withUid(WithTarget);
+export default DroppablePlaceholder;

--- a/packages/categorize/src/categorize/grid-content.jsx
+++ b/packages/categorize/src/categorize/grid-content.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import withStyles from '@mui/styles/withStyles';
-import classNames from 'classnames';
+import { styled } from '@mui/material/styles';
 
 export class GridContent extends React.Component {
   static propTypes = {
-    classes: PropTypes.object.isRequired,
     className: PropTypes.string,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
     columns: PropTypes.number,
@@ -18,7 +16,7 @@ export class GridContent extends React.Component {
   };
 
   render() {
-    const { classes, className, children, columns, extraStyle, rows } = this.props;
+    const { className, children, columns, extraStyle, rows } = this.props;
     const style = {
       gridTemplateColumns: `repeat(${columns}, 1fr)`,
       gridTemplateRows: rows === 2 ? 'auto 1fr' : `repeat(${rows}, auto)`,
@@ -26,22 +24,20 @@ export class GridContent extends React.Component {
     };
 
     return (
-      <div style={style} className={classNames(classes.gridContent, className)}>
+      <StyledDiv style={style} className={className}>
         {children}
-      </div>
+      </StyledDiv>
     );
   }
 }
 
-const styles = (theme) => ({
-  gridContent: {
-    display: 'grid',
-    columnGap: `${theme.spacing.unit}px`,
-    gridColumnGap: `${theme.spacing.unit}px`,
-    rowGap: `${theme.spacing.unit}px`,
-    gridRowGap: `${theme.spacing.unit}px`,
-    gridAutoRows: '1fr',
-  },
-});
+const StyledDiv = styled('div')(({ theme }) => ({
+  display: 'grid',
+  columnGap: theme.spacing(1),
+  gridColumnGap: theme.spacing(1),
+  rowGap: theme.spacing(1),
+  gridRowGap: theme.spacing(1),
+  gridAutoRows: '1fr',
+}));
 
-export default withStyles(styles)(GridContent);
+export default GridContent;


### PR DESCRIPTION
…react-dnd with @dnd-kit/core

- Updated InputHeader, Main, Categories, Category, Choice, Choices, DroppablePlaceholder, GridContent, and Categorize components to use MUI's styled API instead of withStyles.
- Removed class-based styling and replaced with styled components for better readability and maintainability.
- Migrated drag-and-drop functionality from react-dnd to @dnd-kit/core for improved performance and flexibility.
- Cleaned up prop types by removing unnecessary classes and simplifying component structures.
- Enhanced the overall structure and organization of the codebase for better clarity and future scalability.