### PR TITLE
fix(number-line): remove publishConfig from controller package

### DIFF
--- a/packages/number-line/controller/package.json
+++ b/packages/number-line/controller/package.json
@@ -10,9 +10,6 @@
   "repository": "pie-framework/pie-elements",
   "main": "lib/index.js",
   "module": "src/index.js",
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "@pie-lib/controller-utils": "1.1.1-next.0",
     "@pie-lib/feedback": "1.1.1-next.0",


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-5592

Remove publishConfig from number-line-controller package.json to fix bundler
resolution errors. The controller is marked as private and should not be
published, but the publishConfig field caused the bundler to attempt resolving
it from npm, resulting in "Module not found" errors.