### PR TITLE
fix(extended-text-entry): ensure StyledPrompt is displayed as a block…

### DIFF
--- a/packages/extended-text-entry/src/main.jsx
+++ b/packages/extended-text-entry/src/main.jsx
@@ -23,6 +23,7 @@ const StyledPrompt = styled(Typography)(({ theme }) => ({
   color: color.text(),
   marginBottom: theme.spacing(2),
   fontSize: 'inherit',
+  display: 'block',
 }));
 
 const TeacherInstructions = styled('div')(({ theme }) => ({


### PR DESCRIPTION
… element PIE-692

inline display was causing the margin and width to not be applied
https://illuminate.atlassian.net/browse/PIE-692 