### PR TITLE
fix(extended-text-entry): re-render elements on reconnect PIE-672

### DIFF
--- a/packages/extended-text-entry/configure/src/index.js
+++ b/packages/extended-text-entry/configure/src/index.js
@@ -128,6 +128,10 @@ export default class ExtendedTextEntry extends HTMLElement {
     }
   }
 
+  connectedCallback() {
+    this.render();
+  }
+
   disconnectedCallback() {
     if (this._root) {
       this._root.unmount();

--- a/packages/extended-text-entry/src/index.js
+++ b/packages/extended-text-entry/src/index.js
@@ -119,6 +119,7 @@ export default class RootExtendedTextEntry extends HTMLElement {
   disconnectedCallback() {
     if (this._root) {
       this._root.unmount();
+      this._root = null;
     }
   }
 }


### PR DESCRIPTION
The configure element had no connectedCallback while its disconnectedCallback unmounts the React root and sets _root = null. When a host (e.g. Vue keep-alive) detached and re-attached the same element instance without re-assigning model/configuration, nothing re-rendered and the settings panel stayed blank until render() was called manually. Add connectedCallback that calls render() (matching the categorize/select-text configure elements) so it re-renders on reconnect; render() already guards on _model and recreates _root when null, so this is safe and idempotent.

Also null _root in the player element's disconnectedCallback so that a reconnect render() recreates the root instead of calling render() on an already-unmounted root.

https://illuminate.atlassian.net/browse/PIE-672