### PR TITLE
feat(categorize): fix math rendering after React 18 upgrade and optimize performance

### DIFF
--- a/packages/categorize/configure/src/design/categories/index.jsx
+++ b/packages/categorize/configure/src/design/categories/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import { choiceUtils as utils } from '@pie-lib/config-ui';
@@ -65,27 +64,17 @@ export class Categories extends React.Component {
     focusedEl: null,
   };
 
-  componentDidMount() {
-    try {
-      // eslint-disable-next-line react/no-find-dom-node
-      const domNode = ReactDOM.findDOMNode(this);
+  containerRef = React.createRef();
 
-      renderMath(domNode);
-    } catch (e) {
-      // Added try-catch block to handle "Unable to find node on an unmounted component" error from tests, thrown because of the usage of shallow
-      console.error('DOM not mounted');
+  componentDidMount() {
+    if (this.containerRef.current) {
+      setTimeout(() => renderMath(this.containerRef.current), 0);
     }
   }
 
   componentDidUpdate() {
-    try {
-      // eslint-disable-next-line react/no-find-dom-node
-      const domNode = ReactDOM.findDOMNode(this);
-
-      renderMath(domNode);
-    } catch (e) {
-      // Added try-catch block to handle "Unable to find node on an unmounted component" error from tests, thrown because of the usage of shallow
-      console.error('DOM not mounted');
+    if (this.containerRef.current) {
+      setTimeout(() => renderMath(this.containerRef.current), 0);
     }
   }
 
@@ -196,7 +185,7 @@ export class Categories extends React.Component {
     const validationMessage = generateValidationMessage(configuration);
 
     return (
-      <CategoriesContainer className={className}>
+      <CategoriesContainer className={className} ref={this.containerRef}>
         <Header
           label="Categories"
           buttonLabel="ADD A CATEGORY"

--- a/packages/categorize/configure/src/design/categories/index.jsx
+++ b/packages/categorize/configure/src/design/categories/index.jsx
@@ -13,7 +13,6 @@ import Category from './category';
 import Header from '../header';
 import { generateValidationMessage } from '../../utils';
 import { RowLabel } from './RowLabel';
-import { renderMath } from '@pie-lib/math-rendering';
 
 const CategoriesContainer = styled('div')(({ theme }) => ({
   marginBottom: theme.spacing(3),
@@ -63,20 +62,6 @@ export class Categories extends React.Component {
   state = {
     focusedEl: null,
   };
-
-  containerRef = React.createRef();
-
-  componentDidMount() {
-    if (this.containerRef.current) {
-      setTimeout(() => renderMath(this.containerRef.current), 0);
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.containerRef.current) {
-      setTimeout(() => renderMath(this.containerRef.current), 0);
-    }
-  }
 
   add = () => {
     const { model, categories: oldCategories } = this.props;
@@ -185,7 +170,7 @@ export class Categories extends React.Component {
     const validationMessage = generateValidationMessage(configuration);
 
     return (
-      <CategoriesContainer className={className} ref={this.containerRef}>
+      <CategoriesContainer className={className}>
         <Header
           label="Categories"
           buttonLabel="ADD A CATEGORY"

--- a/packages/categorize/configure/src/design/index.jsx
+++ b/packages/categorize/configure/src/design/index.jsx
@@ -233,7 +233,7 @@ export class Design extends React.Component {
     this.setState({ activeDragItem: null });
     
     if (!over || !active) {
-      console.log('[Design] Drag cancelled - no drop target');
+      console.log('Missing over or active:', { over, active });
       return;
     }
 
@@ -242,19 +242,23 @@ export class Design extends React.Component {
     const activeData = active.data.current;
     const overData = over.data.current;
 
+    // moving a choice between categories (correct response)
     if (activeData.type === 'choice-preview' && overData.type === 'category') {
       this.moveChoice(activeData.id, activeData.categoryId, overData.id, 0);
     }
 
+    // placing a choice into a category (correct response)
     if (activeData.type === 'choice' && overData.type === 'category') {
       this.addChoiceToCategory({ id: activeData.id }, overData.id);
     }
 
+    // moving a choice between categories (alternate response)
     if (activeData.type === 'choice-preview' && overData.type === 'category-alternate') {
       const toAlternateIndex = overData.alternateResponseIndex;
       this.moveChoiceInAlternate(activeData.id, activeData.categoryId, overData.id, 0, toAlternateIndex);
     }
 
+    // placing a choice into a category (alternate response)
     if (allowAlternateEnabled && activeData.type === 'choice' && overData.type === 'category-alternate') {
       const choiceId = activeData.id;
       const categoryId = overData.id;

--- a/packages/categorize/configure/src/index.js
+++ b/packages/categorize/configure/src/index.js
@@ -147,9 +147,8 @@ export default class CategorizeConfigure extends HTMLElement {
       this._root = createRoot(this);
     }
     this._root.render(el);
-    queueMicrotask(() => {
-      renderMath(this);
-    });
+// ✅ setTimeout - runs in next event loop, after React commits
+    setTimeout(() => renderMath(this), 0);
   }
 
   disconnectedCallback() {

--- a/packages/categorize/configure/src/index.js
+++ b/packages/categorize/configure/src/index.js
@@ -147,8 +147,10 @@ export default class CategorizeConfigure extends HTMLElement {
       this._root = createRoot(this);
     }
     this._root.render(el);
-// ✅ setTimeout - runs in next event loop, after React commits
-    setTimeout(() => renderMath(this), 0);
+
+    setTimeout(() => {
+      renderMath(this);
+    }, 0);
   }
 
   disconnectedCallback() {

--- a/packages/categorize/src/categorize/index.jsx
+++ b/packages/categorize/src/categorize/index.jsx
@@ -22,7 +22,8 @@ class DragPreviewWrapper extends React.Component {
 
   componentDidMount() {
     if (this.containerRef.current) {
-      renderMath(this.containerRef.current);
+      console.log('Rendering math in drag preview wrapper');
+     renderMath(this.containerRef.current);
     }
   }
 
@@ -44,8 +45,8 @@ export class Categorize extends React.Component {
     }),
     onAnswersChange: PropTypes.func.isRequired,
     onShowCorrectToggle: PropTypes.func.isRequired,
-    onDragStart: PropTypes.func,
-    onDragEnd: PropTypes.func
+    pauseMathObserver: PropTypes.func,
+    resumeMathObserver: PropTypes.func
   };
 
   static defaultProps = {
@@ -330,10 +331,10 @@ class CategorizeProvider extends React.Component {
 
   onDragStart = (event) => {
     const { active } = event;
-    const { onDragStart } = this.props;
+    const { pauseMathObserver } = this.props;
 
-    if (onDragStart) {
-      onDragStart();
+    if (pauseMathObserver) {
+      pauseMathObserver();
     }
 
     if (active?.data?.current) {
@@ -345,12 +346,12 @@ class CategorizeProvider extends React.Component {
 
   onDragEnd = (event) => {
     const { active, over } = event;
-    const { onDragEnd } = this.props;
+    const { resumeMathObserver } = this.props;
 
     this.setState({ activeDragItem: null });
 
-    if (onDragEnd) {
-      onDragEnd();
+    if (resumeMathObserver) {
+      resumeMathObserver();
     }
 
     if (!over || !active) {

--- a/packages/categorize/src/index.js
+++ b/packages/categorize/src/index.js
@@ -339,8 +339,8 @@ export default class Categorize extends HTMLElement {
         session: this._session,
         onAnswersChange: this.changeAnswers.bind(this),
         onShowCorrectToggle: this.onShowCorrectToggle.bind(this),
-        onDragStart: this.pauseMathObserver,
-        onDragEnd: this.resumeMathObserver,
+        pauseMathObserver: this.pauseMathObserver,
+        resumeMathObserver: this.resumeMathObserver,
       });
 
       if (!this._root) {


### PR DESCRIPTION
Fix math rendering not working after React 18 upgrade by adding MutationObserver 
pattern for player and setTimeout for configure. Implement pause/resume during 
drag operations with characterData: false to only trigger on structural changes.