### PR TITLE
fix(multiple-choice): update module exports to point to lib directory for ebsr dependency

### DIFF
--- a/packages/multiple-choice/package.json
+++ b/packages/multiple-choice/package.json
@@ -31,14 +31,17 @@
   "module": "src/index.js",
   "exports": {
     ".": {
-      "import": "./src/index.js",
+      "import": "./lib/index.js",
+      "require": "./lib/index.js",
       "default": "./lib/index.js"
     },
     "./print": {
-      "import": "./src/print.js",
+      "import": "./lib/print.js",
+      "require": "./lib/print.js",
       "default": "./lib/print.js"
     },
     "./configure/lib": {
+      "import": "./configure/lib/index.js",
       "require": "./configure/lib/index.js",
       "default": "./configure/lib/index.js"
     }


### PR DESCRIPTION

.npmignore includes the src directory, so my guess is this is happening: 

snapshot builds fail → npm package does not include src/, so ES import can’t find src/index.js or src/configure/lib/index.js.