### PR TITLE
fix(math-input): bump @pie-framework/mathquill to 1.2.1-beta.1 with jQuery shim fixes PIE-16 PIE-20

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@pie-lib/text-select": "2.2.0-next.7",
     "@pie-lib/tools": "1.2.0-next.4",
     "@pie-lib/translator": "3.2.0-next.3",
-    "@pie-framework/mathquill": "1.2.1-beta.0"
+    "@pie-framework/mathquill": "1.2.1-beta.1"
   },
   "browserslist": [
     ">0.5%",

--- a/packages/math-inline/configure/package.json
+++ b/packages/math-inline/configure/package.json
@@ -11,7 +11,7 @@
     "@emotion/style": "^0.8.0",
     "@mui/icons-material": "^7.3.4",
     "@mui/material": "^7.3.4",
-    "@pie-framework/mathquill": "1.2.1-beta.0",
+    "@pie-framework/mathquill": "1.2.1-beta.1",
     "@pie-framework/pie-configure-events": "^1.3.0",
     "@pie-lib/config-ui": "12.2.0-next.21",
     "@pie-lib/editable-html-tip-tap": "1.2.0-next.20",

--- a/packages/math-inline/package.json
+++ b/packages/math-inline/package.json
@@ -15,7 +15,7 @@
     "@emotion/style": "^0.8.0",
     "@mui/icons-material": "^7.3.4",
     "@mui/material": "^7.3.4",
-    "@pie-framework/mathquill": "1.2.1-beta.0",
+    "@pie-framework/mathquill": "1.2.1-beta.1",
     "@pie-framework/pie-player-events": "^0.1.0",
     "@pie-lib/correct-answer-toggle": "3.2.0-next.7",
     "@pie-lib/math-input": "7.2.0-next.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2791,10 +2791,10 @@
   dependencies:
     "@xmldom/xmldom" "^0.8.10"
 
-"@pie-framework/mathquill@1.2.1-beta.0":
-  version "1.2.1-beta.0"
-  resolved "https://registry.yarnpkg.com/@pie-framework/mathquill/-/mathquill-1.2.1-beta.0.tgz#837613ed07028f6d8f0118a634bc1cb04717f602"
-  integrity sha512-+UhxS65Ge+XvOxG6tV0QboQWkISWWveWHlIlQi/mrC6kw+ef5wnEnB7coWOclcXA+q84pwrtTddePG7wruC1sQ==
+"@pie-framework/mathquill@1.2.1-beta.0", "@pie-framework/mathquill@1.2.1-beta.1":
+  version "1.2.1-beta.1"
+  resolved "https://registry.yarnpkg.com/@pie-framework/mathquill/-/mathquill-1.2.1-beta.1.tgz#ed91434480f0177ac4b648b2900a291a3115ff66"
+  integrity sha512-q7bCrZJCoC071Xwdmg6yNqAn9J0qbYkEkEFaLKtwITLPl7pp+DFKGszFTfUY4DFlZC5l02yCheLfCZkw5V781w==
 
 "@pie-framework/parse-english@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PIE-16
https://illuminate.atlassian.net/browse/PIE-20